### PR TITLE
dump all errors for somewhat better parsing

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -240,37 +240,39 @@ function ObjectPromiseProxy(promise, target) {
             case 13:
               target.isInFlight = false;
               message = target.store.genericErrorMessage;
-              _context.prev = 15;
-              _context.next = 18;
+              _json = {};
+              _context.prev = 16;
+              _context.next = 19;
               return response.json();
 
-            case 18:
+            case 19:
               _json = _context.sent;
               message = parseApiErrors(_json.errors, message);
-              _context.next = 24;
+              _context.next = 25;
               break;
 
-            case 22:
-              _context.prev = 22;
-              _context.t0 = _context["catch"](15);
+            case 23:
+              _context.prev = 23;
+              _context.t0 = _context["catch"](16);
 
-            case 24:
+            case 25:
               // TODO: add all errors from the API response to the target
               target.errors = _objectSpread({}, target.errors, {
                 status: status,
                 base: [{
                   message: message
-                }]
+                }],
+                server: _json.errors
               });
               errorString = JSON.stringify(target.errors);
               return _context.abrupt("return", Promise.reject(new Error(errorString)));
 
-            case 27:
+            case 28:
             case "end":
               return _context.stop();
           }
         }
-      }, _callee, null, [[15, 22]]);
+      }, _callee, null, [[16, 23]]);
     }));
 
     return function (_x) {

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -234,37 +234,39 @@ function ObjectPromiseProxy(promise, target) {
             case 13:
               target.isInFlight = false;
               message = target.store.genericErrorMessage;
-              _context.prev = 15;
-              _context.next = 18;
+              _json = {};
+              _context.prev = 16;
+              _context.next = 19;
               return response.json();
 
-            case 18:
+            case 19:
               _json = _context.sent;
               message = parseApiErrors(_json.errors, message);
-              _context.next = 24;
+              _context.next = 25;
               break;
 
-            case 22:
-              _context.prev = 22;
-              _context.t0 = _context["catch"](15);
+            case 23:
+              _context.prev = 23;
+              _context.t0 = _context["catch"](16);
 
-            case 24:
+            case 25:
               // TODO: add all errors from the API response to the target
               target.errors = _objectSpread({}, target.errors, {
                 status: status,
                 base: [{
                   message: message
-                }]
+                }],
+                server: _json.errors
               });
               errorString = JSON.stringify(target.errors);
               return _context.abrupt("return", Promise.reject(new Error(errorString)));
 
-            case 27:
+            case 28:
             case "end":
               return _context.stop();
           }
         }
-      }, _callee, null, [[15, 22]]);
+      }, _callee, null, [[16, 23]]);
     }));
 
     return function (_x) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -827,15 +827,15 @@ describe('Model', () => {
       // Trigger the save function and subsequent request
       try {
         await note.save()
-      } catch(errors) {
+      } catch (errors) {
         // Assert that errors are set on the record object
         expect(note.errors).toEqual({
           status: 422,
           base: [
-            { message: "Something went wrong." }
+            { message: 'Something went wrong.' }
           ],
           server: {
-            description: ["can't be blank"]
+            description: ['can\'t be blank']
           }
         })
       }

--- a/src/ObjectPromiseProxy.js
+++ b/src/ObjectPromiseProxy.js
@@ -46,8 +46,9 @@ function ObjectPromiseProxy (promise, target) {
         target.isInFlight = false
 
         let message = target.store.genericErrorMessage
+        let json = {}
         try {
-          const json = await response.json()
+          json = await response.json()
           message = parseApiErrors(json.errors, message)
         } catch (error) {
           // 500 doesn't return a parsable response
@@ -56,7 +57,8 @@ function ObjectPromiseProxy (promise, target) {
         target.errors = {
           ...target.errors,
           status: status,
-          base: [{ message: message }]
+          base: [{ message: message }],
+          server: json.errors
         }
 
         const errorString = JSON.stringify(target.errors)


### PR DESCRIPTION
add raw server errors to the Model errors so that server validations can be accessed. We will figure out a better way to align to the format of the server validations and the client validations but that will require a much deeper dive, scheduled for the end of March 2020.