### PR TITLE
guard against removing extra related records

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -2232,13 +2232,13 @@ function (_Array) {
         var referenceIndexToRemove = relationships[property].data.findIndex(function (model) {
           return model.id === id && model.type === type;
         });
-        relationships[property].data.splice(referenceIndexToRemove, 1);
+        if (referenceIndexToRemove >= 0) relationships[property].data.splice(referenceIndexToRemove, 1);
 
         var recordIndexToRemove = _this.findIndex(function (model) {
           return model.id === id && model.type === type;
         });
 
-        if (recordIndexToRemove > 0) _this.splice(recordIndexToRemove, 1);
+        if (recordIndexToRemove >= 0) _this.splice(recordIndexToRemove, 1);
 
         if (!relationships[property].data.length) {
           delete relationships[property];

--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -2230,12 +2230,12 @@ function (_Array) {
 
       if (relationships && relationships[property] && relatedRecord) {
         var referenceIndexToRemove = relationships[property].data.findIndex(function (model) {
-          return model.id === id && model.type === type;
+          return model.id.toString() === id.toString() && model.type === type;
         });
         if (referenceIndexToRemove >= 0) relationships[property].data.splice(referenceIndexToRemove, 1);
 
         var recordIndexToRemove = _this.findIndex(function (model) {
-          return model.id === id && model.type === type;
+          return model.id.toString() === id.toString() && model.type === type;
         });
 
         if (recordIndexToRemove >= 0) _this.splice(recordIndexToRemove, 1);

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -2224,12 +2224,12 @@ function (_Array) {
 
       if (relationships && relationships[property] && relatedRecord) {
         var referenceIndexToRemove = relationships[property].data.findIndex(function (model) {
-          return model.id === id && model.type === type;
+          return model.id.toString() === id.toString() && model.type === type;
         });
         if (referenceIndexToRemove >= 0) relationships[property].data.splice(referenceIndexToRemove, 1);
 
         var recordIndexToRemove = _this.findIndex(function (model) {
-          return model.id === id && model.type === type;
+          return model.id.toString() === id.toString() && model.type === type;
         });
 
         if (recordIndexToRemove >= 0) _this.splice(recordIndexToRemove, 1);

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -2226,13 +2226,13 @@ function (_Array) {
         var referenceIndexToRemove = relationships[property].data.findIndex(function (model) {
           return model.id === id && model.type === type;
         });
-        relationships[property].data.splice(referenceIndexToRemove, 1);
+        if (referenceIndexToRemove >= 0) relationships[property].data.splice(referenceIndexToRemove, 1);
 
         var recordIndexToRemove = _this.findIndex(function (model) {
           return model.id === id && model.type === type;
         });
 
-        if (recordIndexToRemove > 0) _this.splice(recordIndexToRemove, 1);
+        if (recordIndexToRemove >= 0) _this.splice(recordIndexToRemove, 1);
 
         if (!relationships[property].data.length) {
           delete relationships[property];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-async-store",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -353,18 +353,42 @@ describe('Model', () => {
   })
 
   it('relatedToMany models can be removed', () => {
-    const note = store.add('notes', {
+    const note1 = store.add('notes', {
       id: 10,
       description: 'Example description'
     })
+    const note2 = store.add('notes', {
+      id: 11,
+      description: 'Another note'
+    })
     const todo = store.add('organizations', { id: 10, title: 'Buy Milk' })
 
-    todo.notes.add(note)
+    const notes = todo.notes
+    notes.add(note1)
+    notes.add(note2)
 
-    expect(todo.notes).toContain(note)
+    notes.remove(note1)
+    expect(notes).not.toContain(note1)
+    expect(notes).toContain(note2)
+  })
 
-    todo.notes.remove(note)
-    expect(todo.notes).not.toContain(note)
+  it('relatedToMany models remove reference to record', () => {
+    const note1 = store.add('notes', {
+      id: 10,
+      description: 'Example description'
+    })
+    const note2 = store.add('notes', {
+      id: 11,
+      description: 'Another note'
+    })
+    const todo = store.add('organizations', { id: 10, title: 'Buy Milk' })
+
+    todo.notes.add(note1)
+    todo.notes.add(note2)
+    todo.notes.remove(note1)
+
+    expect(todo.notes).not.toContain(note1)
+    expect(todo.notes).toContain(note2)
   })
 
   it('relatedToMany models adds inverse relationships', () => {

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -354,11 +354,9 @@ describe('Model', () => {
 
   it('relatedToMany models can be removed', () => {
     const note1 = store.add('notes', {
-      id: 10,
       description: 'Example description'
     })
     const note2 = store.add('notes', {
-      id: 11,
       description: 'Another note'
     })
     const todo = store.add('organizations', { id: 10, title: 'Buy Milk' })
@@ -374,14 +372,12 @@ describe('Model', () => {
 
   it('relatedToMany models remove reference to record', () => {
     const note1 = store.add('notes', {
-      id: 10,
       description: 'Example description'
     })
     const note2 = store.add('notes', {
-      id: 11,
       description: 'Another note'
     })
-    const todo = store.add('organizations', { id: 10, title: 'Buy Milk' })
+    const todo = store.add('organizations', { title: 'Buy Milk' })
 
     todo.notes.add(note1)
     todo.notes.add(note2)

--- a/src/decorators/relationships.js
+++ b/src/decorators/relationships.js
@@ -283,10 +283,10 @@ export class RelatedRecordsArray extends Array {
     const { id, constructor: { type } } = relatedRecord
 
     if (relationships && relationships[property] && relatedRecord) {
-      const referenceIndexToRemove = relationships[property].data.findIndex((model) => model.id === id && model.type === type)
+      const referenceIndexToRemove = relationships[property].data.findIndex((model) => model.id.toString() === id.toString() && model.type === type)
       if (referenceIndexToRemove >= 0) relationships[property].data.splice(referenceIndexToRemove, 1)
 
-      const recordIndexToRemove = this.findIndex((model) => model.id === id && model.type === type)
+      const recordIndexToRemove = this.findIndex((model) => model.id.toString() === id.toString() && model.type === type)
       if (recordIndexToRemove >= 0) this.splice(recordIndexToRemove, 1)
 
       if (!relationships[property].data.length) {

--- a/src/decorators/relationships.js
+++ b/src/decorators/relationships.js
@@ -284,10 +284,10 @@ export class RelatedRecordsArray extends Array {
 
     if (relationships && relationships[property] && relatedRecord) {
       const referenceIndexToRemove = relationships[property].data.findIndex((model) => model.id === id && model.type === type)
-      relationships[property].data.splice(referenceIndexToRemove, 1)
+      if (referenceIndexToRemove >= 0) relationships[property].data.splice(referenceIndexToRemove, 1)
 
       const recordIndexToRemove = this.findIndex((model) => model.id === id && model.type === type)
-      if (recordIndexToRemove > 0) this.splice(recordIndexToRemove, 1)
+      if (recordIndexToRemove >= 0) this.splice(recordIndexToRemove, 1)
 
       if (!relationships[property].data.length) {
         delete relationships[property]


### PR DESCRIPTION
when removing a relatedRecord, if it was not found it would remove the
relationship for the last record (at index -1). This had the side effect
of removing two records when one was found because of the recursive
nature between `remove` and `setRelatedRecord`.

PR to pull it into artemis-store: https://github.com/artemis-ag/artemis-store/pull/54
PR to pull it into portal: https://github.com/artemis-ag/portal/pull/3206