### PR TITLE
aliased @relatedToOne property fails to discern type

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,8 @@ module.exports = {
   ],
   "rules": {
     "camelcase": 0,
-    "indent": 0
+    "indent": 0,
+    "quote-props": [2, "consistent-as-needed"]
   },
   "env": {
     "jest": true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-async-store",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/spec/Store.spec.js
+++ b/spec/Store.spec.js
@@ -1,12 +1,29 @@
 /* global fetch */
 import { isObservable, toJS } from 'mobx'
-import { Store, Model, attribute } from '../src/main'
+import { Store, Model, attribute, relatedToOne, relatedToMany } from '../src/main'
+
+class Tag extends Model {
+  static type = 'tags'
+  static endpoint = 'tags'
+
+  @attribute(String) label = ''
+  @relatedToOne todo
+}
+
+class Category extends Model {
+  static type = 'categories'
+  static endpoint = 'categories'
+
+  @attribute(String) name = ''
+  @relatedToOne todo
+}
 
 class Note extends Model {
   static type = 'notes'
   static endpoint = 'notes'
 
   @attribute(String) text = ''
+  @relatedToOne todo
 }
 
 class Todo extends Model {
@@ -14,12 +31,18 @@ class Todo extends Model {
   static endpoint = 'todos'
 
   @attribute(String) title = ''
+  @relatedToMany(Note) user_notes
+  @relatedToOne(Note) instructions
+  @relatedToOne category
+  @relatedToMany tags
 }
 
 class AppStore extends Store {
   static types = [
     Note,
-    Todo
+    Todo,
+    Tag,
+    Category
   ]
 }
 
@@ -85,7 +108,9 @@ describe('Store', () => {
     expect.assertions(1)
     expect(store.modelTypeIndex).toEqual({
       'todos': Todo,
-      'notes': Note
+      'notes': Note,
+      'categories': Category,
+      'tags': Tag
     })
   })
 
@@ -93,7 +118,9 @@ describe('Store', () => {
     expect.assertions(1)
     expect(toJS(store.data)).toEqual({
       todos: { cache: {}, records: {} },
-      notes: { cache: {}, records: {} }
+      notes: { cache: {}, records: {} },
+      categories: { cache: {}, records: {} },
+      tags: { cache: {}, records: {} }
     })
   })
 
@@ -384,6 +411,70 @@ describe('Store', () => {
           expect(cachedTodo.title).toEqual('New title')
         })
       })
+    })
+  })
+
+  describe('createModel', () => {
+    it('creates a model obj with attributes', () => {
+      const todoData = {
+        attributes: { title: 'hello!' }
+      }
+      const todo = store.createModel('todos', 1, todoData)
+      expect(todo.id).toEqual(1)
+      expect(todo.title).toEqual('hello!')
+    })
+
+    it('creates a model obj with relatedToOne property', () => {
+      store.add('categories', { id: 5, name: 'Cat5' })
+      const todoData = {
+        attributes: { title: 'hello!' },
+        relationships: {
+          category: { data: { id: '5', type: 'categories' } }
+        }
+      }
+      const todo = store.createModel('todos', 1, todoData)
+      expect(todo.category.id).toEqual(5)
+      expect(todo.category.name).toEqual('Cat5')
+    })
+
+    it('creates a model with relatedToMany property', () => {
+      store.add('tags', { id: 3, label: 'Tag #3' })
+      const todoData = {
+        attributes: { title: 'hello!' },
+        relationships: {
+          tags: { data: [{ id: '3', type: 'tags' }] }
+        }
+      }
+      const todo = store.createModel('todos', 1, todoData)
+      expect(todo.id).toEqual(1)
+      expect(todo.tags[0].id).toEqual(3)
+      expect(todo.tags[0].label).toEqual('Tag #3')
+    })
+
+    it('creates a model with aliased relatedToOne property', () => {
+      store.add('notes', { id: 17, text: 'Example text' })
+      const todoData = {
+        attributes: { title: 'hello!' },
+        relationships: {
+          note: { data: { id: '17', type: 'notes' } }
+        }
+      }
+      const todo = store.createModel('todos', 1, todoData)
+      expect(todo.instructions.id).toEqual(17)
+      expect(todo.instructions.text).toEqual('Example text')
+    })
+
+    it('creates a model with aliased relatedToMany property', () => {
+      store.add('notes', { id: 3, text: 'hi' })
+      const todoData = {
+        attributes: { title: 'hello!' },
+        relationships: {
+          notes: { data: [{ id: '3', type: 'notes' }] }
+        }
+      }
+      const todo = store.createModel('todos', 1, todoData)
+      expect(todo.user_notes[0].id).toEqual(3)
+      expect(todo.user_notes[0].text).toEqual('hi')
     })
   })
 

--- a/spec/Store.spec.js
+++ b/spec/Store.spec.js
@@ -107,10 +107,10 @@ describe('Store', () => {
   it('sets model type index', () => {
     expect.assertions(1)
     expect(store.modelTypeIndex).toEqual({
-      'todos': Todo,
-      'notes': Note,
-      'categories': Category,
-      'tags': Tag
+      todos: Todo,
+      notes: Note,
+      categories: Category,
+      tags: Tag
     })
   })
 

--- a/spec/Store.spec.js
+++ b/spec/Store.spec.js
@@ -421,11 +421,11 @@ describe('Store', () => {
       }
       const todo = store.createModel('todos', 1, todoData)
       expect(todo.id).toEqual(1)
-      expect(todo.title).toEqual('hello!')
+      expect(todo.title).toEqual(todoData.attributes.title)
     })
 
     it('creates a model obj with relatedToOne property', () => {
-      store.add('categories', { id: 5, name: 'Cat5' })
+      const category = store.add('categories', { id: 5, name: 'Cat5' })
       const todoData = {
         attributes: { title: 'hello!' },
         relationships: {
@@ -433,12 +433,12 @@ describe('Store', () => {
         }
       }
       const todo = store.createModel('todos', 1, todoData)
-      expect(todo.category.id).toEqual(5)
-      expect(todo.category.name).toEqual('Cat5')
+      expect(todo.category.id).toEqual(category.id)
+      expect(todo.category.name).toEqual(category.name)
     })
 
     it('creates a model with relatedToMany property', () => {
-      store.add('tags', { id: 3, label: 'Tag #3' })
+      const tag = store.add('tags', { id: 3, label: 'Tag #3' })
       const todoData = {
         attributes: { title: 'hello!' },
         relationships: {
@@ -447,12 +447,12 @@ describe('Store', () => {
       }
       const todo = store.createModel('todos', 1, todoData)
       expect(todo.id).toEqual(1)
-      expect(todo.tags[0].id).toEqual(3)
-      expect(todo.tags[0].label).toEqual('Tag #3')
+      expect(todo.tags[0].id).toEqual(tag.id)
+      expect(todo.tags[0].label).toEqual(tag.label)
     })
 
     it('creates a model with aliased relatedToOne property', () => {
-      store.add('notes', { id: 17, text: 'Example text' })
+      const note = store.add('notes', { id: 17, text: 'Example text' })
       const todoData = {
         attributes: { title: 'hello!' },
         relationships: {
@@ -460,12 +460,12 @@ describe('Store', () => {
         }
       }
       const todo = store.createModel('todos', 1, todoData)
-      expect(todo.instructions.id).toEqual(17)
-      expect(todo.instructions.text).toEqual('Example text')
+      expect(todo.instructions.id).toEqual(note.id)
+      expect(todo.instructions.text).toEqual(note.text)
     })
 
     it('creates a model with aliased relatedToMany property', () => {
-      store.add('notes', { id: 3, text: 'hi' })
+      const note = store.add('notes', { id: 3, text: 'hi' })
       const todoData = {
         attributes: { title: 'hello!' },
         relationships: {
@@ -473,8 +473,8 @@ describe('Store', () => {
         }
       }
       const todo = store.createModel('todos', 1, todoData)
-      expect(todo.user_notes[0].id).toEqual(3)
-      expect(todo.user_notes[0].text).toEqual('hi')
+      expect(todo.user_notes[0].id).toEqual(note.id)
+      expect(todo.user_notes[0].text).toEqual(note.text)
     })
   })
 
@@ -488,10 +488,10 @@ describe('Store', () => {
       expect(todos).toHaveLength(2)
       expect(todos[0].type).toEqual('todos')
       expect(todos[1].type).toEqual('todos')
-      expect(todos[0].id).toEqual(1)
-      expect(todos[1].id).toEqual(2)
-      expect(todos[0].title).toEqual('hello!')
-      expect(todos[1].title).toEqual('see ya!')
+      expect(todos[0].id).toEqual(dataObjs[0].id)
+      expect(todos[1].id).toEqual(dataObjs[1].id)
+      expect(todos[0].title).toEqual(dataObjs[0].attributes.title)
+      expect(todos[1].title).toEqual(dataObjs[1].attributes.title)
     })
 
     it('skips objs with an unknown type', () => {

--- a/src/decorators/relationships.js
+++ b/src/decorators/relationships.js
@@ -139,13 +139,13 @@ export function getRelatedRecord (record, property, modelType = null) {
   if (!relationships) return
 
   // Use property name unless model type is provided
-  const relationType = modelType || property
+  const relationType = modelType ? singularizeType(modelType) : property
   const reference = relationships[relationType]
 
   // Short circuit if matching reference is not found
   if (!reference || !reference.data) return
 
-  const { id, type } = relationships[relationType].data
+  const { id, type } = reference.data
   const recordType = modelType || type
 
   return record.store.getRecord(recordType, id)


### PR DESCRIPTION
- [x] fix a bug discerning relationship type with aliased `@relatedToOne` property
- [x] test `Store#createModels` with `@relatedToOne` property
- [x] test `Store#createModels` with `@relatedToMany` property
- [x] test `Store#createModels` with aliased `@relatedToOne` property
- [x] test `Store#createModels` with aliased `@relatedToMany` property
