### PR TITLE
derive Model#isDirty from Model#dirtyAttributes

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -191,7 +191,7 @@ function ObjectPromiseProxy(promise, target) {
               status = response.status;
 
               if (!(status === 200 || status === 201)) {
-                _context.next = 14;
+                _context.next = 13;
                 break;
               }
 
@@ -219,10 +219,9 @@ function ObjectPromiseProxy(promise, target) {
                 if (json.included) {
                   target.store.createModelsFromData(json.included);
                 }
-              }); // Update target isInFlight and isDirty
+              }); // Update target isInFlight
 
               target.isInFlight = false;
-              target.isDirty = false;
               target.setPreviousSnapshot();
               mobx.transaction(function () {
                 // NOTE: This resolves an issue where a record is persisted but the
@@ -236,24 +235,24 @@ function ObjectPromiseProxy(promise, target) {
               });
               return _context.abrupt("return", target);
 
-            case 14:
+            case 13:
               target.isInFlight = false;
               message = target.store.genericErrorMessage;
-              _context.prev = 16;
-              _context.next = 19;
+              _context.prev = 15;
+              _context.next = 18;
               return response.json();
 
-            case 19:
+            case 18:
               _json = _context.sent;
               message = parseApiErrors(_json.errors, message);
-              _context.next = 25;
+              _context.next = 24;
               break;
 
-            case 23:
-              _context.prev = 23;
-              _context.t0 = _context["catch"](16);
+            case 22:
+              _context.prev = 22;
+              _context.t0 = _context["catch"](15);
 
-            case 25:
+            case 24:
               // TODO: add all errors from the API response to the target
               target.errors = _objectSpread({}, target.errors, {
                 status: status,
@@ -264,12 +263,12 @@ function ObjectPromiseProxy(promise, target) {
               errorString = JSON.stringify(target.errors);
               return _context.abrupt("return", Promise.reject(new Error(errorString)));
 
-            case 28:
+            case 27:
             case "end":
               return _context.stop();
           }
         }
-      }, _callee, null, [[16, 23]]);
+      }, _callee, null, [[15, 22]]);
     }));
 
     return function (_x) {
@@ -358,7 +357,7 @@ function () {
 
 var schema = new Schema();
 
-var _class, _descriptor, _descriptor2, _temp;
+var _class, _descriptor, _temp;
 
 function ownKeys$1(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
@@ -418,19 +417,15 @@ function () {
 
     _classCallCheck(this, Model);
 
-    _initializerDefineProperty(this, "_isDirty", _descriptor, this);
-
     this.isInFlight = false;
 
-    _initializerDefineProperty(this, "errors", _descriptor2, this);
+    _initializerDefineProperty(this, "errors", _descriptor, this);
 
     this.previousSnapshot = {};
 
     this._makeObservable(initialAttributes);
 
     this.setPreviousSnapshot();
-
-    this._trackState();
   }
   /**
    * The type of the model. Defined on the class. Defaults to the underscored version of the class name
@@ -740,37 +735,6 @@ function () {
      */
 
   }, {
-    key: "_trackState",
-
-    /**
-     * Uses mobx.autorun to track changes to attributes
-     *
-     * @method _trackState
-     */
-    value: function _trackState() {
-      var _this4 = this;
-
-      mobx.reaction(function () {
-        return JSON.stringify(_this4.attributes);
-      }, function (objectString) {
-        // console.log(objectString)
-        _this4.isDirty = true;
-      });
-      mobx.reaction(function () {
-        return JSON.stringify(_this4.relationships);
-      }, function (relString) {
-        // console.log(relString)
-        _this4.isDirty = true;
-      });
-    }
-    /**
-     * shortcut to get the static
-     *
-     * @method type
-     * @return {String} current attributes
-    */
-
-  }, {
     key: "errorForKey",
 
     /**
@@ -800,7 +764,7 @@ function () {
      * @return {Object} data in JSON::API format
      */
     value: function jsonapi() {
-      var _this5 = this;
+      var _this4 = this;
 
       var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
       var attributeDefinitions = this.attributeDefinitions,
@@ -818,7 +782,7 @@ function () {
       }
 
       var attributes = filteredAttributeNames.reduce(function (attrs, key) {
-        var value = _this5[key];
+        var value = _this4[key];
 
         if (value) {
           var DataType = attributeDefinitions[key].dataType;
@@ -850,7 +814,7 @@ function () {
           return options.relationships.includes(name);
         });
         var relationships = filteredRelationshipNames.reduce(function (rels, key) {
-          rels[key] = mobx.toJS(_this5.relationships[key]);
+          rels[key] = mobx.toJS(_this4.relationships[key]);
           stringifyIds(rels[key]);
           return rels;
         }, {});
@@ -872,41 +836,27 @@ function () {
   }, {
     key: "updateAttributes",
     value: function updateAttributes(attributes) {
-      var _this6 = this;
+      var _this5 = this;
 
       mobx.transaction(function () {
         Object.keys(attributes).forEach(function (key) {
-          _this6[key] = attributes[key];
+          _this5[key] = attributes[key];
         });
       });
     }
   }, {
     key: "isDirty",
     get: function get() {
-      var isNew = this.isNew,
-          _isDirty = this._isDirty;
-      return _isDirty || isNew;
-    },
-    set: function set(value) {
-      this._isDirty = value;
+      return this.dirtyAttributes.length > 0;
     }
-    /**
-     * Private method. True if the model has been programatically changed,
-     * as opposed to just being new.
-     * @property _isDirty
-     * @type {Boolean}
-     * @default false
-     * @private
-     */
-
-  }, {
-    key: "isNew",
-
     /**
      * True if the model has not been sent to the store
      * @property isNew
      * @type {Boolean}
      */
+
+  }, {
+    key: "isNew",
     get: function get() {
       var id = this.id;
       return !!String(id).match(/tmp/);
@@ -938,15 +888,22 @@ function () {
   }, {
     key: "dirtyAttributes",
     get: function get() {
-      var _this7 = this;
+      var _this6 = this;
 
       return flattenDeep(walk(this.previousSnapshot.attributes, function (prevValue, path) {
-        var currValue = dig(_this7.snapshot.attributes, path);
+        var currValue = dig(_this6.snapshot.attributes, path);
         return prevValue === currValue ? undefined : path;
       })).filter(function (x) {
         return x;
       });
     }
+    /**
+     * shortcut to get the static
+     *
+     * @method type
+     * @return {String} current attributes
+    */
+
   }, {
     key: "type",
     get: function get() {
@@ -962,10 +919,10 @@ function () {
   }, {
     key: "attributes",
     get: function get() {
-      var _this8 = this;
+      var _this7 = this;
 
       return this.attributeNames.reduce(function (attributes, key) {
-        var value = mobx.toJS(_this8[key]);
+        var value = mobx.toJS(_this7[key]);
 
         if (!value) {
           delete attributes[key];
@@ -1041,14 +998,7 @@ function () {
   }]);
 
   return Model;
-}(), _temp), (_applyDecoratedDescriptor(_class.prototype, "isDirty", [mobx.computed], Object.getOwnPropertyDescriptor(_class.prototype, "isDirty"), _class.prototype), _descriptor = _applyDecoratedDescriptor(_class.prototype, "_isDirty", [mobx.observable], {
-  configurable: true,
-  enumerable: true,
-  writable: true,
-  initializer: function initializer() {
-    return false;
-  }
-}), _applyDecoratedDescriptor(_class.prototype, "isNew", [mobx.computed], Object.getOwnPropertyDescriptor(_class.prototype, "isNew"), _class.prototype), _descriptor2 = _applyDecoratedDescriptor(_class.prototype, "errors", [mobx.observable], {
+}(), _temp), (_applyDecoratedDescriptor(_class.prototype, "isNew", [mobx.computed], Object.getOwnPropertyDescriptor(_class.prototype, "isNew"), _class.prototype), _descriptor = _applyDecoratedDescriptor(_class.prototype, "errors", [mobx.observable], {
   configurable: true,
   enumerable: true,
   writable: true,
@@ -1057,7 +1007,7 @@ function () {
   }
 })), _class);
 
-var _class$1, _descriptor$1, _descriptor2$1, _descriptor3, _temp$1;
+var _class$1, _descriptor$1, _descriptor2, _descriptor3, _temp$1;
 
 function ownKeys$2(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
@@ -1103,7 +1053,7 @@ function () {
       }
     };
 
-    _initializerDefineProperty(this, "addModel", _descriptor2$1, this);
+    _initializerDefineProperty(this, "addModel", _descriptor2, this);
 
     this.addModels = function (type, data) {
       var records = [];
@@ -1802,7 +1752,7 @@ function () {
   initializer: function initializer() {
     return {};
   }
-}), _descriptor2$1 = _applyDecoratedDescriptor(_class$1.prototype, "addModel", [mobx.action], {
+}), _descriptor2 = _applyDecoratedDescriptor(_class$1.prototype, "addModel", [mobx.action], {
   configurable: true,
   enumerable: true,
   writable: true,
@@ -2232,7 +2182,6 @@ function (_Array) {
         setRelatedRecord(relatedRecord, record, recordType.slice(0, recordType.length - 1));
       }
 
-      record.isDirty = true;
       return relatedRecord;
     };
 
@@ -2270,7 +2219,6 @@ function (_Array) {
         setRelatedRecord(relatedRecord, null, recordType.slice(0, recordType.length - 1));
       }
 
-      record.isDirty = true;
       return relatedRecord;
     };
 
@@ -2288,7 +2236,6 @@ function (_Array) {
           return _this.add(object);
         });
       });
-      record.isDirty = true;
     };
 
     _this.property = _property;

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -1,15 +1,15 @@
+import _toConsumableArray from '@babel/runtime/helpers/toConsumableArray';
 import _defineProperty from '@babel/runtime/helpers/defineProperty';
 import _regeneratorRuntime from '@babel/runtime/regenerator';
 import _asyncToGenerator from '@babel/runtime/helpers/asyncToGenerator';
 import _initializerDefineProperty from '@babel/runtime/helpers/initializerDefineProperty';
 import _classCallCheck from '@babel/runtime/helpers/classCallCheck';
 import _createClass from '@babel/runtime/helpers/createClass';
-import '@babel/runtime/helpers/initializerWarningHelper';
 import _applyDecoratedDescriptor from '@babel/runtime/helpers/applyDecoratedDescriptor';
+import '@babel/runtime/helpers/initializerWarningHelper';
 import _typeof from '@babel/runtime/helpers/typeof';
-import { transaction, set, computed, observable, extendObservable, toJS, action } from 'mobx';
+import { transaction, set, observable, computed, extendObservable, toJS, action } from 'mobx';
 import moment from 'moment';
-import _toConsumableArray from '@babel/runtime/helpers/toConsumableArray';
 import uuidv1 from 'uuid/v1';
 import jqueryParam from 'jquery-param';
 import pluralize from 'pluralize';
@@ -351,7 +351,7 @@ function () {
 
 var schema = new Schema();
 
-var _class, _descriptor, _temp;
+var _class, _descriptor, _descriptor2, _temp;
 
 function ownKeys$1(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
@@ -411,9 +411,11 @@ function () {
 
     _classCallCheck(this, Model);
 
+    _initializerDefineProperty(this, "_dirtyRelationships", _descriptor, this);
+
     this.isInFlight = false;
 
-    _initializerDefineProperty(this, "errors", _descriptor, this);
+    _initializerDefineProperty(this, "errors", _descriptor2, this);
 
     this.previousSnapshot = {};
 
@@ -434,29 +436,6 @@ function () {
    * Defaults to the underscored version of the class name
    * @property endpoint
    * @static
-   */
-
-  /**
-   * True if the instance has been modified from its persisted state
-   * ```
-   * kpi = store.add('kpis', { name: 'A good thing to measure' })
-   * kpi.isDirty
-   * => true
-   * kpi.name
-   * => "A good thing to measure"
-   * await kpi.save()
-   * kpi.isDirty
-   * => false
-   * kpi.name = "Another good thing to measure"
-   * kpi.isDirty
-   * => true
-   * await kpi.save()
-   * kpi.isDirty
-   * => false
-   * ```
-   * @property isDirty
-   * @type {Boolean}
-   * @default false
    */
 
 
@@ -711,6 +690,7 @@ function () {
      * @method setPreviousSnapshot
      */
     value: function setPreviousSnapshot() {
+      this._dirtyRelationships = new Set();
       this.previousSnapshot = this.snapshot;
     }
     /**
@@ -840,6 +820,39 @@ function () {
     }
   }, {
     key: "isDirty",
+
+    /**
+     * True if the instance has been modified from its persisted state
+     *
+     * NOTE that isDirty does _NOT_ track changes to the related objects
+     * but it _does_ track changes to the relationships themselves.
+     *
+     * For example, adding or removing a related object will mark this record as dirty,
+     * but changing a related object's properties will not mark this record as dirty.
+     *
+     * The caller is reponsible for asking related objects about their
+     * own dirty state.
+     *
+     * ```
+     * kpi = store.add('kpis', { name: 'A good thing to measure' })
+     * kpi.isDirty
+     * => true
+     * kpi.name
+     * => "A good thing to measure"
+     * await kpi.save()
+     * kpi.isDirty
+     * => false
+     * kpi.name = "Another good thing to measure"
+     * kpi.isDirty
+     * => true
+     * await kpi.save()
+     * kpi.isDirty
+     * => false
+     * ```
+     * @property isDirty
+     * @type {Boolean}
+     * @default false
+     */
     get: function get() {
       return this.dirtyAttributes.length > 0;
     }
@@ -884,12 +897,16 @@ function () {
     get: function get() {
       var _this6 = this;
 
-      return flattenDeep(walk(this.previousSnapshot.attributes, function (prevValue, path) {
+      var relationships = Array.from(this._dirtyRelationships).map(function (property) {
+        return "relationships.".concat(property);
+      });
+      var attributes = flattenDeep(walk(this.previousSnapshot.attributes, function (prevValue, path) {
         var currValue = dig(_this6.snapshot.attributes, path);
         return prevValue === currValue ? undefined : path;
       })).filter(function (x) {
         return x;
       });
+      return [].concat(_toConsumableArray(relationships), _toConsumableArray(attributes));
     }
     /**
      * shortcut to get the static
@@ -992,7 +1009,14 @@ function () {
   }]);
 
   return Model;
-}(), _temp), (_applyDecoratedDescriptor(_class.prototype, "isNew", [computed], Object.getOwnPropertyDescriptor(_class.prototype, "isNew"), _class.prototype), _descriptor = _applyDecoratedDescriptor(_class.prototype, "errors", [observable], {
+}(), _temp), (_descriptor = _applyDecoratedDescriptor(_class.prototype, "_dirtyRelationships", [observable], {
+  configurable: true,
+  enumerable: true,
+  writable: true,
+  initializer: function initializer() {
+    return new Set();
+  }
+}), _applyDecoratedDescriptor(_class.prototype, "isNew", [computed], Object.getOwnPropertyDescriptor(_class.prototype, "isNew"), _class.prototype), _descriptor2 = _applyDecoratedDescriptor(_class.prototype, "errors", [observable], {
   configurable: true,
   enumerable: true,
   writable: true,
@@ -1001,7 +1025,7 @@ function () {
   }
 })), _class);
 
-var _class$1, _descriptor$1, _descriptor2, _descriptor3, _temp$1;
+var _class$1, _descriptor$1, _descriptor2$1, _descriptor3, _temp$1;
 
 function ownKeys$2(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
@@ -1047,7 +1071,7 @@ function () {
       }
     };
 
-    _initializerDefineProperty(this, "addModel", _descriptor2, this);
+    _initializerDefineProperty(this, "addModel", _descriptor2$1, this);
 
     this.addModels = function (type, data) {
       var records = [];
@@ -1746,7 +1770,7 @@ function () {
   initializer: function initializer() {
     return {};
   }
-}), _descriptor2 = _applyDecoratedDescriptor(_class$1.prototype, "addModel", [action], {
+}), _descriptor2$1 = _applyDecoratedDescriptor(_class$1.prototype, "addModel", [action], {
   configurable: true,
   enumerable: true,
   writable: true,
@@ -2170,7 +2194,9 @@ function (_Array) {
           type: type
         });
 
-        _this.push(relatedRecord); // setting the inverse - hack this will only work with singularized relationships.
+        _this.push(relatedRecord);
+
+        record._dirtyRelationships.add(property); // setting the inverse - hack this will only work with singularized relationships.
 
 
         setRelatedRecord(relatedRecord, record, recordType.slice(0, recordType.length - 1));
@@ -2207,7 +2233,9 @@ function (_Array) {
 
         if (!Object.keys(record.relationships).length) {
           delete record.relationships;
-        } // hack this will only work with singularized relationships.
+        }
+
+        record._dirtyRelationships.add(property); // hack this will only work with singularized relationships.
 
 
         setRelatedRecord(relatedRecord, null, recordType.slice(0, recordType.length - 1));
@@ -2229,6 +2257,8 @@ function (_Array) {
         array.forEach(function (object) {
           return _this.add(object);
         });
+
+        record._dirtyRelationships.add(property);
       });
     };
 

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -7,7 +7,7 @@ import _createClass from '@babel/runtime/helpers/createClass';
 import '@babel/runtime/helpers/initializerWarningHelper';
 import _applyDecoratedDescriptor from '@babel/runtime/helpers/applyDecoratedDescriptor';
 import _typeof from '@babel/runtime/helpers/typeof';
-import { transaction, set, computed, observable, extendObservable, reaction, toJS, action } from 'mobx';
+import { transaction, set, computed, observable, extendObservable, toJS, action } from 'mobx';
 import moment from 'moment';
 import _toConsumableArray from '@babel/runtime/helpers/toConsumableArray';
 import uuidv1 from 'uuid/v1';
@@ -185,7 +185,7 @@ function ObjectPromiseProxy(promise, target) {
               status = response.status;
 
               if (!(status === 200 || status === 201)) {
-                _context.next = 14;
+                _context.next = 13;
                 break;
               }
 
@@ -213,10 +213,9 @@ function ObjectPromiseProxy(promise, target) {
                 if (json.included) {
                   target.store.createModelsFromData(json.included);
                 }
-              }); // Update target isInFlight and isDirty
+              }); // Update target isInFlight
 
               target.isInFlight = false;
-              target.isDirty = false;
               target.setPreviousSnapshot();
               transaction(function () {
                 // NOTE: This resolves an issue where a record is persisted but the
@@ -230,24 +229,24 @@ function ObjectPromiseProxy(promise, target) {
               });
               return _context.abrupt("return", target);
 
-            case 14:
+            case 13:
               target.isInFlight = false;
               message = target.store.genericErrorMessage;
-              _context.prev = 16;
-              _context.next = 19;
+              _context.prev = 15;
+              _context.next = 18;
               return response.json();
 
-            case 19:
+            case 18:
               _json = _context.sent;
               message = parseApiErrors(_json.errors, message);
-              _context.next = 25;
+              _context.next = 24;
               break;
 
-            case 23:
-              _context.prev = 23;
-              _context.t0 = _context["catch"](16);
+            case 22:
+              _context.prev = 22;
+              _context.t0 = _context["catch"](15);
 
-            case 25:
+            case 24:
               // TODO: add all errors from the API response to the target
               target.errors = _objectSpread({}, target.errors, {
                 status: status,
@@ -258,12 +257,12 @@ function ObjectPromiseProxy(promise, target) {
               errorString = JSON.stringify(target.errors);
               return _context.abrupt("return", Promise.reject(new Error(errorString)));
 
-            case 28:
+            case 27:
             case "end":
               return _context.stop();
           }
         }
-      }, _callee, null, [[16, 23]]);
+      }, _callee, null, [[15, 22]]);
     }));
 
     return function (_x) {
@@ -352,7 +351,7 @@ function () {
 
 var schema = new Schema();
 
-var _class, _descriptor, _descriptor2, _temp;
+var _class, _descriptor, _temp;
 
 function ownKeys$1(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
@@ -412,19 +411,15 @@ function () {
 
     _classCallCheck(this, Model);
 
-    _initializerDefineProperty(this, "_isDirty", _descriptor, this);
-
     this.isInFlight = false;
 
-    _initializerDefineProperty(this, "errors", _descriptor2, this);
+    _initializerDefineProperty(this, "errors", _descriptor, this);
 
     this.previousSnapshot = {};
 
     this._makeObservable(initialAttributes);
 
     this.setPreviousSnapshot();
-
-    this._trackState();
   }
   /**
    * The type of the model. Defined on the class. Defaults to the underscored version of the class name
@@ -734,37 +729,6 @@ function () {
      */
 
   }, {
-    key: "_trackState",
-
-    /**
-     * Uses mobx.autorun to track changes to attributes
-     *
-     * @method _trackState
-     */
-    value: function _trackState() {
-      var _this4 = this;
-
-      reaction(function () {
-        return JSON.stringify(_this4.attributes);
-      }, function (objectString) {
-        // console.log(objectString)
-        _this4.isDirty = true;
-      });
-      reaction(function () {
-        return JSON.stringify(_this4.relationships);
-      }, function (relString) {
-        // console.log(relString)
-        _this4.isDirty = true;
-      });
-    }
-    /**
-     * shortcut to get the static
-     *
-     * @method type
-     * @return {String} current attributes
-    */
-
-  }, {
     key: "errorForKey",
 
     /**
@@ -794,7 +758,7 @@ function () {
      * @return {Object} data in JSON::API format
      */
     value: function jsonapi() {
-      var _this5 = this;
+      var _this4 = this;
 
       var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
       var attributeDefinitions = this.attributeDefinitions,
@@ -812,7 +776,7 @@ function () {
       }
 
       var attributes = filteredAttributeNames.reduce(function (attrs, key) {
-        var value = _this5[key];
+        var value = _this4[key];
 
         if (value) {
           var DataType = attributeDefinitions[key].dataType;
@@ -844,7 +808,7 @@ function () {
           return options.relationships.includes(name);
         });
         var relationships = filteredRelationshipNames.reduce(function (rels, key) {
-          rels[key] = toJS(_this5.relationships[key]);
+          rels[key] = toJS(_this4.relationships[key]);
           stringifyIds(rels[key]);
           return rels;
         }, {});
@@ -866,41 +830,27 @@ function () {
   }, {
     key: "updateAttributes",
     value: function updateAttributes(attributes) {
-      var _this6 = this;
+      var _this5 = this;
 
       transaction(function () {
         Object.keys(attributes).forEach(function (key) {
-          _this6[key] = attributes[key];
+          _this5[key] = attributes[key];
         });
       });
     }
   }, {
     key: "isDirty",
     get: function get() {
-      var isNew = this.isNew,
-          _isDirty = this._isDirty;
-      return _isDirty || isNew;
-    },
-    set: function set(value) {
-      this._isDirty = value;
+      return this.dirtyAttributes.length > 0;
     }
-    /**
-     * Private method. True if the model has been programatically changed,
-     * as opposed to just being new.
-     * @property _isDirty
-     * @type {Boolean}
-     * @default false
-     * @private
-     */
-
-  }, {
-    key: "isNew",
-
     /**
      * True if the model has not been sent to the store
      * @property isNew
      * @type {Boolean}
      */
+
+  }, {
+    key: "isNew",
     get: function get() {
       var id = this.id;
       return !!String(id).match(/tmp/);
@@ -932,15 +882,22 @@ function () {
   }, {
     key: "dirtyAttributes",
     get: function get() {
-      var _this7 = this;
+      var _this6 = this;
 
       return flattenDeep(walk(this.previousSnapshot.attributes, function (prevValue, path) {
-        var currValue = dig(_this7.snapshot.attributes, path);
+        var currValue = dig(_this6.snapshot.attributes, path);
         return prevValue === currValue ? undefined : path;
       })).filter(function (x) {
         return x;
       });
     }
+    /**
+     * shortcut to get the static
+     *
+     * @method type
+     * @return {String} current attributes
+    */
+
   }, {
     key: "type",
     get: function get() {
@@ -956,10 +913,10 @@ function () {
   }, {
     key: "attributes",
     get: function get() {
-      var _this8 = this;
+      var _this7 = this;
 
       return this.attributeNames.reduce(function (attributes, key) {
-        var value = toJS(_this8[key]);
+        var value = toJS(_this7[key]);
 
         if (!value) {
           delete attributes[key];
@@ -1035,14 +992,7 @@ function () {
   }]);
 
   return Model;
-}(), _temp), (_applyDecoratedDescriptor(_class.prototype, "isDirty", [computed], Object.getOwnPropertyDescriptor(_class.prototype, "isDirty"), _class.prototype), _descriptor = _applyDecoratedDescriptor(_class.prototype, "_isDirty", [observable], {
-  configurable: true,
-  enumerable: true,
-  writable: true,
-  initializer: function initializer() {
-    return false;
-  }
-}), _applyDecoratedDescriptor(_class.prototype, "isNew", [computed], Object.getOwnPropertyDescriptor(_class.prototype, "isNew"), _class.prototype), _descriptor2 = _applyDecoratedDescriptor(_class.prototype, "errors", [observable], {
+}(), _temp), (_applyDecoratedDescriptor(_class.prototype, "isNew", [computed], Object.getOwnPropertyDescriptor(_class.prototype, "isNew"), _class.prototype), _descriptor = _applyDecoratedDescriptor(_class.prototype, "errors", [observable], {
   configurable: true,
   enumerable: true,
   writable: true,
@@ -1051,7 +1001,7 @@ function () {
   }
 })), _class);
 
-var _class$1, _descriptor$1, _descriptor2$1, _descriptor3, _temp$1;
+var _class$1, _descriptor$1, _descriptor2, _descriptor3, _temp$1;
 
 function ownKeys$2(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
@@ -1097,7 +1047,7 @@ function () {
       }
     };
 
-    _initializerDefineProperty(this, "addModel", _descriptor2$1, this);
+    _initializerDefineProperty(this, "addModel", _descriptor2, this);
 
     this.addModels = function (type, data) {
       var records = [];
@@ -1796,7 +1746,7 @@ function () {
   initializer: function initializer() {
     return {};
   }
-}), _descriptor2$1 = _applyDecoratedDescriptor(_class$1.prototype, "addModel", [action], {
+}), _descriptor2 = _applyDecoratedDescriptor(_class$1.prototype, "addModel", [action], {
   configurable: true,
   enumerable: true,
   writable: true,
@@ -2226,7 +2176,6 @@ function (_Array) {
         setRelatedRecord(relatedRecord, record, recordType.slice(0, recordType.length - 1));
       }
 
-      record.isDirty = true;
       return relatedRecord;
     };
 
@@ -2264,7 +2213,6 @@ function (_Array) {
         setRelatedRecord(relatedRecord, null, recordType.slice(0, recordType.length - 1));
       }
 
-      record.isDirty = true;
       return relatedRecord;
     };
 
@@ -2282,7 +2230,6 @@ function (_Array) {
           return _this.add(object);
         });
       });
-      record.isDirty = true;
     };
 
     _this.property = _property;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-async-store",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -463,13 +463,21 @@ describe('Model', () => {
   describe('.isDirty', () => {
     it('is initially false', async () => {
       const todo = new Organization({ title: 'Buy Milk' })
-      expect(todo.isDirty).toBeFalsy()
+      expect(todo.isDirty).toBe(false)
     })
 
     it('is set to true if record changes', async () => {
       const todo = new Organization({ title: 'Buy Milk' })
       todo.title = 'Do the laundry'
       expect(todo.isDirty).toBe(true)
+    })
+
+    it('is set back to false if changed back to original value', async () => {
+      const todo = new Organization({ title: 'Buy Milk' })
+      todo.title = 'Do the laundry'
+      expect(todo.isDirty).toBe(true)
+      todo.title = 'Buy Milk'
+      expect(todo.isDirty).toBe(false)
     })
   })
 

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -411,6 +411,59 @@ describe('Model', () => {
       expect(todo.dirtyAttributes).toHaveLength(1)
       expect(todo.dirtyAttributes[0]).toEqual('options.variety')
     })
+
+    it('tracks removed to relationships', async () => {
+      const todo = store.add('organizations', { id: 11, title: 'Buy Milk' })
+      const note = store.add('notes', {
+        id: 11,
+        description: 'Example description'
+      })
+
+      todo.notes.add(note)
+      todo.setPreviousSnapshot()
+      expect(todo.dirtyAttributes).toEqual([])
+      todo.notes.remove(note)
+      expect(todo.dirtyAttributes).toEqual(['relationships.notes'])
+    })
+
+    it('tracks added relationship', async () => {
+      const todo = store.add('organizations', { id: 11, title: 'Buy Milk' })
+      const note = store.add('notes', {
+        id: 11,
+        description: 'Example description'
+      })
+
+      expect(todo.dirtyAttributes).toEqual([])
+      todo.notes.add(note)
+      expect(todo.dirtyAttributes).toEqual(['relationships.notes'])
+    })
+
+    it('does NOT revert to empty after adding and then removing a relationship', async () => {
+      const todo = store.add('organizations', { id: 11, title: 'Buy Milk' })
+      const note = store.add('notes', {
+        id: 11,
+        description: 'Example description'
+      })
+
+      expect(todo.dirtyAttributes).toEqual([])
+      todo.notes.add(note)
+      expect(todo.dirtyAttributes).toEqual(['relationships.notes'])
+      todo.notes.remove(note)
+      expect(todo.dirtyAttributes).toEqual(['relationships.notes'])
+    })
+
+    it('does NOT track changes to the related objects themselves', async () => {
+      const todo = store.add('organizations', { id: 11, title: 'Buy Milk' })
+      const note = store.add('notes', {
+        id: 11,
+        description: 'Example description'
+      })
+
+      todo.notes.add(note)
+      todo.setPreviousSnapshot()
+      note.description = 'something different'
+      expect(todo.dirtyAttributes).toEqual([])
+    })
   })
 
   describe('.jsonapi', () => {
@@ -478,6 +531,18 @@ describe('Model', () => {
       expect(todo.isDirty).toBe(true)
       todo.title = 'Buy Milk'
       expect(todo.isDirty).toBe(false)
+    })
+
+    it('is set to true if a relationship is added', async () => {
+      const todo = store.add('organizations', { id: 11, title: 'Buy Milk' })
+      const note = store.add('notes', {
+        id: 11,
+        description: 'Example description'
+      })
+
+      expect(todo.isDirty).toBe(false)
+      todo.notes.add(note)
+      expect(todo.isDirty).toBe(true)
     })
   })
 

--- a/src/Model.js
+++ b/src/Model.js
@@ -194,8 +194,20 @@ class Model {
    * @static
    */
 
+   @observable _dirtyRelationships = new Set()
+
   /**
    * True if the instance has been modified from its persisted state
+   *
+   * NOTE that isDirty does _NOT_ track changes to the related objects
+   * but it _does_ track changes to the relationships themselves.
+   *
+   * For example, adding or removing a related object will mark this record as dirty,
+   * but changing a related object's properties will not mark this record as dirty.
+   *
+   * The caller is reponsible for asking related objects about their
+   * own dirty state.
+   *
    * ```
    * kpi = store.add('kpis', { name: 'A good thing to measure' })
    * kpi.isDirty
@@ -468,6 +480,7 @@ class Model {
    * @method setPreviousSnapshot
    */
   setPreviousSnapshot () {
+    this._dirtyRelationships = new Set()
     this.previousSnapshot = this.snapshot
   }
 
@@ -487,10 +500,12 @@ class Model {
    */
 
   get dirtyAttributes () {
-    return flattenDeep(walk(this.previousSnapshot.attributes, (prevValue, path) => {
+    const relationships = Array.from(this._dirtyRelationships).map((property) => `relationships.${property}`)
+    const attributes = flattenDeep(walk(this.previousSnapshot.attributes, (prevValue, path) => {
       const currValue = dig(this.snapshot.attributes, path)
       return prevValue === currValue ? undefined : path
     })).filter((x) => x)
+    return [...relationships, ...attributes]
   }
 
   /**

--- a/src/Model.js
+++ b/src/Model.js
@@ -1,5 +1,4 @@
 import {
-  reaction,
   computed,
   extendObservable,
   set,
@@ -178,7 +177,6 @@ class Model {
   constructor (initialAttributes = {}) {
     this._makeObservable(initialAttributes)
     this.setPreviousSnapshot()
-    this._trackState()
   }
 
   /**
@@ -218,24 +216,9 @@ class Model {
    * @type {Boolean}
    * @default false
    */
-  @computed get isDirty () {
-    const { isNew, _isDirty } = this
-    return _isDirty || isNew
+  get isDirty () {
+    return this.dirtyAttributes.length > 0
   }
-  set isDirty (value) {
-    this._isDirty = value
-  }
-
-  /**
-   * Private method. True if the model has been programatically changed,
-   * as opposed to just being new.
-   * @property _isDirty
-   * @type {Boolean}
-   * @default false
-   * @private
-   */
-
-  @observable _isDirty = false
 
   /**
    * True if the model has not been sent to the store
@@ -508,29 +491,6 @@ class Model {
       const currValue = dig(this.snapshot.attributes, path)
       return prevValue === currValue ? undefined : path
     })).filter((x) => x)
-  }
-
-  /**
-   * Uses mobx.autorun to track changes to attributes
-   *
-   * @method _trackState
-   */
-  _trackState () {
-    reaction(
-      () => JSON.stringify(this.attributes),
-      objectString => {
-        // console.log(objectString)
-        this.isDirty = true
-      }
-    )
-
-    reaction(
-      () => JSON.stringify(this.relationships),
-      relString => {
-        // console.log(relString)
-        this.isDirty = true
-      }
-    )
   }
 
   /**

--- a/src/ObjectPromiseProxy.js
+++ b/src/ObjectPromiseProxy.js
@@ -26,9 +26,8 @@ function ObjectPromiseProxy (promise, target) {
             target.store.createModelsFromData(json.included)
           }
         })
-        // Update target isInFlight and isDirty
+        // Update target isInFlight
         target.isInFlight = false
-        target.isDirty = false
         target.setPreviousSnapshot()
         transaction(() => {
           // NOTE: This resolves an issue where a record is persisted but the

--- a/src/decorators/relationships.js
+++ b/src/decorators/relationships.js
@@ -267,8 +267,6 @@ export class RelatedRecordsArray extends Array {
       setRelatedRecord(relatedRecord, record, recordType.slice(0, recordType.length - 1))
     }
 
-    record.isDirty = true
-
     return relatedRecord
   }
 
@@ -302,8 +300,6 @@ export class RelatedRecordsArray extends Array {
       setRelatedRecord(relatedRecord, null, recordType.slice(0, recordType.length - 1))
     }
 
-    record.isDirty = true
-
     return relatedRecord
   }
 
@@ -315,7 +311,5 @@ export class RelatedRecordsArray extends Array {
       relationships[property] = { data: [] }
       array.forEach(object => this.add(object))
     })
-
-    record.isDirty = true
   }
 }

--- a/src/decorators/relationships.js
+++ b/src/decorators/relationships.js
@@ -263,6 +263,7 @@ export class RelatedRecordsArray extends Array {
     if (!alreadyThere) {
       relationships[property].data.push({ id, type })
       this.push(relatedRecord)
+      record._dirtyRelationships.add(property)
       // setting the inverse - hack this will only work with singularized relationships.
       setRelatedRecord(relatedRecord, record, recordType.slice(0, recordType.length - 1))
     }
@@ -296,6 +297,8 @@ export class RelatedRecordsArray extends Array {
         delete record.relationships
       }
 
+      record._dirtyRelationships.add(property)
+
       // hack this will only work with singularized relationships.
       setRelatedRecord(relatedRecord, null, recordType.slice(0, recordType.length - 1))
     }
@@ -310,6 +313,7 @@ export class RelatedRecordsArray extends Array {
     transaction(() => {
       relationships[property] = { data: [] }
       array.forEach(object => this.add(object))
+      record._dirtyRelationships.add(property)
     })
   }
 }


### PR DESCRIPTION
- [x] derive Model#isDirty from Model#dirtyAttributes
- [x] determine a strategy for `relationships`: We have chosen option (ii) below
  1. ~Do we _need_ `isDirty` to be `true` is _any_ change is made on a relationship? What does that mean for long-living objects that are related to many others? Should those objects be dirty if any related object is dirty?~
  2. Can we put the burden of checking for dirty relationships on the caller? So as to avoid potentially walking the entire object graph every time a caller asks for dirty state.
- [x] track changes to relationships, but _not_ to the related objects themselves.
  * We can do this at write time since we have access to the methods that make these mutations. We do this by introducing a new `Model#_dirtyRelationships` Set which keeps a set of paths that have changed since the last snapshot.

- [x] ~Try to make relationship changes "revertable" so that if a change is made which makes the record "dirty" you should be able to undo that change and the record should not longer be dirty.~ I have given up on this for the meantime. This gets tricky fast, and I unfortunately don't have time to really engage with it.

I would still like to refactor the `Model#dirtyAttributes` implementation to track state at write time, but in the meantime, at least saves us _some_ work by removing the need for the reactions.