### PR TITLE
Model#dirtyAttributes

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -18,11 +18,155 @@ var _toConsumableArray = _interopDefault(require('@babel/runtime/helpers/toConsu
 var uuidv1 = _interopDefault(require('uuid/v1'));
 var jqueryParam = _interopDefault(require('jquery-param'));
 var pluralize = _interopDefault(require('pluralize'));
+var dig = _interopDefault(require('lodash/get'));
+var flattenDeep = _interopDefault(require('lodash/flattenDeep'));
 var _possibleConstructorReturn = _interopDefault(require('@babel/runtime/helpers/possibleConstructorReturn'));
 var _getPrototypeOf = _interopDefault(require('@babel/runtime/helpers/getPrototypeOf'));
 var _assertThisInitialized = _interopDefault(require('@babel/runtime/helpers/assertThisInitialized'));
 var _inherits = _interopDefault(require('@babel/runtime/helpers/inherits'));
 var _wrapNativeSuper = _interopDefault(require('@babel/runtime/helpers/wrapNativeSuper'));
+
+var pending = {};
+var counter = {};
+
+var incrementor = function incrementor(key) {
+  return function () {
+    var count = (counter[key] || 0) + 1;
+    counter[key] = count;
+    return count;
+  };
+};
+
+var decrementor = function decrementor(key) {
+  return function () {
+    var count = (counter[key] || 0) - 1;
+    counter[key] = count;
+    return count;
+  };
+};
+/**
+ * Singularizes record type
+ * @method singularizeType
+ * @param {String} recordType type of record
+ * @return {String}
+ */
+
+
+function singularizeType(recordType) {
+  var typeParts = recordType.split('_');
+  var endPart = typeParts[typeParts.length - 1];
+  typeParts = typeParts.slice(0, -1);
+  endPart = pluralize.singular(endPart);
+  return [].concat(_toConsumableArray(typeParts), [endPart]).join('_');
+}
+/**
+ * Build request url from base url, endpoint, query params, and ids.
+ *
+ * @method requestUrl
+ * @return {String} formatted url string
+ */
+
+function requestUrl(baseUrl, endpoint) {
+  var queryParams = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+  var id = arguments.length > 3 ? arguments[3] : undefined;
+  var queryParamString = '';
+
+  if (Object.keys(queryParams).length > 0) {
+    queryParamString = "?".concat(jqueryParam(queryParams));
+  }
+
+  var idForPath = '';
+
+  if (id) {
+    idForPath = "/".concat(id);
+  } // Return full url
+
+
+  return "".concat(baseUrl, "/").concat(endpoint).concat(idForPath).concat(queryParamString);
+}
+function newId() {
+  return "tmp-".concat(uuidv1());
+}
+function dbOrNewId(properties) {
+  return properties.id || newId();
+}
+/**
+ * Avoids making racing requests by blocking a request if an identical one is
+ * already in-flight. Blocked requests will be resolved when the initial request
+ * resolves by cloning the response.
+ *
+ * @method combineRacedRequests
+ * @param {String} key the unique key for the request
+ * @param {Function} fn the function the generates the promise
+ * @return {Promise}
+ */
+
+function combineRacedRequests(key, fn) {
+  var incrementBlocked = incrementor(key);
+  var decrementBlocked = decrementor(key); // keep track of the number of callers waiting for this promise to resolve
+
+  incrementBlocked();
+
+  function handleResponse(response) {
+    var count = decrementBlocked(); // if there are other callers waiting for this request to resolve, we should
+    // clone the response before returning so that we can re-use it for the
+    // remaining callers
+
+    if (count > 0) return response.clone(); // if there are no more callers waiting for this promise to resolve (i.e. if
+    // this is the last one), we can remove the reference to the pending promise
+    // allowing subsequent requests to proceed unblocked.
+
+    delete pending[key];
+    return response;
+  } // Return pending promise if one already exists
+
+
+  if (pending[key]) return pending[key].then(handleResponse); // Otherwise call the method and on resolution
+  // clear out the pending promise for the key
+
+  pending[key] = fn.call();
+  return pending[key].then(handleResponse);
+}
+/**
+ * Reducer function for filtering out duplicate records
+ * by a key provided. Returns a function that has a accumulator and
+ * current record per Array.reduce.
+ *
+ * @method uniqueByReducer
+ * @param {Array} key
+ * @return {Function}
+ */
+
+function uniqueByReducer(key) {
+  return function (accumulator, current) {
+    return accumulator.some(function (item) {
+      return item[key] === current[key];
+    }) ? accumulator : [].concat(_toConsumableArray(accumulator), [current]);
+  };
+}
+/**
+ * Returns objects unique by key provided
+ *
+ * @method uniqueBy
+ * @param {Array} array
+ * @param {String} key
+ * @return {Array}
+ */
+
+function uniqueBy(array, key) {
+  return array.reduce(uniqueByReducer(key), []);
+}
+function walk(value, iteratee, prop, path) {
+  if (value != null && _typeof(value) === 'object') {
+    return Object.keys(value).map(function (prop) {
+      return walk(value[prop], iteratee, prop, [path, prop].filter(function (x) {
+        return x;
+      }).join('.'));
+    });
+  }
+
+  return iteratee(value, path);
+}
 
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
@@ -560,13 +704,28 @@ function () {
       this.previousSnapshot = this.snapshot;
     }
     /**
-     * Uses mobx.autorun to track changes to attributes
-     *
-     * @method _trackState
+     * a list of any property paths which have been changed since the previous
+     * snapshot
+     * ```
+     * const todo = new Todo({ title: 'Buy Milk' })
+     * todo.dirtyAttributes
+     * => []
+     * todo.title = 'Buy Cheese'
+     * todo.dirtyAttributes
+     * => ['title']
+     * ```
+     * @method dirtyAttributes
+     * @return {Array} dirty attribute paths
      */
 
   }, {
     key: "_trackState",
+
+    /**
+     * Uses mobx.autorun to track changes to attributes
+     *
+     * @method _trackState
+     */
     value: function _trackState() {
       var _this4 = this;
 
@@ -756,6 +915,18 @@ function () {
       };
     }
   }, {
+    key: "dirtyAttributes",
+    get: function get() {
+      var _this7 = this;
+
+      return flattenDeep(walk(this.previousSnapshot.attributes, function (prevValue, path) {
+        var currValue = dig(_this7.snapshot.attributes, path);
+        return prevValue === currValue ? undefined : path;
+      })).filter(function (x) {
+        return x;
+      });
+    }
+  }, {
     key: "type",
     get: function get() {
       return this.constructor.type;
@@ -770,10 +941,10 @@ function () {
   }, {
     key: "attributes",
     get: function get() {
-      var _this7 = this;
+      var _this8 = this;
 
       return this.attributeNames.reduce(function (attributes, key) {
-        var value = mobx.toJS(_this7[key]);
+        var value = mobx.toJS(_this8[key]);
 
         if (!value) {
           delete attributes[key];
@@ -864,137 +1035,6 @@ function () {
     return {};
   }
 })), _class);
-
-var pending = {};
-var counter = {};
-
-var incrementor = function incrementor(key) {
-  return function () {
-    var count = (counter[key] || 0) + 1;
-    counter[key] = count;
-    return count;
-  };
-};
-
-var decrementor = function decrementor(key) {
-  return function () {
-    var count = (counter[key] || 0) - 1;
-    counter[key] = count;
-    return count;
-  };
-};
-/**
- * Singularizes record type
- * @method singularizeType
- * @param {String} recordType type of record
- * @return {String}
- */
-
-
-function singularizeType(recordType) {
-  var typeParts = recordType.split('_');
-  var endPart = typeParts[typeParts.length - 1];
-  typeParts = typeParts.slice(0, -1);
-  endPart = pluralize.singular(endPart);
-  return [].concat(_toConsumableArray(typeParts), [endPart]).join('_');
-}
-/**
- * Build request url from base url, endpoint, query params, and ids.
- *
- * @method requestUrl
- * @return {String} formatted url string
- */
-
-function requestUrl(baseUrl, endpoint) {
-  var queryParams = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
-  var id = arguments.length > 3 ? arguments[3] : undefined;
-  var queryParamString = '';
-
-  if (Object.keys(queryParams).length > 0) {
-    queryParamString = "?".concat(jqueryParam(queryParams));
-  }
-
-  var idForPath = '';
-
-  if (id) {
-    idForPath = "/".concat(id);
-  } // Return full url
-
-
-  return "".concat(baseUrl, "/").concat(endpoint).concat(idForPath).concat(queryParamString);
-}
-function newId() {
-  return "tmp-".concat(uuidv1());
-}
-function dbOrNewId(properties) {
-  return properties.id || newId();
-}
-/**
- * Avoids making racing requests by blocking a request if an identical one is
- * already in-flight. Blocked requests will be resolved when the initial request
- * resolves by cloning the response.
- *
- * @method combineRacedRequests
- * @param {String} key the unique key for the request
- * @param {Function} fn the function the generates the promise
- * @return {Promise}
- */
-
-function combineRacedRequests(key, fn) {
-  var incrementBlocked = incrementor(key);
-  var decrementBlocked = decrementor(key); // keep track of the number of callers waiting for this promise to resolve
-
-  incrementBlocked();
-
-  function handleResponse(response) {
-    var count = decrementBlocked(); // if there are other callers waiting for this request to resolve, we should
-    // clone the response before returning so that we can re-use it for the
-    // remaining callers
-
-    if (count > 0) return response.clone(); // if there are no more callers waiting for this promise to resolve (i.e. if
-    // this is the last one), we can remove the reference to the pending promise
-    // allowing subsequent requests to proceed unblocked.
-
-    delete pending[key];
-    return response;
-  } // Return pending promise if one already exists
-
-
-  if (pending[key]) return pending[key].then(handleResponse); // Otherwise call the method and on resolution
-  // clear out the pending promise for the key
-
-  pending[key] = fn.call();
-  return pending[key].then(handleResponse);
-}
-/**
- * Reducer function for filtering out duplicate records
- * by a key provided. Returns a function that has a accumulator and
- * current record per Array.reduce.
- *
- * @method uniqueByReducer
- * @param {Array} key
- * @return {Function}
- */
-
-function uniqueByReducer(key) {
-  return function (accumulator, current) {
-    return accumulator.some(function (item) {
-      return item[key] === current[key];
-    }) ? accumulator : [].concat(_toConsumableArray(accumulator), [current]);
-  };
-}
-/**
- * Returns objects unique by key provided
- *
- * @method uniqueBy
- * @param {Array} array
- * @param {String} key
- * @return {Array}
- */
-
-function uniqueBy(array, key) {
-  return array.reduce(uniqueByReducer(key), []);
-}
 
 var _class$1, _descriptor$1, _descriptor2$1, _descriptor3, _temp$1;
 

--- a/dist/mobx-async-store.umd.js
+++ b/dist/mobx-async-store.umd.js
@@ -8277,847 +8277,6 @@
   })));
   });
 
-  function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
-
-  function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
-
-  function ObjectPromiseProxy(promise, target) {
-    target.isInFlight = true;
-    var tmpId = target.id;
-    var result = promise.then(function _callee(response) {
-      var status, json, _json$data, attributes, relationships, message, _json, errorString;
-
-      return regeneratorRuntime.async(function _callee$(_context) {
-        while (1) {
-          switch (_context.prev = _context.next) {
-            case 0:
-              status = response.status;
-
-              if (!(status === 200 || status === 201)) {
-                _context.next = 14;
-                break;
-              }
-
-              _context.next = 4;
-              return regeneratorRuntime.awrap(response.json());
-
-            case 4:
-              json = _context.sent;
-              // Update target model
-              _json$data = json.data, attributes = _json$data.attributes, relationships = _json$data.relationships;
-              transaction$$1(function () {
-                Object.keys(attributes).forEach(function (key) {
-                  set$$1(target, key, attributes[key]);
-                });
-
-                if (relationships) {
-                  Object.keys(relationships).forEach(function (key) {
-                    if (!relationships[key].hasOwnProperty('meta')) {
-                      // todo: throw error if relationship is not defined in model
-                      set$$1(target.relationships, key, relationships[key]);
-                    }
-                  });
-                }
-
-                if (json.included) {
-                  target.store.createModelsFromData(json.included);
-                }
-              }); // Update target isInFlight and isDirty
-
-              target.isInFlight = false;
-              target.isDirty = false;
-              target.setPreviousSnapshot();
-              transaction$$1(function () {
-                // NOTE: This resolves an issue where a record is persisted but the
-                // index key is still a temp uuid. We can't simply remove the temp
-                // key because there may be associated records that have the temp
-                // uuid id as its only reference to the newly persisted record.
-                // TODO: Figure out a way to update associated records to use the
-                // newly persisted id.
-                target.store.data[target.type].records[tmpId] = target;
-                target.store.data[target.type].records[target.id] = target;
-              });
-              return _context.abrupt("return", target);
-
-            case 14:
-              target.isInFlight = false;
-              message = target.store.genericErrorMessage;
-              _context.prev = 16;
-              _context.next = 19;
-              return regeneratorRuntime.awrap(response.json());
-
-            case 19:
-              _json = _context.sent;
-              message = parseApiErrors(_json.errors, message);
-              _context.next = 25;
-              break;
-
-            case 23:
-              _context.prev = 23;
-              _context.t0 = _context["catch"](16);
-
-            case 25:
-              // TODO: add all errors from the API response to the target
-              target.errors = _objectSpread({}, target.errors, {
-                status: status,
-                base: [{
-                  message: message
-                }]
-              });
-              errorString = JSON.stringify(target.errors);
-              return _context.abrupt("return", Promise.reject(new Error(errorString)));
-
-            case 28:
-            case "end":
-              return _context.stop();
-          }
-        }
-      }, null, null, [[16, 23]]);
-    }, function (error) {
-      // TODO: Handle error states correctly
-      target.isInFlight = false;
-      target.errors = error;
-      throw error; // return target
-    }); // Define proxied attributes
-
-    var attributeNames = Object.keys(target.attributeNames);
-    var tempProperties = attributeNames.reduce(function (attrs, key) {
-      attrs[key] = {
-        value: target[key],
-        writable: false
-      };
-      return attrs;
-    }, {});
-    Object.defineProperties(result, _objectSpread({
-      isInFlight: {
-        value: target.isInFlight
-      }
-    }, tempProperties)); // Return promise
-
-    return result;
-  }
-
-  function parseApiErrors(errors, defaultMessage) {
-    return errors[0].detail.length === 0 ? defaultMessage : errors[0].detail[0];
-  }
-
-  /**
-   * Utility class used to store the schema
-   * of model attribute definitions
-   *
-   * @class Schema
-   */
-  var Schema =
-  /*#__PURE__*/
-  function () {
-    function Schema() {
-      _classCallCheck(this, Schema);
-
-      this.structure = {};
-      this.relations = {};
-    }
-
-    _createClass(Schema, [{
-      key: "addAttribute",
-      value: function addAttribute(_ref) {
-        var type = _ref.type,
-            property = _ref.property,
-            dataType = _ref.dataType,
-            defaultValue = _ref.defaultValue;
-        this.structure[type] = this.structure[type] || {};
-        this.structure[type][property] = {
-          defaultValue: defaultValue,
-          dataType: dataType
-        };
-      }
-    }, {
-      key: "addRelationship",
-      value: function addRelationship(_ref2) {
-        var type = _ref2.type,
-            property = _ref2.property,
-            dataType = _ref2.dataType;
-        this.relations[type] = this.relations[type] || {};
-        this.relations[type][property] = {
-          dataType: dataType
-        };
-      }
-    }, {
-      key: "addValidation",
-      value: function addValidation(_ref3) {
-        var type = _ref3.type,
-            property = _ref3.property,
-            validator = _ref3.validator;
-        this.structure[type][property].validator = validator;
-      }
-    }]);
-
-    return Schema;
-  }();
-
-  var schema = new Schema();
-
-  var _class, _descriptor, _descriptor2, _temp;
-
-  function ownKeys$1(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
-
-  function _objectSpread$1(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys$1(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys$1(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
-
-  function stringifyIds(object) {
-    Object.keys(object).forEach(function (key) {
-      var property = object[key];
-
-      if (_typeof(property) === 'object') {
-        if (property.id) {
-          property.id = String(property.id);
-        }
-
-        stringifyIds(property);
-      }
-    });
-  }
-  /*
-   * Defines a many-to-one relationship. Defaults to the class with camelized name of the property.
-   * An optional argument specifies the data model, if different from the property name.
-   * ```
-   * class Note extends Model {
-   *   @belongsTo todo
-   *   @belongsTo(Facility) greenhouse
-   * }
-   * ```
-   * Polymorphic relationships
-   * Define `belongsTo` with the the associated models
-   * Define `hasMany` as you normally would
-   * ```
-   * class Note extends Model {
-   *   @belongsTo(Todo, ScheduledEvent) notable
-   * }
-   *
-   * class Todo extends Model {
-   *   @hasMany notes
-   * }
-   * ```
-   * @method belongsTo
-   */
-
-  /**
-   @class Model
-   */
-
-  var Model = (_class = (_temp =
-  /*#__PURE__*/
-  function () {
-    /**
-     * Initializer for model
-     *
-     * @method constructor
-     */
-    function Model() {
-      var initialAttributes = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-
-      _classCallCheck(this, Model);
-
-      _initializerDefineProperty(this, "_isDirty", _descriptor, this);
-
-      this.isInFlight = false;
-
-      _initializerDefineProperty(this, "errors", _descriptor2, this);
-
-      this.previousSnapshot = {};
-
-      this._makeObservable(initialAttributes);
-
-      this.setPreviousSnapshot();
-
-      this._trackState();
-    }
-    /**
-     * The type of the model. Defined on the class. Defaults to the underscored version of the class name
-     * (eg 'calendar_events').
-     *
-     * @property type
-     * @static
-     */
-
-    /**
-     * The canonical path to the resource on the server. Defined on the class.
-     * Defaults to the underscored version of the class name
-     * @property endpoint
-     * @static
-     */
-
-    /**
-     * True if the instance has been modified from its persisted state
-     * ```
-     * kpi = store.add('kpis', { name: 'A good thing to measure' })
-     * kpi.isDirty
-     * => true
-     * kpi.name
-     * => "A good thing to measure"
-     * await kpi.save()
-     * kpi.isDirty
-     * => false
-     * kpi.name = "Another good thing to measure"
-     * kpi.isDirty
-     * => true
-     * await kpi.save()
-     * kpi.isDirty
-     * => false
-     * ```
-     * @property isDirty
-     * @type {Boolean}
-     * @default false
-     */
-
-
-    _createClass(Model, [{
-      key: "rollback",
-
-      /**
-       * restores data to its last persisted state
-       * ```
-       * kpi = store.find('kpis', 5)
-       * kpi.name
-       * => "A good thing to measure"
-       * kpi.name = "Another good thing to measure"
-       * kpi.rollback()
-       * kpi.name
-       * => "A good thing to measure"
-       * ```
-       * @method rollback
-       */
-      value: function rollback() {
-        var _this2 = this;
-
-        transaction$$1(function () {
-          var previousSnapshot = _this2.previousSnapshot;
-
-          _this2.attributeNames.forEach(function (key) {
-            _this2[key] = previousSnapshot.attributes[key];
-          });
-
-          _this2.relationships = previousSnapshot.relationships;
-          _this2.errors = {};
-        });
-        this.setPreviousSnapshot();
-      }
-      /**
-       * creates or updates a record.
-       * @method save
-       * @return {Promise}
-       * @param {Object} options
-       */
-
-    }, {
-      key: "save",
-      value: function save() {
-        var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-
-        if (!options.skip_validations && !this.validate()) {
-          var errorString = JSON.stringify(this.errors);
-          return Promise.reject(new Error(errorString));
-        }
-
-        var queryParams = options.queryParams,
-            relationships = options.relationships,
-            attributes = options.attributes;
-        var constructor = this.constructor,
-            id = this.id,
-            isNew = this.isNew;
-        var requestId = id;
-        var method = 'PATCH';
-
-        if (isNew) {
-          method = 'POST';
-          requestId = null;
-        }
-
-        var url = this.store.fetchUrl(constructor.type, queryParams, requestId);
-        var body = JSON.stringify(this.jsonapi({
-          relationships: relationships,
-          attributes: attributes
-        }));
-        var response = this.store.fetch(url, {
-          method: method,
-          body: body
-        });
-        return new ObjectPromiseProxy(response, this);
-      }
-      /**
-       * Checks all validations, adding errors where necessary and returning `false` if any are not valid
-       * @method validate
-       * @return {Boolean}
-       */
-
-    }, {
-      key: "validate",
-      value: function validate() {
-        var _this3 = this;
-
-        this.errors = {};
-        var attributeNames = this.attributeNames,
-            attributeDefinitions = this.attributeDefinitions;
-        var validationChecks = attributeNames.map(function (property) {
-          var validator = attributeDefinitions[property].validator;
-          if (!validator) return true;
-          var validationResult = validator(_this3[property], _this3);
-
-          if (!validationResult.isValid) {
-            _this3.errors[property] = validationResult.errors;
-          }
-
-          return validationResult.isValid;
-        });
-        return validationChecks.every(function (value) {
-          return value;
-        });
-      }
-      /**
-       * deletes a record from the store and server
-       * @method destroy
-       * @return {Promise} an empty promise with any success/error status
-       */
-
-    }, {
-      key: "destroy",
-      value: function destroy() {
-        var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-        var type = this.constructor.type,
-            id = this.id,
-            snapshot = this.snapshot,
-            isNew = this.isNew;
-
-        if (isNew) {
-          this.store.remove(type, id);
-          return snapshot;
-        }
-
-        var _options$params = options.params,
-            params = _options$params === void 0 ? {} : _options$params,
-            _options$skipRemove = options.skipRemove,
-            skipRemove = _options$skipRemove === void 0 ? false : _options$skipRemove;
-        var url = this.store.fetchUrl(type, params, id);
-        this.isInFlight = true;
-        var promise = this.store.fetch(url, {
-          method: 'DELETE'
-        });
-
-        var _this = this;
-
-        _this.errors = {};
-        return promise.then(function _callee(response) {
-          var json;
-          return regeneratorRuntime.async(function _callee$(_context) {
-            while (1) {
-              switch (_context.prev = _context.next) {
-                case 0:
-                  _this.isInFlight = false;
-
-                  if (!(response.status === 202 || response.status === 204)) {
-                    _context.next = 17;
-                    break;
-                  }
-
-                  if (!skipRemove) {
-                    _this.store.remove(type, id);
-                  }
-
-                  _context.prev = 3;
-                  _context.next = 6;
-                  return regeneratorRuntime.awrap(response.json());
-
-                case 6:
-                  json = _context.sent;
-
-                  if (json.data && json.data.attributes) {
-                    Object.keys(json.data.attributes).forEach(function (key) {
-                      set$$1(_this, key, json.data.attributes[key]);
-                    });
-                  }
-
-                  _context.next = 13;
-                  break;
-
-                case 10:
-                  _context.prev = 10;
-                  _context.t0 = _context["catch"](3);
-                  console.log(_context.t0); // It is text, do you text handling here
-
-                case 13:
-                  // NOTE: If deleting a record changes other related model
-                  // You can return then in the delete response
-                  if (json && json.included) {
-                    _this.store.createModelsFromData(json.included);
-                  }
-
-                  return _context.abrupt("return", _this);
-
-                case 17:
-                  _this.errors = {
-                    status: response.status
-                  };
-                  return _context.abrupt("return", _this);
-
-                case 19:
-                case "end":
-                  return _context.stop();
-              }
-            }
-          }, null, null, [[3, 10]]);
-        }, function (error) {
-          // TODO: Handle error states correctly
-          _this.isInFlight = false;
-          _this.errors = error;
-          throw error;
-        });
-      }
-      /* Private Methods */
-
-      /**
-       * Magic method that makes changes to records
-       * observable
-       *
-       * @method _makeObservable
-       */
-
-    }, {
-      key: "_makeObservable",
-      value: function _makeObservable(initialAttributes) {
-        var defaultAttributes = this.defaultAttributes;
-        extendObservable$$1(this, _objectSpread$1({}, defaultAttributes, {}, initialAttributes));
-      }
-      /**
-       * The current state of defined attributes and relationships of the instance
-       * Really just an alias for attributes
-       * ```
-       * todo = store.find('todos', 5)
-       * todo.title
-       * => "Buy the eggs"
-       * snapshot = todo.snapshot
-       * todo.title = "Buy the eggs and bacon"
-       * snapshot.title
-       * => "Buy the eggs and bacon"
-       * ```
-       * @method snapshot
-       * @return {Object} current attributes
-       */
-
-    }, {
-      key: "setPreviousSnapshot",
-
-      /**
-       * Sets previous snapshot to current snapshot
-       *
-       * @method setPreviousSnapshot
-       */
-      value: function setPreviousSnapshot() {
-        this.previousSnapshot = this.snapshot;
-      }
-      /**
-       * Uses mobx.autorun to track changes to attributes
-       *
-       * @method _trackState
-       */
-
-    }, {
-      key: "_trackState",
-      value: function _trackState() {
-        var _this4 = this;
-
-        reaction$$1(function () {
-          return JSON.stringify(_this4.attributes);
-        }, function (objectString) {
-          // console.log(objectString)
-          _this4.isDirty = true;
-        });
-        reaction$$1(function () {
-          return JSON.stringify(_this4.relationships);
-        }, function (relString) {
-          // console.log(relString)
-          _this4.isDirty = true;
-        });
-      }
-      /**
-       * shortcut to get the static
-       *
-       * @method type
-       * @return {String} current attributes
-      */
-
-    }, {
-      key: "errorForKey",
-
-      /**
-       * Getter to check if the record has errors.
-       *
-       * @method hasErrors
-       * @return {Boolean}
-       */
-      value: function errorForKey(key) {
-        return this.errors[key];
-      }
-      /**
-       * Getter to just get the names of a records attributes.
-       *
-       * @method attributeNames
-       * @return {Array}
-       */
-
-    }, {
-      key: "jsonapi",
-
-      /**
-       * getter method to get data in api compliance format
-       * TODO: Figure out how to handle unpersisted ids
-       *
-       * @method jsonapi
-       * @return {Object} data in JSON::API format
-       */
-      value: function jsonapi() {
-        var _this5 = this;
-
-        var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-        var attributeDefinitions = this.attributeDefinitions,
-            attributeNames = this.attributeNames,
-            meta = this.meta,
-            id = this.id,
-            type = this.constructor.type;
-        var filteredAttributeNames = attributeNames;
-        var filteredRelationshipNames = [];
-
-        if (options.attributes) {
-          filteredAttributeNames = attributeNames.filter(function (name) {
-            return options.attributes.includes(name);
-          });
-        }
-
-        var attributes = filteredAttributeNames.reduce(function (attrs, key) {
-          var value = _this5[key];
-
-          if (value) {
-            var DataType = attributeDefinitions[key].dataType;
-            var attr;
-
-            if (DataType.name === 'Array' || DataType.name === 'Object') {
-              attr = toJS$$1(value);
-            } else if (DataType.name === 'Date') {
-              attr = moment(value).toISOString();
-            } else {
-              attr = DataType(value);
-            }
-
-            attrs[key] = attr;
-          } else {
-            attrs[key] = value;
-          }
-
-          return attrs;
-        }, {});
-        var data = {
-          type: type,
-          attributes: attributes,
-          id: String(id)
-        };
-
-        if (options.relationships) {
-          filteredRelationshipNames = Object.keys(this.relationships).filter(function (name) {
-            return options.relationships.includes(name);
-          });
-          var relationships = filteredRelationshipNames.reduce(function (rels, key) {
-            rels[key] = toJS$$1(_this5.relationships[key]);
-            stringifyIds(rels[key]);
-            return rels;
-          }, {});
-          data.relationships = relationships;
-        }
-
-        if (meta) {
-          data['meta'] = meta;
-        }
-
-        if (String(id).match(/tmp/)) {
-          delete data.id;
-        }
-
-        return {
-          data: data
-        };
-      }
-    }, {
-      key: "updateAttributes",
-      value: function updateAttributes(attributes) {
-        var _this6 = this;
-
-        transaction$$1(function () {
-          Object.keys(attributes).forEach(function (key) {
-            _this6[key] = attributes[key];
-          });
-        });
-      }
-    }, {
-      key: "isDirty",
-      get: function get() {
-        var isNew = this.isNew,
-            _isDirty = this._isDirty;
-        return _isDirty || isNew;
-      },
-      set: function set(value) {
-        this._isDirty = value;
-      }
-      /**
-       * Private method. True if the model has been programatically changed,
-       * as opposed to just being new.
-       * @property _isDirty
-       * @type {Boolean}
-       * @default false
-       * @private
-       */
-
-    }, {
-      key: "isNew",
-
-      /**
-       * True if the model has not been sent to the store
-       * @property isNew
-       * @type {Boolean}
-       */
-      get: function get() {
-        var id = this.id;
-        return !!String(id).match(/tmp/);
-      }
-      /**
-       * True if the instance is coming from / going to the server
-       * ```
-       * kpi = store.find('kpis', 5)
-       * // fetch started
-       * kpi.isInFlight
-       * => true
-       * // fetch finished
-       * kpi.isInFlight
-       * => false
-       * ```
-       * @property isInFlight
-       * @type {Boolean}
-       * @default false
-       */
-
-    }, {
-      key: "snapshot",
-      get: function get() {
-        return {
-          attributes: this.attributes,
-          relationships: toJS$$1(this.relationships)
-        };
-      }
-    }, {
-      key: "type",
-      get: function get() {
-        return this.constructor.type;
-      }
-      /**
-       * current attributes of record
-       *
-       * @method attributes
-       * @return {Object} current attributes
-       */
-
-    }, {
-      key: "attributes",
-      get: function get() {
-        var _this7 = this;
-
-        return this.attributeNames.reduce(function (attributes, key) {
-          var value = toJS$$1(_this7[key]);
-
-          if (!value) {
-            delete attributes[key];
-          } else {
-            attributes[key] = value;
-          }
-
-          return attributes;
-        }, {});
-      }
-      /**
-       * Getter find the attribute definition for the model type.
-       *
-       * @method attributeDefinitions
-       * @return {Object}
-       */
-
-    }, {
-      key: "attributeDefinitions",
-      get: function get() {
-        var type = this.constructor.type;
-        return schema.structure[type];
-      }
-      /**
-       * Getter find the relationship definitions for the model type.
-       *
-       * @method relationshipDefinitions
-       * @return {Object}
-       */
-
-    }, {
-      key: "relationshipDefinitions",
-      get: function get() {
-        var type = this.constructor.type;
-        return schema.relations[type];
-      }
-      /**
-       * Getter to check if the record has errors.
-       *
-       * @method hasErrors
-       * @return {Boolean}
-       */
-
-    }, {
-      key: "hasErrors",
-      get: function get() {
-        return Object.keys(this.errors).length > 0;
-      }
-    }, {
-      key: "attributeNames",
-      get: function get() {
-        return Object.keys(this.attributeDefinitions);
-      }
-      /**
-       * getter method to get the default attributes
-       *
-       * @method defaultAttributes
-       * @return {Object}
-       */
-
-    }, {
-      key: "defaultAttributes",
-      get: function get() {
-        var attributeDefinitions = this.attributeDefinitions;
-        return this.attributeNames.reduce(function (defaults, key) {
-          var defaultValue = attributeDefinitions[key].defaultValue;
-          defaults[key] = defaultValue;
-          return defaults;
-        }, {
-          relationships: {}
-        });
-      }
-    }]);
-
-    return Model;
-  }(), _temp), (_applyDecoratedDescriptor(_class.prototype, "isDirty", [computed$$1], Object.getOwnPropertyDescriptor(_class.prototype, "isDirty"), _class.prototype), _descriptor = _applyDecoratedDescriptor(_class.prototype, "_isDirty", [observable$$1], {
-    configurable: true,
-    enumerable: true,
-    writable: true,
-    initializer: function initializer() {
-      return false;
-    }
-  }), _applyDecoratedDescriptor(_class.prototype, "isNew", [computed$$1], Object.getOwnPropertyDescriptor(_class.prototype, "isNew"), _class.prototype), _descriptor2 = _applyDecoratedDescriptor(_class.prototype, "errors", [observable$$1], {
-    configurable: true,
-    enumerable: true,
-    writable: true,
-    initializer: function initializer() {
-      return {};
-    }
-  })), _class);
-
   function _arrayWithoutHoles(arr) {
     if (Array.isArray(arr)) {
       for (var i = 0, arr2 = new Array(arr.length); i < arr.length; i++) {
@@ -9993,6 +9152,2220 @@
   function uniqueBy(array, key) {
     return array.reduce(uniqueByReducer(key), []);
   }
+  function walk(value, iteratee, prop, path) {
+    if (value != null && _typeof(value) === 'object') {
+      return Object.keys(value).map(function (prop) {
+        return walk(value[prop], iteratee, prop, [path, prop].filter(function (x) {
+          return x;
+        }).join('.'));
+      });
+    }
+
+    return iteratee(value, path);
+  }
+
+  function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+  function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+  function ObjectPromiseProxy(promise, target) {
+    target.isInFlight = true;
+    var tmpId = target.id;
+    var result = promise.then(function _callee(response) {
+      var status, json, _json$data, attributes, relationships, message, _json, errorString;
+
+      return regeneratorRuntime.async(function _callee$(_context) {
+        while (1) {
+          switch (_context.prev = _context.next) {
+            case 0:
+              status = response.status;
+
+              if (!(status === 200 || status === 201)) {
+                _context.next = 14;
+                break;
+              }
+
+              _context.next = 4;
+              return regeneratorRuntime.awrap(response.json());
+
+            case 4:
+              json = _context.sent;
+              // Update target model
+              _json$data = json.data, attributes = _json$data.attributes, relationships = _json$data.relationships;
+              transaction$$1(function () {
+                Object.keys(attributes).forEach(function (key) {
+                  set$$1(target, key, attributes[key]);
+                });
+
+                if (relationships) {
+                  Object.keys(relationships).forEach(function (key) {
+                    if (!relationships[key].hasOwnProperty('meta')) {
+                      // todo: throw error if relationship is not defined in model
+                      set$$1(target.relationships, key, relationships[key]);
+                    }
+                  });
+                }
+
+                if (json.included) {
+                  target.store.createModelsFromData(json.included);
+                }
+              }); // Update target isInFlight and isDirty
+
+              target.isInFlight = false;
+              target.isDirty = false;
+              target.setPreviousSnapshot();
+              transaction$$1(function () {
+                // NOTE: This resolves an issue where a record is persisted but the
+                // index key is still a temp uuid. We can't simply remove the temp
+                // key because there may be associated records that have the temp
+                // uuid id as its only reference to the newly persisted record.
+                // TODO: Figure out a way to update associated records to use the
+                // newly persisted id.
+                target.store.data[target.type].records[tmpId] = target;
+                target.store.data[target.type].records[target.id] = target;
+              });
+              return _context.abrupt("return", target);
+
+            case 14:
+              target.isInFlight = false;
+              message = target.store.genericErrorMessage;
+              _context.prev = 16;
+              _context.next = 19;
+              return regeneratorRuntime.awrap(response.json());
+
+            case 19:
+              _json = _context.sent;
+              message = parseApiErrors(_json.errors, message);
+              _context.next = 25;
+              break;
+
+            case 23:
+              _context.prev = 23;
+              _context.t0 = _context["catch"](16);
+
+            case 25:
+              // TODO: add all errors from the API response to the target
+              target.errors = _objectSpread({}, target.errors, {
+                status: status,
+                base: [{
+                  message: message
+                }]
+              });
+              errorString = JSON.stringify(target.errors);
+              return _context.abrupt("return", Promise.reject(new Error(errorString)));
+
+            case 28:
+            case "end":
+              return _context.stop();
+          }
+        }
+      }, null, null, [[16, 23]]);
+    }, function (error) {
+      // TODO: Handle error states correctly
+      target.isInFlight = false;
+      target.errors = error;
+      throw error; // return target
+    }); // Define proxied attributes
+
+    var attributeNames = Object.keys(target.attributeNames);
+    var tempProperties = attributeNames.reduce(function (attrs, key) {
+      attrs[key] = {
+        value: target[key],
+        writable: false
+      };
+      return attrs;
+    }, {});
+    Object.defineProperties(result, _objectSpread({
+      isInFlight: {
+        value: target.isInFlight
+      }
+    }, tempProperties)); // Return promise
+
+    return result;
+  }
+
+  function parseApiErrors(errors, defaultMessage) {
+    return errors[0].detail.length === 0 ? defaultMessage : errors[0].detail[0];
+  }
+
+  /**
+   * Utility class used to store the schema
+   * of model attribute definitions
+   *
+   * @class Schema
+   */
+  var Schema =
+  /*#__PURE__*/
+  function () {
+    function Schema() {
+      _classCallCheck(this, Schema);
+
+      this.structure = {};
+      this.relations = {};
+    }
+
+    _createClass(Schema, [{
+      key: "addAttribute",
+      value: function addAttribute(_ref) {
+        var type = _ref.type,
+            property = _ref.property,
+            dataType = _ref.dataType,
+            defaultValue = _ref.defaultValue;
+        this.structure[type] = this.structure[type] || {};
+        this.structure[type][property] = {
+          defaultValue: defaultValue,
+          dataType: dataType
+        };
+      }
+    }, {
+      key: "addRelationship",
+      value: function addRelationship(_ref2) {
+        var type = _ref2.type,
+            property = _ref2.property,
+            dataType = _ref2.dataType;
+        this.relations[type] = this.relations[type] || {};
+        this.relations[type][property] = {
+          dataType: dataType
+        };
+      }
+    }, {
+      key: "addValidation",
+      value: function addValidation(_ref3) {
+        var type = _ref3.type,
+            property = _ref3.property,
+            validator = _ref3.validator;
+        this.structure[type][property].validator = validator;
+      }
+    }]);
+
+    return Schema;
+  }();
+
+  var schema = new Schema();
+
+  /**
+   * Checks if `value` is classified as an `Array` object.
+   *
+   * @static
+   * @memberOf _
+   * @since 0.1.0
+   * @category Lang
+   * @param {*} value The value to check.
+   * @returns {boolean} Returns `true` if `value` is an array, else `false`.
+   * @example
+   *
+   * _.isArray([1, 2, 3]);
+   * // => true
+   *
+   * _.isArray(document.body.children);
+   * // => false
+   *
+   * _.isArray('abc');
+   * // => false
+   *
+   * _.isArray(_.noop);
+   * // => false
+   */
+  var isArray = Array.isArray;
+
+  var isArray_1 = isArray;
+
+  /** Detect free variable `global` from Node.js. */
+  var freeGlobal = typeof commonjsGlobal == 'object' && commonjsGlobal && commonjsGlobal.Object === Object && commonjsGlobal;
+
+  var _freeGlobal = freeGlobal;
+
+  /** Detect free variable `self`. */
+  var freeSelf = typeof self == 'object' && self && self.Object === Object && self;
+
+  /** Used as a reference to the global object. */
+  var root = _freeGlobal || freeSelf || Function('return this')();
+
+  var _root = root;
+
+  /** Built-in value references. */
+  var Symbol$1 = _root.Symbol;
+
+  var _Symbol = Symbol$1;
+
+  /** Used for built-in method references. */
+  var objectProto = Object.prototype;
+
+  /** Used to check objects for own properties. */
+  var hasOwnProperty = objectProto.hasOwnProperty;
+
+  /**
+   * Used to resolve the
+   * [`toStringTag`](http://ecma-international.org/ecma-262/7.0/#sec-object.prototype.tostring)
+   * of values.
+   */
+  var nativeObjectToString = objectProto.toString;
+
+  /** Built-in value references. */
+  var symToStringTag = _Symbol ? _Symbol.toStringTag : undefined;
+
+  /**
+   * A specialized version of `baseGetTag` which ignores `Symbol.toStringTag` values.
+   *
+   * @private
+   * @param {*} value The value to query.
+   * @returns {string} Returns the raw `toStringTag`.
+   */
+  function getRawTag(value) {
+    var isOwn = hasOwnProperty.call(value, symToStringTag),
+        tag = value[symToStringTag];
+
+    try {
+      value[symToStringTag] = undefined;
+      var unmasked = true;
+    } catch (e) {}
+
+    var result = nativeObjectToString.call(value);
+    if (unmasked) {
+      if (isOwn) {
+        value[symToStringTag] = tag;
+      } else {
+        delete value[symToStringTag];
+      }
+    }
+    return result;
+  }
+
+  var _getRawTag = getRawTag;
+
+  /** Used for built-in method references. */
+  var objectProto$1 = Object.prototype;
+
+  /**
+   * Used to resolve the
+   * [`toStringTag`](http://ecma-international.org/ecma-262/7.0/#sec-object.prototype.tostring)
+   * of values.
+   */
+  var nativeObjectToString$1 = objectProto$1.toString;
+
+  /**
+   * Converts `value` to a string using `Object.prototype.toString`.
+   *
+   * @private
+   * @param {*} value The value to convert.
+   * @returns {string} Returns the converted string.
+   */
+  function objectToString(value) {
+    return nativeObjectToString$1.call(value);
+  }
+
+  var _objectToString = objectToString;
+
+  /** `Object#toString` result references. */
+  var nullTag = '[object Null]',
+      undefinedTag = '[object Undefined]';
+
+  /** Built-in value references. */
+  var symToStringTag$1 = _Symbol ? _Symbol.toStringTag : undefined;
+
+  /**
+   * The base implementation of `getTag` without fallbacks for buggy environments.
+   *
+   * @private
+   * @param {*} value The value to query.
+   * @returns {string} Returns the `toStringTag`.
+   */
+  function baseGetTag(value) {
+    if (value == null) {
+      return value === undefined ? undefinedTag : nullTag;
+    }
+    return (symToStringTag$1 && symToStringTag$1 in Object(value))
+      ? _getRawTag(value)
+      : _objectToString(value);
+  }
+
+  var _baseGetTag = baseGetTag;
+
+  /**
+   * Checks if `value` is object-like. A value is object-like if it's not `null`
+   * and has a `typeof` result of "object".
+   *
+   * @static
+   * @memberOf _
+   * @since 4.0.0
+   * @category Lang
+   * @param {*} value The value to check.
+   * @returns {boolean} Returns `true` if `value` is object-like, else `false`.
+   * @example
+   *
+   * _.isObjectLike({});
+   * // => true
+   *
+   * _.isObjectLike([1, 2, 3]);
+   * // => true
+   *
+   * _.isObjectLike(_.noop);
+   * // => false
+   *
+   * _.isObjectLike(null);
+   * // => false
+   */
+  function isObjectLike(value) {
+    return value != null && typeof value == 'object';
+  }
+
+  var isObjectLike_1 = isObjectLike;
+
+  /** `Object#toString` result references. */
+  var symbolTag = '[object Symbol]';
+
+  /**
+   * Checks if `value` is classified as a `Symbol` primitive or object.
+   *
+   * @static
+   * @memberOf _
+   * @since 4.0.0
+   * @category Lang
+   * @param {*} value The value to check.
+   * @returns {boolean} Returns `true` if `value` is a symbol, else `false`.
+   * @example
+   *
+   * _.isSymbol(Symbol.iterator);
+   * // => true
+   *
+   * _.isSymbol('abc');
+   * // => false
+   */
+  function isSymbol(value) {
+    return typeof value == 'symbol' ||
+      (isObjectLike_1(value) && _baseGetTag(value) == symbolTag);
+  }
+
+  var isSymbol_1 = isSymbol;
+
+  /** Used to match property names within property paths. */
+  var reIsDeepProp = /\.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\\]|\\.)*?\1)\]/,
+      reIsPlainProp = /^\w*$/;
+
+  /**
+   * Checks if `value` is a property name and not a property path.
+   *
+   * @private
+   * @param {*} value The value to check.
+   * @param {Object} [object] The object to query keys on.
+   * @returns {boolean} Returns `true` if `value` is a property name, else `false`.
+   */
+  function isKey(value, object) {
+    if (isArray_1(value)) {
+      return false;
+    }
+    var type = typeof value;
+    if (type == 'number' || type == 'symbol' || type == 'boolean' ||
+        value == null || isSymbol_1(value)) {
+      return true;
+    }
+    return reIsPlainProp.test(value) || !reIsDeepProp.test(value) ||
+      (object != null && value in Object(object));
+  }
+
+  var _isKey = isKey;
+
+  /**
+   * Checks if `value` is the
+   * [language type](http://www.ecma-international.org/ecma-262/7.0/#sec-ecmascript-language-types)
+   * of `Object`. (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
+   *
+   * @static
+   * @memberOf _
+   * @since 0.1.0
+   * @category Lang
+   * @param {*} value The value to check.
+   * @returns {boolean} Returns `true` if `value` is an object, else `false`.
+   * @example
+   *
+   * _.isObject({});
+   * // => true
+   *
+   * _.isObject([1, 2, 3]);
+   * // => true
+   *
+   * _.isObject(_.noop);
+   * // => true
+   *
+   * _.isObject(null);
+   * // => false
+   */
+  function isObject(value) {
+    var type = typeof value;
+    return value != null && (type == 'object' || type == 'function');
+  }
+
+  var isObject_1 = isObject;
+
+  /** `Object#toString` result references. */
+  var asyncTag = '[object AsyncFunction]',
+      funcTag = '[object Function]',
+      genTag = '[object GeneratorFunction]',
+      proxyTag = '[object Proxy]';
+
+  /**
+   * Checks if `value` is classified as a `Function` object.
+   *
+   * @static
+   * @memberOf _
+   * @since 0.1.0
+   * @category Lang
+   * @param {*} value The value to check.
+   * @returns {boolean} Returns `true` if `value` is a function, else `false`.
+   * @example
+   *
+   * _.isFunction(_);
+   * // => true
+   *
+   * _.isFunction(/abc/);
+   * // => false
+   */
+  function isFunction(value) {
+    if (!isObject_1(value)) {
+      return false;
+    }
+    // The use of `Object#toString` avoids issues with the `typeof` operator
+    // in Safari 9 which returns 'object' for typed arrays and other constructors.
+    var tag = _baseGetTag(value);
+    return tag == funcTag || tag == genTag || tag == asyncTag || tag == proxyTag;
+  }
+
+  var isFunction_1 = isFunction;
+
+  /** Used to detect overreaching core-js shims. */
+  var coreJsData = _root['__core-js_shared__'];
+
+  var _coreJsData = coreJsData;
+
+  /** Used to detect methods masquerading as native. */
+  var maskSrcKey = (function() {
+    var uid = /[^.]+$/.exec(_coreJsData && _coreJsData.keys && _coreJsData.keys.IE_PROTO || '');
+    return uid ? ('Symbol(src)_1.' + uid) : '';
+  }());
+
+  /**
+   * Checks if `func` has its source masked.
+   *
+   * @private
+   * @param {Function} func The function to check.
+   * @returns {boolean} Returns `true` if `func` is masked, else `false`.
+   */
+  function isMasked(func) {
+    return !!maskSrcKey && (maskSrcKey in func);
+  }
+
+  var _isMasked = isMasked;
+
+  /** Used for built-in method references. */
+  var funcProto = Function.prototype;
+
+  /** Used to resolve the decompiled source of functions. */
+  var funcToString = funcProto.toString;
+
+  /**
+   * Converts `func` to its source code.
+   *
+   * @private
+   * @param {Function} func The function to convert.
+   * @returns {string} Returns the source code.
+   */
+  function toSource(func) {
+    if (func != null) {
+      try {
+        return funcToString.call(func);
+      } catch (e) {}
+      try {
+        return (func + '');
+      } catch (e) {}
+    }
+    return '';
+  }
+
+  var _toSource = toSource;
+
+  /**
+   * Used to match `RegExp`
+   * [syntax characters](http://ecma-international.org/ecma-262/7.0/#sec-patterns).
+   */
+  var reRegExpChar = /[\\^$.*+?()[\]{}|]/g;
+
+  /** Used to detect host constructors (Safari). */
+  var reIsHostCtor = /^\[object .+?Constructor\]$/;
+
+  /** Used for built-in method references. */
+  var funcProto$1 = Function.prototype,
+      objectProto$2 = Object.prototype;
+
+  /** Used to resolve the decompiled source of functions. */
+  var funcToString$1 = funcProto$1.toString;
+
+  /** Used to check objects for own properties. */
+  var hasOwnProperty$1 = objectProto$2.hasOwnProperty;
+
+  /** Used to detect if a method is native. */
+  var reIsNative = RegExp('^' +
+    funcToString$1.call(hasOwnProperty$1).replace(reRegExpChar, '\\$&')
+    .replace(/hasOwnProperty|(function).*?(?=\\\()| for .+?(?=\\\])/g, '$1.*?') + '$'
+  );
+
+  /**
+   * The base implementation of `_.isNative` without bad shim checks.
+   *
+   * @private
+   * @param {*} value The value to check.
+   * @returns {boolean} Returns `true` if `value` is a native function,
+   *  else `false`.
+   */
+  function baseIsNative(value) {
+    if (!isObject_1(value) || _isMasked(value)) {
+      return false;
+    }
+    var pattern = isFunction_1(value) ? reIsNative : reIsHostCtor;
+    return pattern.test(_toSource(value));
+  }
+
+  var _baseIsNative = baseIsNative;
+
+  /**
+   * Gets the value at `key` of `object`.
+   *
+   * @private
+   * @param {Object} [object] The object to query.
+   * @param {string} key The key of the property to get.
+   * @returns {*} Returns the property value.
+   */
+  function getValue(object, key) {
+    return object == null ? undefined : object[key];
+  }
+
+  var _getValue = getValue;
+
+  /**
+   * Gets the native function at `key` of `object`.
+   *
+   * @private
+   * @param {Object} object The object to query.
+   * @param {string} key The key of the method to get.
+   * @returns {*} Returns the function if it's native, else `undefined`.
+   */
+  function getNative(object, key) {
+    var value = _getValue(object, key);
+    return _baseIsNative(value) ? value : undefined;
+  }
+
+  var _getNative = getNative;
+
+  /* Built-in method references that are verified to be native. */
+  var nativeCreate = _getNative(Object, 'create');
+
+  var _nativeCreate = nativeCreate;
+
+  /**
+   * Removes all key-value entries from the hash.
+   *
+   * @private
+   * @name clear
+   * @memberOf Hash
+   */
+  function hashClear() {
+    this.__data__ = _nativeCreate ? _nativeCreate(null) : {};
+    this.size = 0;
+  }
+
+  var _hashClear = hashClear;
+
+  /**
+   * Removes `key` and its value from the hash.
+   *
+   * @private
+   * @name delete
+   * @memberOf Hash
+   * @param {Object} hash The hash to modify.
+   * @param {string} key The key of the value to remove.
+   * @returns {boolean} Returns `true` if the entry was removed, else `false`.
+   */
+  function hashDelete(key) {
+    var result = this.has(key) && delete this.__data__[key];
+    this.size -= result ? 1 : 0;
+    return result;
+  }
+
+  var _hashDelete = hashDelete;
+
+  /** Used to stand-in for `undefined` hash values. */
+  var HASH_UNDEFINED = '__lodash_hash_undefined__';
+
+  /** Used for built-in method references. */
+  var objectProto$3 = Object.prototype;
+
+  /** Used to check objects for own properties. */
+  var hasOwnProperty$2 = objectProto$3.hasOwnProperty;
+
+  /**
+   * Gets the hash value for `key`.
+   *
+   * @private
+   * @name get
+   * @memberOf Hash
+   * @param {string} key The key of the value to get.
+   * @returns {*} Returns the entry value.
+   */
+  function hashGet(key) {
+    var data = this.__data__;
+    if (_nativeCreate) {
+      var result = data[key];
+      return result === HASH_UNDEFINED ? undefined : result;
+    }
+    return hasOwnProperty$2.call(data, key) ? data[key] : undefined;
+  }
+
+  var _hashGet = hashGet;
+
+  /** Used for built-in method references. */
+  var objectProto$4 = Object.prototype;
+
+  /** Used to check objects for own properties. */
+  var hasOwnProperty$3 = objectProto$4.hasOwnProperty;
+
+  /**
+   * Checks if a hash value for `key` exists.
+   *
+   * @private
+   * @name has
+   * @memberOf Hash
+   * @param {string} key The key of the entry to check.
+   * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
+   */
+  function hashHas(key) {
+    var data = this.__data__;
+    return _nativeCreate ? (data[key] !== undefined) : hasOwnProperty$3.call(data, key);
+  }
+
+  var _hashHas = hashHas;
+
+  /** Used to stand-in for `undefined` hash values. */
+  var HASH_UNDEFINED$1 = '__lodash_hash_undefined__';
+
+  /**
+   * Sets the hash `key` to `value`.
+   *
+   * @private
+   * @name set
+   * @memberOf Hash
+   * @param {string} key The key of the value to set.
+   * @param {*} value The value to set.
+   * @returns {Object} Returns the hash instance.
+   */
+  function hashSet(key, value) {
+    var data = this.__data__;
+    this.size += this.has(key) ? 0 : 1;
+    data[key] = (_nativeCreate && value === undefined) ? HASH_UNDEFINED$1 : value;
+    return this;
+  }
+
+  var _hashSet = hashSet;
+
+  /**
+   * Creates a hash object.
+   *
+   * @private
+   * @constructor
+   * @param {Array} [entries] The key-value pairs to cache.
+   */
+  function Hash(entries) {
+    var index = -1,
+        length = entries == null ? 0 : entries.length;
+
+    this.clear();
+    while (++index < length) {
+      var entry = entries[index];
+      this.set(entry[0], entry[1]);
+    }
+  }
+
+  // Add methods to `Hash`.
+  Hash.prototype.clear = _hashClear;
+  Hash.prototype['delete'] = _hashDelete;
+  Hash.prototype.get = _hashGet;
+  Hash.prototype.has = _hashHas;
+  Hash.prototype.set = _hashSet;
+
+  var _Hash = Hash;
+
+  /**
+   * Removes all key-value entries from the list cache.
+   *
+   * @private
+   * @name clear
+   * @memberOf ListCache
+   */
+  function listCacheClear() {
+    this.__data__ = [];
+    this.size = 0;
+  }
+
+  var _listCacheClear = listCacheClear;
+
+  /**
+   * Performs a
+   * [`SameValueZero`](http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero)
+   * comparison between two values to determine if they are equivalent.
+   *
+   * @static
+   * @memberOf _
+   * @since 4.0.0
+   * @category Lang
+   * @param {*} value The value to compare.
+   * @param {*} other The other value to compare.
+   * @returns {boolean} Returns `true` if the values are equivalent, else `false`.
+   * @example
+   *
+   * var object = { 'a': 1 };
+   * var other = { 'a': 1 };
+   *
+   * _.eq(object, object);
+   * // => true
+   *
+   * _.eq(object, other);
+   * // => false
+   *
+   * _.eq('a', 'a');
+   * // => true
+   *
+   * _.eq('a', Object('a'));
+   * // => false
+   *
+   * _.eq(NaN, NaN);
+   * // => true
+   */
+  function eq$1(value, other) {
+    return value === other || (value !== value && other !== other);
+  }
+
+  var eq_1 = eq$1;
+
+  /**
+   * Gets the index at which the `key` is found in `array` of key-value pairs.
+   *
+   * @private
+   * @param {Array} array The array to inspect.
+   * @param {*} key The key to search for.
+   * @returns {number} Returns the index of the matched value, else `-1`.
+   */
+  function assocIndexOf(array, key) {
+    var length = array.length;
+    while (length--) {
+      if (eq_1(array[length][0], key)) {
+        return length;
+      }
+    }
+    return -1;
+  }
+
+  var _assocIndexOf = assocIndexOf;
+
+  /** Used for built-in method references. */
+  var arrayProto = Array.prototype;
+
+  /** Built-in value references. */
+  var splice = arrayProto.splice;
+
+  /**
+   * Removes `key` and its value from the list cache.
+   *
+   * @private
+   * @name delete
+   * @memberOf ListCache
+   * @param {string} key The key of the value to remove.
+   * @returns {boolean} Returns `true` if the entry was removed, else `false`.
+   */
+  function listCacheDelete(key) {
+    var data = this.__data__,
+        index = _assocIndexOf(data, key);
+
+    if (index < 0) {
+      return false;
+    }
+    var lastIndex = data.length - 1;
+    if (index == lastIndex) {
+      data.pop();
+    } else {
+      splice.call(data, index, 1);
+    }
+    --this.size;
+    return true;
+  }
+
+  var _listCacheDelete = listCacheDelete;
+
+  /**
+   * Gets the list cache value for `key`.
+   *
+   * @private
+   * @name get
+   * @memberOf ListCache
+   * @param {string} key The key of the value to get.
+   * @returns {*} Returns the entry value.
+   */
+  function listCacheGet(key) {
+    var data = this.__data__,
+        index = _assocIndexOf(data, key);
+
+    return index < 0 ? undefined : data[index][1];
+  }
+
+  var _listCacheGet = listCacheGet;
+
+  /**
+   * Checks if a list cache value for `key` exists.
+   *
+   * @private
+   * @name has
+   * @memberOf ListCache
+   * @param {string} key The key of the entry to check.
+   * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
+   */
+  function listCacheHas(key) {
+    return _assocIndexOf(this.__data__, key) > -1;
+  }
+
+  var _listCacheHas = listCacheHas;
+
+  /**
+   * Sets the list cache `key` to `value`.
+   *
+   * @private
+   * @name set
+   * @memberOf ListCache
+   * @param {string} key The key of the value to set.
+   * @param {*} value The value to set.
+   * @returns {Object} Returns the list cache instance.
+   */
+  function listCacheSet(key, value) {
+    var data = this.__data__,
+        index = _assocIndexOf(data, key);
+
+    if (index < 0) {
+      ++this.size;
+      data.push([key, value]);
+    } else {
+      data[index][1] = value;
+    }
+    return this;
+  }
+
+  var _listCacheSet = listCacheSet;
+
+  /**
+   * Creates an list cache object.
+   *
+   * @private
+   * @constructor
+   * @param {Array} [entries] The key-value pairs to cache.
+   */
+  function ListCache(entries) {
+    var index = -1,
+        length = entries == null ? 0 : entries.length;
+
+    this.clear();
+    while (++index < length) {
+      var entry = entries[index];
+      this.set(entry[0], entry[1]);
+    }
+  }
+
+  // Add methods to `ListCache`.
+  ListCache.prototype.clear = _listCacheClear;
+  ListCache.prototype['delete'] = _listCacheDelete;
+  ListCache.prototype.get = _listCacheGet;
+  ListCache.prototype.has = _listCacheHas;
+  ListCache.prototype.set = _listCacheSet;
+
+  var _ListCache = ListCache;
+
+  /* Built-in method references that are verified to be native. */
+  var Map$1 = _getNative(_root, 'Map');
+
+  var _Map = Map$1;
+
+  /**
+   * Removes all key-value entries from the map.
+   *
+   * @private
+   * @name clear
+   * @memberOf MapCache
+   */
+  function mapCacheClear() {
+    this.size = 0;
+    this.__data__ = {
+      'hash': new _Hash,
+      'map': new (_Map || _ListCache),
+      'string': new _Hash
+    };
+  }
+
+  var _mapCacheClear = mapCacheClear;
+
+  /**
+   * Checks if `value` is suitable for use as unique object key.
+   *
+   * @private
+   * @param {*} value The value to check.
+   * @returns {boolean} Returns `true` if `value` is suitable, else `false`.
+   */
+  function isKeyable(value) {
+    var type = typeof value;
+    return (type == 'string' || type == 'number' || type == 'symbol' || type == 'boolean')
+      ? (value !== '__proto__')
+      : (value === null);
+  }
+
+  var _isKeyable = isKeyable;
+
+  /**
+   * Gets the data for `map`.
+   *
+   * @private
+   * @param {Object} map The map to query.
+   * @param {string} key The reference key.
+   * @returns {*} Returns the map data.
+   */
+  function getMapData(map, key) {
+    var data = map.__data__;
+    return _isKeyable(key)
+      ? data[typeof key == 'string' ? 'string' : 'hash']
+      : data.map;
+  }
+
+  var _getMapData = getMapData;
+
+  /**
+   * Removes `key` and its value from the map.
+   *
+   * @private
+   * @name delete
+   * @memberOf MapCache
+   * @param {string} key The key of the value to remove.
+   * @returns {boolean} Returns `true` if the entry was removed, else `false`.
+   */
+  function mapCacheDelete(key) {
+    var result = _getMapData(this, key)['delete'](key);
+    this.size -= result ? 1 : 0;
+    return result;
+  }
+
+  var _mapCacheDelete = mapCacheDelete;
+
+  /**
+   * Gets the map value for `key`.
+   *
+   * @private
+   * @name get
+   * @memberOf MapCache
+   * @param {string} key The key of the value to get.
+   * @returns {*} Returns the entry value.
+   */
+  function mapCacheGet(key) {
+    return _getMapData(this, key).get(key);
+  }
+
+  var _mapCacheGet = mapCacheGet;
+
+  /**
+   * Checks if a map value for `key` exists.
+   *
+   * @private
+   * @name has
+   * @memberOf MapCache
+   * @param {string} key The key of the entry to check.
+   * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
+   */
+  function mapCacheHas(key) {
+    return _getMapData(this, key).has(key);
+  }
+
+  var _mapCacheHas = mapCacheHas;
+
+  /**
+   * Sets the map `key` to `value`.
+   *
+   * @private
+   * @name set
+   * @memberOf MapCache
+   * @param {string} key The key of the value to set.
+   * @param {*} value The value to set.
+   * @returns {Object} Returns the map cache instance.
+   */
+  function mapCacheSet(key, value) {
+    var data = _getMapData(this, key),
+        size = data.size;
+
+    data.set(key, value);
+    this.size += data.size == size ? 0 : 1;
+    return this;
+  }
+
+  var _mapCacheSet = mapCacheSet;
+
+  /**
+   * Creates a map cache object to store key-value pairs.
+   *
+   * @private
+   * @constructor
+   * @param {Array} [entries] The key-value pairs to cache.
+   */
+  function MapCache(entries) {
+    var index = -1,
+        length = entries == null ? 0 : entries.length;
+
+    this.clear();
+    while (++index < length) {
+      var entry = entries[index];
+      this.set(entry[0], entry[1]);
+    }
+  }
+
+  // Add methods to `MapCache`.
+  MapCache.prototype.clear = _mapCacheClear;
+  MapCache.prototype['delete'] = _mapCacheDelete;
+  MapCache.prototype.get = _mapCacheGet;
+  MapCache.prototype.has = _mapCacheHas;
+  MapCache.prototype.set = _mapCacheSet;
+
+  var _MapCache = MapCache;
+
+  /** Error message constants. */
+  var FUNC_ERROR_TEXT = 'Expected a function';
+
+  /**
+   * Creates a function that memoizes the result of `func`. If `resolver` is
+   * provided, it determines the cache key for storing the result based on the
+   * arguments provided to the memoized function. By default, the first argument
+   * provided to the memoized function is used as the map cache key. The `func`
+   * is invoked with the `this` binding of the memoized function.
+   *
+   * **Note:** The cache is exposed as the `cache` property on the memoized
+   * function. Its creation may be customized by replacing the `_.memoize.Cache`
+   * constructor with one whose instances implement the
+   * [`Map`](http://ecma-international.org/ecma-262/7.0/#sec-properties-of-the-map-prototype-object)
+   * method interface of `clear`, `delete`, `get`, `has`, and `set`.
+   *
+   * @static
+   * @memberOf _
+   * @since 0.1.0
+   * @category Function
+   * @param {Function} func The function to have its output memoized.
+   * @param {Function} [resolver] The function to resolve the cache key.
+   * @returns {Function} Returns the new memoized function.
+   * @example
+   *
+   * var object = { 'a': 1, 'b': 2 };
+   * var other = { 'c': 3, 'd': 4 };
+   *
+   * var values = _.memoize(_.values);
+   * values(object);
+   * // => [1, 2]
+   *
+   * values(other);
+   * // => [3, 4]
+   *
+   * object.a = 2;
+   * values(object);
+   * // => [1, 2]
+   *
+   * // Modify the result cache.
+   * values.cache.set(object, ['a', 'b']);
+   * values(object);
+   * // => ['a', 'b']
+   *
+   * // Replace `_.memoize.Cache`.
+   * _.memoize.Cache = WeakMap;
+   */
+  function memoize(func, resolver) {
+    if (typeof func != 'function' || (resolver != null && typeof resolver != 'function')) {
+      throw new TypeError(FUNC_ERROR_TEXT);
+    }
+    var memoized = function() {
+      var args = arguments,
+          key = resolver ? resolver.apply(this, args) : args[0],
+          cache = memoized.cache;
+
+      if (cache.has(key)) {
+        return cache.get(key);
+      }
+      var result = func.apply(this, args);
+      memoized.cache = cache.set(key, result) || cache;
+      return result;
+    };
+    memoized.cache = new (memoize.Cache || _MapCache);
+    return memoized;
+  }
+
+  // Expose `MapCache`.
+  memoize.Cache = _MapCache;
+
+  var memoize_1 = memoize;
+
+  /** Used as the maximum memoize cache size. */
+  var MAX_MEMOIZE_SIZE = 500;
+
+  /**
+   * A specialized version of `_.memoize` which clears the memoized function's
+   * cache when it exceeds `MAX_MEMOIZE_SIZE`.
+   *
+   * @private
+   * @param {Function} func The function to have its output memoized.
+   * @returns {Function} Returns the new memoized function.
+   */
+  function memoizeCapped(func) {
+    var result = memoize_1(func, function(key) {
+      if (cache.size === MAX_MEMOIZE_SIZE) {
+        cache.clear();
+      }
+      return key;
+    });
+
+    var cache = result.cache;
+    return result;
+  }
+
+  var _memoizeCapped = memoizeCapped;
+
+  /** Used to match property names within property paths. */
+  var rePropName = /[^.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|$))/g;
+
+  /** Used to match backslashes in property paths. */
+  var reEscapeChar = /\\(\\)?/g;
+
+  /**
+   * Converts `string` to a property path array.
+   *
+   * @private
+   * @param {string} string The string to convert.
+   * @returns {Array} Returns the property path array.
+   */
+  var stringToPath = _memoizeCapped(function(string) {
+    var result = [];
+    if (string.charCodeAt(0) === 46 /* . */) {
+      result.push('');
+    }
+    string.replace(rePropName, function(match, number, quote, subString) {
+      result.push(quote ? subString.replace(reEscapeChar, '$1') : (number || match));
+    });
+    return result;
+  });
+
+  var _stringToPath = stringToPath;
+
+  /**
+   * A specialized version of `_.map` for arrays without support for iteratee
+   * shorthands.
+   *
+   * @private
+   * @param {Array} [array] The array to iterate over.
+   * @param {Function} iteratee The function invoked per iteration.
+   * @returns {Array} Returns the new mapped array.
+   */
+  function arrayMap(array, iteratee) {
+    var index = -1,
+        length = array == null ? 0 : array.length,
+        result = Array(length);
+
+    while (++index < length) {
+      result[index] = iteratee(array[index], index, array);
+    }
+    return result;
+  }
+
+  var _arrayMap = arrayMap;
+
+  /** Used as references for various `Number` constants. */
+  var INFINITY = 1 / 0;
+
+  /** Used to convert symbols to primitives and strings. */
+  var symbolProto = _Symbol ? _Symbol.prototype : undefined,
+      symbolToString = symbolProto ? symbolProto.toString : undefined;
+
+  /**
+   * The base implementation of `_.toString` which doesn't convert nullish
+   * values to empty strings.
+   *
+   * @private
+   * @param {*} value The value to process.
+   * @returns {string} Returns the string.
+   */
+  function baseToString(value) {
+    // Exit early for strings to avoid a performance hit in some environments.
+    if (typeof value == 'string') {
+      return value;
+    }
+    if (isArray_1(value)) {
+      // Recursively convert values (susceptible to call stack limits).
+      return _arrayMap(value, baseToString) + '';
+    }
+    if (isSymbol_1(value)) {
+      return symbolToString ? symbolToString.call(value) : '';
+    }
+    var result = (value + '');
+    return (result == '0' && (1 / value) == -INFINITY) ? '-0' : result;
+  }
+
+  var _baseToString = baseToString;
+
+  /**
+   * Converts `value` to a string. An empty string is returned for `null`
+   * and `undefined` values. The sign of `-0` is preserved.
+   *
+   * @static
+   * @memberOf _
+   * @since 4.0.0
+   * @category Lang
+   * @param {*} value The value to convert.
+   * @returns {string} Returns the converted string.
+   * @example
+   *
+   * _.toString(null);
+   * // => ''
+   *
+   * _.toString(-0);
+   * // => '-0'
+   *
+   * _.toString([1, 2, 3]);
+   * // => '1,2,3'
+   */
+  function toString$1(value) {
+    return value == null ? '' : _baseToString(value);
+  }
+
+  var toString_1 = toString$1;
+
+  /**
+   * Casts `value` to a path array if it's not one.
+   *
+   * @private
+   * @param {*} value The value to inspect.
+   * @param {Object} [object] The object to query keys on.
+   * @returns {Array} Returns the cast property path array.
+   */
+  function castPath(value, object) {
+    if (isArray_1(value)) {
+      return value;
+    }
+    return _isKey(value, object) ? [value] : _stringToPath(toString_1(value));
+  }
+
+  var _castPath = castPath;
+
+  /** Used as references for various `Number` constants. */
+  var INFINITY$1 = 1 / 0;
+
+  /**
+   * Converts `value` to a string key if it's not a string or symbol.
+   *
+   * @private
+   * @param {*} value The value to inspect.
+   * @returns {string|symbol} Returns the key.
+   */
+  function toKey(value) {
+    if (typeof value == 'string' || isSymbol_1(value)) {
+      return value;
+    }
+    var result = (value + '');
+    return (result == '0' && (1 / value) == -INFINITY$1) ? '-0' : result;
+  }
+
+  var _toKey = toKey;
+
+  /**
+   * The base implementation of `_.get` without support for default values.
+   *
+   * @private
+   * @param {Object} object The object to query.
+   * @param {Array|string} path The path of the property to get.
+   * @returns {*} Returns the resolved value.
+   */
+  function baseGet(object, path) {
+    path = _castPath(path, object);
+
+    var index = 0,
+        length = path.length;
+
+    while (object != null && index < length) {
+      object = object[_toKey(path[index++])];
+    }
+    return (index && index == length) ? object : undefined;
+  }
+
+  var _baseGet = baseGet;
+
+  /**
+   * Gets the value at `path` of `object`. If the resolved value is
+   * `undefined`, the `defaultValue` is returned in its place.
+   *
+   * @static
+   * @memberOf _
+   * @since 3.7.0
+   * @category Object
+   * @param {Object} object The object to query.
+   * @param {Array|string} path The path of the property to get.
+   * @param {*} [defaultValue] The value returned for `undefined` resolved values.
+   * @returns {*} Returns the resolved value.
+   * @example
+   *
+   * var object = { 'a': [{ 'b': { 'c': 3 } }] };
+   *
+   * _.get(object, 'a[0].b.c');
+   * // => 3
+   *
+   * _.get(object, ['a', '0', 'b', 'c']);
+   * // => 3
+   *
+   * _.get(object, 'a.b.c', 'default');
+   * // => 'default'
+   */
+  function get(object, path, defaultValue) {
+    var result = object == null ? undefined : _baseGet(object, path);
+    return result === undefined ? defaultValue : result;
+  }
+
+  var get_1 = get;
+
+  /**
+   * Appends the elements of `values` to `array`.
+   *
+   * @private
+   * @param {Array} array The array to modify.
+   * @param {Array} values The values to append.
+   * @returns {Array} Returns `array`.
+   */
+  function arrayPush(array, values) {
+    var index = -1,
+        length = values.length,
+        offset = array.length;
+
+    while (++index < length) {
+      array[offset + index] = values[index];
+    }
+    return array;
+  }
+
+  var _arrayPush = arrayPush;
+
+  /** `Object#toString` result references. */
+  var argsTag = '[object Arguments]';
+
+  /**
+   * The base implementation of `_.isArguments`.
+   *
+   * @private
+   * @param {*} value The value to check.
+   * @returns {boolean} Returns `true` if `value` is an `arguments` object,
+   */
+  function baseIsArguments(value) {
+    return isObjectLike_1(value) && _baseGetTag(value) == argsTag;
+  }
+
+  var _baseIsArguments = baseIsArguments;
+
+  /** Used for built-in method references. */
+  var objectProto$5 = Object.prototype;
+
+  /** Used to check objects for own properties. */
+  var hasOwnProperty$4 = objectProto$5.hasOwnProperty;
+
+  /** Built-in value references. */
+  var propertyIsEnumerable = objectProto$5.propertyIsEnumerable;
+
+  /**
+   * Checks if `value` is likely an `arguments` object.
+   *
+   * @static
+   * @memberOf _
+   * @since 0.1.0
+   * @category Lang
+   * @param {*} value The value to check.
+   * @returns {boolean} Returns `true` if `value` is an `arguments` object,
+   *  else `false`.
+   * @example
+   *
+   * _.isArguments(function() { return arguments; }());
+   * // => true
+   *
+   * _.isArguments([1, 2, 3]);
+   * // => false
+   */
+  var isArguments = _baseIsArguments(function() { return arguments; }()) ? _baseIsArguments : function(value) {
+    return isObjectLike_1(value) && hasOwnProperty$4.call(value, 'callee') &&
+      !propertyIsEnumerable.call(value, 'callee');
+  };
+
+  var isArguments_1 = isArguments;
+
+  /** Built-in value references. */
+  var spreadableSymbol = _Symbol ? _Symbol.isConcatSpreadable : undefined;
+
+  /**
+   * Checks if `value` is a flattenable `arguments` object or array.
+   *
+   * @private
+   * @param {*} value The value to check.
+   * @returns {boolean} Returns `true` if `value` is flattenable, else `false`.
+   */
+  function isFlattenable(value) {
+    return isArray_1(value) || isArguments_1(value) ||
+      !!(spreadableSymbol && value && value[spreadableSymbol]);
+  }
+
+  var _isFlattenable = isFlattenable;
+
+  /**
+   * The base implementation of `_.flatten` with support for restricting flattening.
+   *
+   * @private
+   * @param {Array} array The array to flatten.
+   * @param {number} depth The maximum recursion depth.
+   * @param {boolean} [predicate=isFlattenable] The function invoked per iteration.
+   * @param {boolean} [isStrict] Restrict to values that pass `predicate` checks.
+   * @param {Array} [result=[]] The initial result value.
+   * @returns {Array} Returns the new flattened array.
+   */
+  function baseFlatten(array, depth, predicate, isStrict, result) {
+    var index = -1,
+        length = array.length;
+
+    predicate || (predicate = _isFlattenable);
+    result || (result = []);
+
+    while (++index < length) {
+      var value = array[index];
+      if (depth > 0 && predicate(value)) {
+        if (depth > 1) {
+          // Recursively flatten arrays (susceptible to call stack limits).
+          baseFlatten(value, depth - 1, predicate, isStrict, result);
+        } else {
+          _arrayPush(result, value);
+        }
+      } else if (!isStrict) {
+        result[result.length] = value;
+      }
+    }
+    return result;
+  }
+
+  var _baseFlatten = baseFlatten;
+
+  /** Used as references for various `Number` constants. */
+  var INFINITY$2 = 1 / 0;
+
+  /**
+   * Recursively flattens `array`.
+   *
+   * @static
+   * @memberOf _
+   * @since 3.0.0
+   * @category Array
+   * @param {Array} array The array to flatten.
+   * @returns {Array} Returns the new flattened array.
+   * @example
+   *
+   * _.flattenDeep([1, [2, [3, [4]], 5]]);
+   * // => [1, 2, 3, 4, 5]
+   */
+  function flattenDeep(array) {
+    var length = array == null ? 0 : array.length;
+    return length ? _baseFlatten(array, INFINITY$2) : [];
+  }
+
+  var flattenDeep_1 = flattenDeep;
+
+  var _class, _descriptor, _descriptor2, _temp;
+
+  function ownKeys$1(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+  function _objectSpread$1(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys$1(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys$1(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+  function stringifyIds(object) {
+    Object.keys(object).forEach(function (key) {
+      var property = object[key];
+
+      if (_typeof(property) === 'object') {
+        if (property.id) {
+          property.id = String(property.id);
+        }
+
+        stringifyIds(property);
+      }
+    });
+  }
+  /*
+   * Defines a many-to-one relationship. Defaults to the class with camelized name of the property.
+   * An optional argument specifies the data model, if different from the property name.
+   * ```
+   * class Note extends Model {
+   *   @belongsTo todo
+   *   @belongsTo(Facility) greenhouse
+   * }
+   * ```
+   * Polymorphic relationships
+   * Define `belongsTo` with the the associated models
+   * Define `hasMany` as you normally would
+   * ```
+   * class Note extends Model {
+   *   @belongsTo(Todo, ScheduledEvent) notable
+   * }
+   *
+   * class Todo extends Model {
+   *   @hasMany notes
+   * }
+   * ```
+   * @method belongsTo
+   */
+
+  /**
+   @class Model
+   */
+
+  var Model = (_class = (_temp =
+  /*#__PURE__*/
+  function () {
+    /**
+     * Initializer for model
+     *
+     * @method constructor
+     */
+    function Model() {
+      var initialAttributes = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+      _classCallCheck(this, Model);
+
+      _initializerDefineProperty(this, "_isDirty", _descriptor, this);
+
+      this.isInFlight = false;
+
+      _initializerDefineProperty(this, "errors", _descriptor2, this);
+
+      this.previousSnapshot = {};
+
+      this._makeObservable(initialAttributes);
+
+      this.setPreviousSnapshot();
+
+      this._trackState();
+    }
+    /**
+     * The type of the model. Defined on the class. Defaults to the underscored version of the class name
+     * (eg 'calendar_events').
+     *
+     * @property type
+     * @static
+     */
+
+    /**
+     * The canonical path to the resource on the server. Defined on the class.
+     * Defaults to the underscored version of the class name
+     * @property endpoint
+     * @static
+     */
+
+    /**
+     * True if the instance has been modified from its persisted state
+     * ```
+     * kpi = store.add('kpis', { name: 'A good thing to measure' })
+     * kpi.isDirty
+     * => true
+     * kpi.name
+     * => "A good thing to measure"
+     * await kpi.save()
+     * kpi.isDirty
+     * => false
+     * kpi.name = "Another good thing to measure"
+     * kpi.isDirty
+     * => true
+     * await kpi.save()
+     * kpi.isDirty
+     * => false
+     * ```
+     * @property isDirty
+     * @type {Boolean}
+     * @default false
+     */
+
+
+    _createClass(Model, [{
+      key: "rollback",
+
+      /**
+       * restores data to its last persisted state
+       * ```
+       * kpi = store.find('kpis', 5)
+       * kpi.name
+       * => "A good thing to measure"
+       * kpi.name = "Another good thing to measure"
+       * kpi.rollback()
+       * kpi.name
+       * => "A good thing to measure"
+       * ```
+       * @method rollback
+       */
+      value: function rollback() {
+        var _this2 = this;
+
+        transaction$$1(function () {
+          var previousSnapshot = _this2.previousSnapshot;
+
+          _this2.attributeNames.forEach(function (key) {
+            _this2[key] = previousSnapshot.attributes[key];
+          });
+
+          _this2.relationships = previousSnapshot.relationships;
+          _this2.errors = {};
+        });
+        this.setPreviousSnapshot();
+      }
+      /**
+       * creates or updates a record.
+       * @method save
+       * @return {Promise}
+       * @param {Object} options
+       */
+
+    }, {
+      key: "save",
+      value: function save() {
+        var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+        if (!options.skip_validations && !this.validate()) {
+          var errorString = JSON.stringify(this.errors);
+          return Promise.reject(new Error(errorString));
+        }
+
+        var queryParams = options.queryParams,
+            relationships = options.relationships,
+            attributes = options.attributes;
+        var constructor = this.constructor,
+            id = this.id,
+            isNew = this.isNew;
+        var requestId = id;
+        var method = 'PATCH';
+
+        if (isNew) {
+          method = 'POST';
+          requestId = null;
+        }
+
+        var url = this.store.fetchUrl(constructor.type, queryParams, requestId);
+        var body = JSON.stringify(this.jsonapi({
+          relationships: relationships,
+          attributes: attributes
+        }));
+        var response = this.store.fetch(url, {
+          method: method,
+          body: body
+        });
+        return new ObjectPromiseProxy(response, this);
+      }
+      /**
+       * Checks all validations, adding errors where necessary and returning `false` if any are not valid
+       * @method validate
+       * @return {Boolean}
+       */
+
+    }, {
+      key: "validate",
+      value: function validate() {
+        var _this3 = this;
+
+        this.errors = {};
+        var attributeNames = this.attributeNames,
+            attributeDefinitions = this.attributeDefinitions;
+        var validationChecks = attributeNames.map(function (property) {
+          var validator = attributeDefinitions[property].validator;
+          if (!validator) return true;
+          var validationResult = validator(_this3[property], _this3);
+
+          if (!validationResult.isValid) {
+            _this3.errors[property] = validationResult.errors;
+          }
+
+          return validationResult.isValid;
+        });
+        return validationChecks.every(function (value) {
+          return value;
+        });
+      }
+      /**
+       * deletes a record from the store and server
+       * @method destroy
+       * @return {Promise} an empty promise with any success/error status
+       */
+
+    }, {
+      key: "destroy",
+      value: function destroy() {
+        var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+        var type = this.constructor.type,
+            id = this.id,
+            snapshot = this.snapshot,
+            isNew = this.isNew;
+
+        if (isNew) {
+          this.store.remove(type, id);
+          return snapshot;
+        }
+
+        var _options$params = options.params,
+            params = _options$params === void 0 ? {} : _options$params,
+            _options$skipRemove = options.skipRemove,
+            skipRemove = _options$skipRemove === void 0 ? false : _options$skipRemove;
+        var url = this.store.fetchUrl(type, params, id);
+        this.isInFlight = true;
+        var promise = this.store.fetch(url, {
+          method: 'DELETE'
+        });
+
+        var _this = this;
+
+        _this.errors = {};
+        return promise.then(function _callee(response) {
+          var json;
+          return regeneratorRuntime.async(function _callee$(_context) {
+            while (1) {
+              switch (_context.prev = _context.next) {
+                case 0:
+                  _this.isInFlight = false;
+
+                  if (!(response.status === 202 || response.status === 204)) {
+                    _context.next = 17;
+                    break;
+                  }
+
+                  if (!skipRemove) {
+                    _this.store.remove(type, id);
+                  }
+
+                  _context.prev = 3;
+                  _context.next = 6;
+                  return regeneratorRuntime.awrap(response.json());
+
+                case 6:
+                  json = _context.sent;
+
+                  if (json.data && json.data.attributes) {
+                    Object.keys(json.data.attributes).forEach(function (key) {
+                      set$$1(_this, key, json.data.attributes[key]);
+                    });
+                  }
+
+                  _context.next = 13;
+                  break;
+
+                case 10:
+                  _context.prev = 10;
+                  _context.t0 = _context["catch"](3);
+                  console.log(_context.t0); // It is text, do you text handling here
+
+                case 13:
+                  // NOTE: If deleting a record changes other related model
+                  // You can return then in the delete response
+                  if (json && json.included) {
+                    _this.store.createModelsFromData(json.included);
+                  }
+
+                  return _context.abrupt("return", _this);
+
+                case 17:
+                  _this.errors = {
+                    status: response.status
+                  };
+                  return _context.abrupt("return", _this);
+
+                case 19:
+                case "end":
+                  return _context.stop();
+              }
+            }
+          }, null, null, [[3, 10]]);
+        }, function (error) {
+          // TODO: Handle error states correctly
+          _this.isInFlight = false;
+          _this.errors = error;
+          throw error;
+        });
+      }
+      /* Private Methods */
+
+      /**
+       * Magic method that makes changes to records
+       * observable
+       *
+       * @method _makeObservable
+       */
+
+    }, {
+      key: "_makeObservable",
+      value: function _makeObservable(initialAttributes) {
+        var defaultAttributes = this.defaultAttributes;
+        extendObservable$$1(this, _objectSpread$1({}, defaultAttributes, {}, initialAttributes));
+      }
+      /**
+       * The current state of defined attributes and relationships of the instance
+       * Really just an alias for attributes
+       * ```
+       * todo = store.find('todos', 5)
+       * todo.title
+       * => "Buy the eggs"
+       * snapshot = todo.snapshot
+       * todo.title = "Buy the eggs and bacon"
+       * snapshot.title
+       * => "Buy the eggs and bacon"
+       * ```
+       * @method snapshot
+       * @return {Object} current attributes
+       */
+
+    }, {
+      key: "setPreviousSnapshot",
+
+      /**
+       * Sets previous snapshot to current snapshot
+       *
+       * @method setPreviousSnapshot
+       */
+      value: function setPreviousSnapshot() {
+        this.previousSnapshot = this.snapshot;
+      }
+      /**
+       * a list of any property paths which have been changed since the previous
+       * snapshot
+       * ```
+       * const todo = new Todo({ title: 'Buy Milk' })
+       * todo.dirtyAttributes
+       * => []
+       * todo.title = 'Buy Cheese'
+       * todo.dirtyAttributes
+       * => ['title']
+       * ```
+       * @method dirtyAttributes
+       * @return {Array} dirty attribute paths
+       */
+
+    }, {
+      key: "_trackState",
+
+      /**
+       * Uses mobx.autorun to track changes to attributes
+       *
+       * @method _trackState
+       */
+      value: function _trackState() {
+        var _this4 = this;
+
+        reaction$$1(function () {
+          return JSON.stringify(_this4.attributes);
+        }, function (objectString) {
+          // console.log(objectString)
+          _this4.isDirty = true;
+        });
+        reaction$$1(function () {
+          return JSON.stringify(_this4.relationships);
+        }, function (relString) {
+          // console.log(relString)
+          _this4.isDirty = true;
+        });
+      }
+      /**
+       * shortcut to get the static
+       *
+       * @method type
+       * @return {String} current attributes
+      */
+
+    }, {
+      key: "errorForKey",
+
+      /**
+       * Getter to check if the record has errors.
+       *
+       * @method hasErrors
+       * @return {Boolean}
+       */
+      value: function errorForKey(key) {
+        return this.errors[key];
+      }
+      /**
+       * Getter to just get the names of a records attributes.
+       *
+       * @method attributeNames
+       * @return {Array}
+       */
+
+    }, {
+      key: "jsonapi",
+
+      /**
+       * getter method to get data in api compliance format
+       * TODO: Figure out how to handle unpersisted ids
+       *
+       * @method jsonapi
+       * @return {Object} data in JSON::API format
+       */
+      value: function jsonapi() {
+        var _this5 = this;
+
+        var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+        var attributeDefinitions = this.attributeDefinitions,
+            attributeNames = this.attributeNames,
+            meta = this.meta,
+            id = this.id,
+            type = this.constructor.type;
+        var filteredAttributeNames = attributeNames;
+        var filteredRelationshipNames = [];
+
+        if (options.attributes) {
+          filteredAttributeNames = attributeNames.filter(function (name) {
+            return options.attributes.includes(name);
+          });
+        }
+
+        var attributes = filteredAttributeNames.reduce(function (attrs, key) {
+          var value = _this5[key];
+
+          if (value) {
+            var DataType = attributeDefinitions[key].dataType;
+            var attr;
+
+            if (DataType.name === 'Array' || DataType.name === 'Object') {
+              attr = toJS$$1(value);
+            } else if (DataType.name === 'Date') {
+              attr = moment(value).toISOString();
+            } else {
+              attr = DataType(value);
+            }
+
+            attrs[key] = attr;
+          } else {
+            attrs[key] = value;
+          }
+
+          return attrs;
+        }, {});
+        var data = {
+          type: type,
+          attributes: attributes,
+          id: String(id)
+        };
+
+        if (options.relationships) {
+          filteredRelationshipNames = Object.keys(this.relationships).filter(function (name) {
+            return options.relationships.includes(name);
+          });
+          var relationships = filteredRelationshipNames.reduce(function (rels, key) {
+            rels[key] = toJS$$1(_this5.relationships[key]);
+            stringifyIds(rels[key]);
+            return rels;
+          }, {});
+          data.relationships = relationships;
+        }
+
+        if (meta) {
+          data['meta'] = meta;
+        }
+
+        if (String(id).match(/tmp/)) {
+          delete data.id;
+        }
+
+        return {
+          data: data
+        };
+      }
+    }, {
+      key: "updateAttributes",
+      value: function updateAttributes(attributes) {
+        var _this6 = this;
+
+        transaction$$1(function () {
+          Object.keys(attributes).forEach(function (key) {
+            _this6[key] = attributes[key];
+          });
+        });
+      }
+    }, {
+      key: "isDirty",
+      get: function get() {
+        var isNew = this.isNew,
+            _isDirty = this._isDirty;
+        return _isDirty || isNew;
+      },
+      set: function set(value) {
+        this._isDirty = value;
+      }
+      /**
+       * Private method. True if the model has been programatically changed,
+       * as opposed to just being new.
+       * @property _isDirty
+       * @type {Boolean}
+       * @default false
+       * @private
+       */
+
+    }, {
+      key: "isNew",
+
+      /**
+       * True if the model has not been sent to the store
+       * @property isNew
+       * @type {Boolean}
+       */
+      get: function get() {
+        var id = this.id;
+        return !!String(id).match(/tmp/);
+      }
+      /**
+       * True if the instance is coming from / going to the server
+       * ```
+       * kpi = store.find('kpis', 5)
+       * // fetch started
+       * kpi.isInFlight
+       * => true
+       * // fetch finished
+       * kpi.isInFlight
+       * => false
+       * ```
+       * @property isInFlight
+       * @type {Boolean}
+       * @default false
+       */
+
+    }, {
+      key: "snapshot",
+      get: function get() {
+        return {
+          attributes: this.attributes,
+          relationships: toJS$$1(this.relationships)
+        };
+      }
+    }, {
+      key: "dirtyAttributes",
+      get: function get() {
+        var _this7 = this;
+
+        return flattenDeep_1(walk(this.previousSnapshot.attributes, function (prevValue, path) {
+          var currValue = get_1(_this7.snapshot.attributes, path);
+          return prevValue === currValue ? undefined : path;
+        })).filter(function (x) {
+          return x;
+        });
+      }
+    }, {
+      key: "type",
+      get: function get() {
+        return this.constructor.type;
+      }
+      /**
+       * current attributes of record
+       *
+       * @method attributes
+       * @return {Object} current attributes
+       */
+
+    }, {
+      key: "attributes",
+      get: function get() {
+        var _this8 = this;
+
+        return this.attributeNames.reduce(function (attributes, key) {
+          var value = toJS$$1(_this8[key]);
+
+          if (!value) {
+            delete attributes[key];
+          } else {
+            attributes[key] = value;
+          }
+
+          return attributes;
+        }, {});
+      }
+      /**
+       * Getter find the attribute definition for the model type.
+       *
+       * @method attributeDefinitions
+       * @return {Object}
+       */
+
+    }, {
+      key: "attributeDefinitions",
+      get: function get() {
+        var type = this.constructor.type;
+        return schema.structure[type];
+      }
+      /**
+       * Getter find the relationship definitions for the model type.
+       *
+       * @method relationshipDefinitions
+       * @return {Object}
+       */
+
+    }, {
+      key: "relationshipDefinitions",
+      get: function get() {
+        var type = this.constructor.type;
+        return schema.relations[type];
+      }
+      /**
+       * Getter to check if the record has errors.
+       *
+       * @method hasErrors
+       * @return {Boolean}
+       */
+
+    }, {
+      key: "hasErrors",
+      get: function get() {
+        return Object.keys(this.errors).length > 0;
+      }
+    }, {
+      key: "attributeNames",
+      get: function get() {
+        return Object.keys(this.attributeDefinitions);
+      }
+      /**
+       * getter method to get the default attributes
+       *
+       * @method defaultAttributes
+       * @return {Object}
+       */
+
+    }, {
+      key: "defaultAttributes",
+      get: function get() {
+        var attributeDefinitions = this.attributeDefinitions;
+        return this.attributeNames.reduce(function (defaults, key) {
+          var defaultValue = attributeDefinitions[key].defaultValue;
+          defaults[key] = defaultValue;
+          return defaults;
+        }, {
+          relationships: {}
+        });
+      }
+    }]);
+
+    return Model;
+  }(), _temp), (_applyDecoratedDescriptor(_class.prototype, "isDirty", [computed$$1], Object.getOwnPropertyDescriptor(_class.prototype, "isDirty"), _class.prototype), _descriptor = _applyDecoratedDescriptor(_class.prototype, "_isDirty", [observable$$1], {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    initializer: function initializer() {
+      return false;
+    }
+  }), _applyDecoratedDescriptor(_class.prototype, "isNew", [computed$$1], Object.getOwnPropertyDescriptor(_class.prototype, "isNew"), _class.prototype), _descriptor2 = _applyDecoratedDescriptor(_class.prototype, "errors", [observable$$1], {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    initializer: function initializer() {
+      return {};
+    }
+  })), _class);
 
   var _class$1, _descriptor$1, _descriptor2$1, _descriptor3, _temp$1;
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "caniuse-lite": "^1.0.30000998",
     "jquery-param": "^1.0.1",
     "jsonapi-serializer": "^3.6.4",
+    "lodash": "^4.17.15",
     "mobx": "5.5.0",
     "moment": "^2.24.0",
     "pluralize": "^8.0.0",

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -376,6 +376,24 @@ describe('Model', () => {
     })
   })
 
+  describe('.dirtyAttributes', () => {
+    it('returns a list of paths for attributes that have been mutated since the last snapshot', async () => {
+      const todo = new Organization({ title: 'Buy Milk' })
+      expect(todo.dirtyAttributes).toHaveLength(0)
+      todo.title = 'Buy Cheese'
+      expect(todo.dirtyAttributes).toHaveLength(1)
+      expect(todo.dirtyAttributes[0]).toEqual('title')
+    })
+
+    it('works on nested attributes', async () => {
+      const todo = new Organization({ title: 'Buy Milk', options: { variety: '2%' } })
+      expect(todo.dirtyAttributes).toHaveLength(0)
+      todo.options.variety = 'Skim'
+      expect(todo.dirtyAttributes).toHaveLength(1)
+      expect(todo.dirtyAttributes[0]).toEqual('options.variety')
+    })
+  })
+
   describe('.jsonapi', () => {
     it('returns data in valid jsonapi structure with coerced values', async () => {
       const todo = store.add('organizations', { id: 1, title: 'Buy Milk' })

--- a/src/Model.js
+++ b/src/Model.js
@@ -10,8 +10,12 @@ import {
 
 import moment from 'moment'
 
+import { walk } from './utils'
+
 import ObjectPromiseProxy from './ObjectPromiseProxy'
 import schema from './schema'
+import dig from 'lodash/get'
+import flattenDeep from 'lodash/flattenDeep'
 
 function isPresent (value) {
   return value !== null && value !== undefined && value !== ''
@@ -482,6 +486,28 @@ class Model {
    */
   setPreviousSnapshot () {
     this.previousSnapshot = this.snapshot
+  }
+
+  /**
+   * a list of any property paths which have been changed since the previous
+   * snapshot
+   * ```
+   * const todo = new Todo({ title: 'Buy Milk' })
+   * todo.dirtyAttributes
+   * => []
+   * todo.title = 'Buy Cheese'
+   * todo.dirtyAttributes
+   * => ['title']
+   * ```
+   * @method dirtyAttributes
+   * @return {Array} dirty attribute paths
+   */
+
+  get dirtyAttributes () {
+    return flattenDeep(walk(this.previousSnapshot.attributes, (prevValue, path) => {
+      const currValue = dig(this.snapshot.attributes, path)
+      return prevValue === currValue ? undefined : path
+    })).filter((x) => x)
   }
 
   /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -141,3 +141,12 @@ export function stringifyIds (object) {
     }
   })
 }
+
+export function walk (value, iteratee, prop, path) {
+  if (value != null && typeof value === 'object') {
+    return Object.keys(value).map((prop) => {
+      return walk(value[prop], iteratee, prop, [path, prop].filter(x => x).join('.'))
+    })
+  }
+  return iteratee(value, path)
+}


### PR DESCRIPTION
- [x] Defines a new method `dirtyAttributes` on `Model` which aggregate a list of attributes which have changed since the last snapshot. 
- [ ] Can we track these changes at write-time instead of aggregating them at read-time? Maybe via [mobx's `observe`](https://mobx.js.org/refguide/observe.html#observe).
- [ ] If we _can_ track this state at write-time, we should be able to derive `Model#isDirty` directly, rather than via a `reaction` where we serialize the current attributes. Consider replacing that code as well if the write-time approach is tenable. 