### PR TITLE
coerce ids into strings on models

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -1600,10 +1600,11 @@ function () {
       }
 
       return new ModelKlass(_objectSpread$2({
-        id: id,
         store: store,
         relationships: relationships
-      }, attributes));
+      }, attributes, {
+        id: id.toString()
+      }));
     }
     /**
      * Builds fetch url based

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -1594,10 +1594,11 @@ function () {
       }
 
       return new ModelKlass(_objectSpread$2({
-        id: id,
         store: store,
         relationships: relationships
-      }, attributes));
+      }, attributes, {
+        id: id.toString()
+      }));
     }
     /**
      * Builds fetch url based

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -407,7 +407,7 @@ describe('Model', () => {
 
     expect(todo.notes.constructor.name).toEqual('RelatedRecordsArray')
     expect(todo.notes.map((x) => x.id).constructor.name).toEqual('Array')
-    expect(todo.notes.map((x) => x.id)).toEqual([10])
+    expect(todo.notes.map((x) => x.id)).toEqual(['10'])
   })
 
   describe('.snapshot', () => {

--- a/src/Store.js
+++ b/src/Store.js
@@ -583,7 +583,7 @@ class Store {
       throw new Error(`Could not find a model for '${type}'`)
     }
 
-    return new ModelKlass({ id, store, relationships, ...attributes })
+    return new ModelKlass({ store, relationships, ...attributes, id: id.toString() })
   }
 
   /**


### PR DESCRIPTION
for consistent comparisons. use strings instead of integers because new
records have a "tmp-" id which needs to be of type string.

Note: the `id` needs to be the last argument so that it overrides the
integer value returned from our serialized objects from the API

(this change used to be rolled into https://github.com/artemis-ag/mobx-async-store/pull/22 so there is some discussion there)