### PR TITLE
Ignore unexpected relations in JSON response

### DIFF
--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -13,7 +13,9 @@ import {
 
 import {
   exampleRelatedToManyResponse,
-  exampleRelatedToManyIncludedResponse
+  exampleRelatedToManyWithNoiseResponse,
+  exampleRelatedToManyIncludedResponse,
+  exampleRelatedToManyIncludedWithNoiseResponse
 } from './fixtures/exampleRelationalResponses'
 
 // YYYY-MM-DD
@@ -268,6 +270,23 @@ describe('Model', () => {
       expect(todo.title).toEqual('Do laundry')
       expect(todo.meeting_notes).toHaveLength(1)
       expect(todo.meeting_notes[0].description).toEqual('Use fabric softener')
+    })
+
+    it('ignores unexpected types in relationship data', async () => {
+      fetch.mockResponse(exampleRelatedToManyWithNoiseResponse)
+      const todo = await store.findOne('organizations', 1)
+
+      expect(todo.title).toEqual('Do laundry')
+      expect(todo.notes).toHaveLength(1)
+    })
+
+    it('ignores unexpected types in included data', async () => {
+      fetch.mockResponse(exampleRelatedToManyIncludedWithNoiseResponse)
+      const todo = await store.findOne('organizations', 1)
+
+      expect(todo.title).toEqual('Do laundry')
+      expect(todo.notes).toHaveLength(1)
+      expect(todo.notes[0].description).toEqual('Use fabric softener')
     })
   })
 

--- a/spec/fixtures/exampleRelationalResponses.js
+++ b/spec/fixtures/exampleRelationalResponses.js
@@ -22,6 +22,34 @@ export const exampleRelatedToManyResponse = JSON.stringify({
   }
 })
 
+export const exampleRelatedToManyWithNoiseResponse = JSON.stringify({
+  data: {
+    id: '1',
+    type: 'organizations',
+    attributes: {
+      id: 1,
+      title: 'Do laundry'
+    },
+    relationships: {
+      notes: {
+        data: [
+          {
+            type: 'notes',
+            id: '1'
+          },
+          {
+            type: 'unexpected_noise',
+            id: '1'
+          }
+        ]
+      }
+    }
+  },
+  jsonapi: {
+    version: '1.0'
+  }
+})
+
 export const exampleRelatedToManyIncludedResponse = JSON.stringify({
   data: {
     id: '1',
@@ -47,6 +75,50 @@ export const exampleRelatedToManyIncludedResponse = JSON.stringify({
       type: 'notes',
       attributes: {
         description: 'Use fabric softener'
+      }
+    }
+  ],
+  jsonapi: {
+    version: '1.0'
+  }
+})
+
+export const exampleRelatedToManyIncludedWithNoiseResponse = JSON.stringify({
+  data: {
+    id: '1',
+    type: 'organizations',
+    attributes: {
+      id: 1,
+      title: 'Do laundry'
+    },
+    relationships: {
+      notes: {
+        data: [
+          {
+            type: 'notes',
+            id: '1'
+          },
+          {
+            type: 'unexpected_noise',
+            id: '1'
+          }
+        ]
+      }
+    }
+  },
+  included: [
+    {
+      id: '1',
+      type: 'notes',
+      attributes: {
+        description: 'Use fabric softener'
+      }
+    },
+    {
+      id: '1',
+      type: 'unexpected_noise',
+      attributes: {
+        description: 'The store does not know about this type'
       }
     }
   ],

--- a/src/Store.js
+++ b/src/Store.js
@@ -564,7 +564,14 @@ class Store {
     let records = []
 
     transaction(() => {
-      records = data.forEach(dataObject => this.createOrUpdateModel(dataObject))
+      records = data.forEach(dataObject => {
+        // Only build objects for which we have a type defined.
+        // And ignore silently anything else included in the JSON response.
+        // TODO: Put some console message in development mode
+        if (this.getType(dataObject.type)) {
+          this.createOrUpdateModel(dataObject)
+        }
+      })
     })
 
     return records

--- a/src/decorators/relationships.js
+++ b/src/decorators/relationships.js
@@ -111,7 +111,8 @@ export function getRelatedRecords (record, property, modelType = null) {
   // NOTE: If the record doesn't have a matching references for the relation type
   // fall back to looking up records by a foreign id i.e record.related_record_id
   if (references && references.data) {
-    relatedRecords = references.data.map(ref => {
+    // Ignore any records of unknown types
+    relatedRecords = references.data.filter(ref => record.store.getType(ref.type)).map(ref => {
       const recordType = ref.type
       return record.store.getRecord(recordType, ref.id)
     })


### PR DESCRIPTION
Currently, if a JSON response includes a relationship to an unknown type, say "sub_stages", the Store throws an "Could not find a collection for type 'sub_stages'".

In order to make it easier to do changes in the backend without breaking existing clients, the Store should just ignore any types it does not recognize.

We leave the exception checking in the code because it's useful in other scenarios, but avoid calling `getRecord` when we know it will fail.