### PR TITLE
Fix issue with attr id over data id

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -183,7 +183,7 @@ function ObjectPromiseProxy(promise, target) {
     var _ref = _asyncToGenerator(
     /*#__PURE__*/
     _regeneratorRuntime.mark(function _callee(response) {
-      var status, json, _json$data, attributes, relationships, message, _json, errorString;
+      var status, json, _json$data, id, attributes, relationships, message, _json, errorString;
 
       return _regeneratorRuntime.wrap(function _callee$(_context) {
         while (1) {
@@ -202,8 +202,9 @@ function ObjectPromiseProxy(promise, target) {
             case 4:
               json = _context.sent;
               // Update target model
-              _json$data = json.data, attributes = _json$data.attributes, relationships = _json$data.relationships;
+              _json$data = json.data, id = _json$data.id, attributes = _json$data.attributes, relationships = _json$data.relationships;
               mobx.transaction(function () {
+                mobx.set(target, 'id', id);
                 Object.keys(attributes).forEach(function (key) {
                   mobx.set(target, key, attributes[key]);
                 });

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -177,7 +177,7 @@ function ObjectPromiseProxy(promise, target) {
     var _ref = _asyncToGenerator(
     /*#__PURE__*/
     _regeneratorRuntime.mark(function _callee(response) {
-      var status, json, _json$data, attributes, relationships, message, _json, errorString;
+      var status, json, _json$data, id, attributes, relationships, message, _json, errorString;
 
       return _regeneratorRuntime.wrap(function _callee$(_context) {
         while (1) {
@@ -196,8 +196,9 @@ function ObjectPromiseProxy(promise, target) {
             case 4:
               json = _context.sent;
               // Update target model
-              _json$data = json.data, attributes = _json$data.attributes, relationships = _json$data.relationships;
+              _json$data = json.data, id = _json$data.id, attributes = _json$data.attributes, relationships = _json$data.relationships;
               transaction(function () {
+                set(target, 'id', id);
                 Object.keys(attributes).forEach(function (key) {
                   set(target, key, attributes[key]);
                 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -119,7 +119,6 @@ const mockTodoData = {
     id: '1',
     type: 'organizations',
     attributes: {
-      id: 1,
       title: 'Do taxes',
       created_at: timestamp.format('YYYY-MM-DD')
     }
@@ -800,7 +799,7 @@ describe('Model', () => {
       })
       // Check that the id is now what was provider
       // from the server
-      expect(todo.id).toEqual(1)
+      expect(todo.id).toEqual('1')
       // Check that the `created_at` attribute is populated
       expect(todo.created_at)
         .toEqual(timestamp.format('YYYY-MM-DD'))

--- a/src/ObjectPromiseProxy.js
+++ b/src/ObjectPromiseProxy.js
@@ -9,8 +9,10 @@ function ObjectPromiseProxy (promise, target) {
       if (status === 200 || status === 201) {
         const json = await response.json()
         // Update target model
-        const { attributes, relationships } = json.data
+        const { id, attributes, relationships } = json.data
         transaction(() => {
+          set(target, 'id', id)
+
           Object.keys(attributes).forEach(key => {
             set(target, key, attributes[key])
           })


### PR DESCRIPTION
I came across an issue where if the an id attribute is not defined in a serializer (which it shouldn't be anyway) newly persisted records are not overriding their tmp ids with the id returned from the server. We should be using the data id across the board.