### PR TITLE
Rollback to persisted

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -168,7 +168,7 @@ function uniqueBy(array, key) {
  * @param {*} obj
  * @param {Function} iteratee
  * @param {String} prefix
- * @returns Array
+ * @return Array
  */
 
 function walk(obj, iteratee, prefix) {
@@ -191,7 +191,7 @@ function walk(obj, iteratee, prefix) {
  * @method diff
  * @param {Object} a
  * @param {Object} b
- * @returns Array<String>
+ * @return Array<String>
  */
 
 function diff() {
@@ -411,7 +411,7 @@ function () {
 
 var schema = new Schema();
 
-var _class, _descriptor, _descriptor2, _descriptor3, _temp;
+var _class, _descriptor, _descriptor2, _descriptor3, _descriptor4, _temp;
 
 function ownKeys$1(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
@@ -494,13 +494,15 @@ function () {
 
     _classCallCheck(this, Model);
 
-    _initializerDefineProperty(this, "_dirtyRelationships", _descriptor, this);
+    _initializerDefineProperty(this, "_disposed", _descriptor, this);
 
-    _initializerDefineProperty(this, "_dirtyAttributes", _descriptor2, this);
+    _initializerDefineProperty(this, "_dirtyRelationships", _descriptor2, this);
+
+    _initializerDefineProperty(this, "_dirtyAttributes", _descriptor3, this);
 
     this.isInFlight = false;
 
-    _initializerDefineProperty(this, "errors", _descriptor3, this);
+    _initializerDefineProperty(this, "errors", _descriptor4, this);
 
     this._snapshots = [];
 
@@ -524,6 +526,13 @@ function () {
    * @property endpoint
    * @static
    */
+
+  /**
+    * has this object been destroyed?
+    * @property _disposed
+    * @type {Boolean}
+    * @default false
+    */
 
 
   _createClass(Model, [{
@@ -692,7 +701,7 @@ function () {
                   _this.isInFlight = false;
 
                   if (!(response.status === 202 || response.status === 204)) {
-                    _context.next = 17;
+                    _context.next = 18;
                     break;
                   }
 
@@ -728,15 +737,17 @@ function () {
                     _this.store.createModelsFromData(json.included);
                   }
 
+                  _this.dispose();
+
                   return _context.abrupt("return", _this);
 
-                case 17:
+                case 18:
                   _this.errors = {
                     status: response.status
                   };
                   return _context.abrupt("return", _this);
 
-                case 19:
+                case 20:
                 case "end":
                   return _context.stop();
               }
@@ -821,6 +832,8 @@ function () {
   }, {
     key: "dispose",
     value: function dispose() {
+      this._disposed = true;
+
       this._disposers.forEach(function (dispose) {
         return dispose();
       });
@@ -1277,21 +1290,28 @@ function () {
   }]);
 
   return Model;
-}(), _temp), (_descriptor = _applyDecoratedDescriptor(_class.prototype, "_dirtyRelationships", [mobx.observable], {
+}(), _temp), (_descriptor = _applyDecoratedDescriptor(_class.prototype, "_disposed", [mobx.observable], {
+  configurable: true,
+  enumerable: true,
+  writable: true,
+  initializer: function initializer() {
+    return false;
+  }
+}), _descriptor2 = _applyDecoratedDescriptor(_class.prototype, "_dirtyRelationships", [mobx.observable], {
   configurable: true,
   enumerable: true,
   writable: true,
   initializer: function initializer() {
     return new Set();
   }
-}), _descriptor2 = _applyDecoratedDescriptor(_class.prototype, "_dirtyAttributes", [mobx.observable], {
+}), _descriptor3 = _applyDecoratedDescriptor(_class.prototype, "_dirtyAttributes", [mobx.observable], {
   configurable: true,
   enumerable: true,
   writable: true,
   initializer: function initializer() {
     return new Set();
   }
-}), _applyDecoratedDescriptor(_class.prototype, "isNew", [mobx.computed], Object.getOwnPropertyDescriptor(_class.prototype, "isNew"), _class.prototype), _descriptor3 = _applyDecoratedDescriptor(_class.prototype, "errors", [mobx.observable], {
+}), _applyDecoratedDescriptor(_class.prototype, "isNew", [mobx.computed], Object.getOwnPropertyDescriptor(_class.prototype, "isNew"), _class.prototype), _descriptor4 = _applyDecoratedDescriptor(_class.prototype, "errors", [mobx.observable], {
   configurable: true,
   enumerable: true,
   writable: true,

--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -24,6 +24,7 @@ var flattenDeep = _interopDefault(require('lodash/flattenDeep'));
 var cloneDeep = _interopDefault(require('lodash/cloneDeep'));
 var isEqual = _interopDefault(require('lodash/isEqual'));
 var isObject = _interopDefault(require('lodash/isObject'));
+var findLast = _interopDefault(require('lodash/findLast'));
 var _possibleConstructorReturn = _interopDefault(require('@babel/runtime/helpers/possibleConstructorReturn'));
 var _getPrototypeOf = _interopDefault(require('@babel/runtime/helpers/getPrototypeOf'));
 var _assertThisInitialized = _interopDefault(require('@babel/runtime/helpers/assertThisInitialized'));
@@ -237,7 +238,9 @@ function ObjectPromiseProxy(promise, target) {
 
               target.isInFlight = false;
 
-              target._takeSnapshot(true);
+              target._takeSnapshot({
+                persisted: true
+              });
 
               mobx.transaction(function () {
                 // NOTE: This resolves an issue where a record is persisted but the
@@ -477,11 +480,13 @@ function () {
 
     _initializerDefineProperty(this, "errors", _descriptor3, this);
 
-    this.snapshots = [];
+    this._snapshots = [];
 
     this._makeObservable(initialAttributes);
 
-    this._takeSnapshot(!this.isNew);
+    this._takeSnapshot({
+      persisted: !this.isNew
+    });
   }
   /**
    * The type of the model. Defined on the class. Defaults to the underscored version of the class name
@@ -503,7 +508,7 @@ function () {
     key: "rollback",
 
     /**
-     * restores data to its last persisted state
+     * restores data to its last snapshot state
      * ```
      * kpi = store.find('kpis', 5)
      * kpi.name
@@ -516,20 +521,22 @@ function () {
      * @method rollback
      */
     value: function rollback() {
-      var _this2 = this;
+      this._applySnapshot(this.previousSnapshot);
+    }
+    /**
+     * restores data to its last persisted state or the oldest snapshot
+     * state if the model was never persisted
+     * @method rollbackToPersisted
+     */
 
-      mobx.transaction(function () {
-        var previousSnapshot = _this2.previousSnapshot;
+  }, {
+    key: "rollbackToPersisted",
+    value: function rollbackToPersisted() {
+      this._applySnapshot(this.persistedSnapshot);
 
-        _this2.attributeNames.forEach(function (key) {
-          _this2[key] = previousSnapshot.attributes[key];
-        });
-
-        _this2.relationships = previousSnapshot.relationships;
-        _this2.errors = {};
+      this._takeSnapshot({
+        persisted: true
       });
-
-      this._takeSnapshot();
     }
     /**
      * creates or updates a record.
@@ -541,7 +548,7 @@ function () {
   }, {
     key: "save",
     value: function save() {
-      var _this3 = this;
+      var _this2 = this;
 
       var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
@@ -572,13 +579,13 @@ function () {
 
       if (relationships) {
         relationships.forEach(function (rel) {
-          if (Array.isArray(_this3[rel])) {
-            _this3[rel].forEach(function (item, i) {
+          if (Array.isArray(_this2[rel])) {
+            _this2[rel].forEach(function (item, i) {
               if (item.isNew) {
                 throw new Error("Invariant violated: tried to save a relationship to an unpersisted record: \"".concat(rel, "[").concat(i, "]\""));
               }
             });
-          } else if (_this3[rel].isNew) {
+          } else if (_this2[rel].isNew) {
             throw new Error("Invariant violated: tried to save a relationship to an unpersisted record: \"".concat(rel, "\""));
           }
         });
@@ -755,30 +762,30 @@ function () {
   }, {
     key: "_listenForChanges",
     value: function _listenForChanges() {
-      var _this4 = this;
+      var _this3 = this;
 
       this._disposers = Object.keys(this.attributes).map(function (attr) {
         return mobx.reaction(function () {
-          return _this4.attributes[attr];
+          return _this3.attributes[attr];
         }, function (value) {
-          var previousValue = _this4.previousSnapshot.attributes[attr];
+          var previousValue = _this3.previousSnapshot.attributes[attr];
 
           if (isEqual(previousValue, value)) {
-            _this4._dirtyAttributes.delete(attr);
+            _this3._dirtyAttributes.delete(attr);
           } else if (isObject(value)) {
             // handles Objects and Arrays
             // clear out any dirty attrs that start with this attr prefix
             // then we can reset them if they are still (or newly) dirty
-            Array.from(_this4._dirtyAttributes).forEach(function (path) {
+            Array.from(_this3._dirtyAttributes).forEach(function (path) {
               if (path.indexOf("".concat(attr, ".")) === 0) {
-                _this4._dirtyAttributes.delete(path);
+                _this3._dirtyAttributes.delete(path);
               }
             });
             diff(previousValue, value).forEach(function (property) {
-              _this4._dirtyAttributes.add("".concat(attr, ".").concat(property));
+              _this3._dirtyAttributes.add("".concat(attr, ".").concat(property));
             });
           } else {
-            _this4._dirtyAttributes.add(attr);
+            _this3._dirtyAttributes.add(attr);
           }
         });
       });
@@ -823,10 +830,25 @@ function () {
     value: function setPreviousSnapshot() {
       this._takeSnapshot();
     }
+    /**
+     * the latest snapshot
+     *
+     * @method previousSnapshot
+     */
+
   }, {
     key: "_takeSnapshot",
+
+    /**
+     * take a snapshot of the current model state.
+     * if persisted, clear the stack and push this snapshot to the top
+     * if not persisted, push this snapshot to the top of the stack
+     * @method _takeSnapshot
+     * @param {Object} options
+     */
     value: function _takeSnapshot() {
-      var persisted = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : false;
+      var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+      var persisted = options.persisted || false;
 
       this._dirtyRelationships.clear();
 
@@ -835,20 +857,39 @@ function () {
       var _this$snapshot = this.snapshot,
           attributes = _this$snapshot.attributes,
           relationships = _this$snapshot.relationships;
+      var snapshot = {
+        persisted: persisted,
+        attributes: attributes,
+        relationships: relationships
+      };
 
       if (persisted) {
-        this.snapshots = [{
-          persisted: true,
-          attributes: attributes,
-          relationships: relationships
-        }];
-      } else {
-        this.snapshots.push({
-          persisted: false,
-          attributes: attributes,
-          relationships: relationships
-        });
+        this._snapshots = [];
       }
+
+      this._snapshots.push(snapshot);
+    }
+    /**
+     * set the current attributes and relationships to the attributes
+     * and relationships of the snapshot to be applied. also reset errors
+     * @method _applySnapshot
+     * @param {Object} snapshot
+     */
+
+  }, {
+    key: "_applySnapshot",
+    value: function _applySnapshot(snapshot) {
+      var _this4 = this;
+
+      if (!snapshot) throw new Error('Invariant violated: tried to apply undefined snapshot');
+      mobx.transaction(function () {
+        _this4.attributeNames.forEach(function (key) {
+          _this4[key] = snapshot.attributes[key];
+        });
+
+        _this4.relationships = snapshot.relationships;
+        _this4.errors = {};
+      });
     }
     /**
      * a list of any property paths which have been changed since the previous
@@ -1075,9 +1116,22 @@ function () {
   }, {
     key: "previousSnapshot",
     get: function get() {
-      var length = this.snapshots.length;
+      var length = this._snapshots.length;
       if (length === 0) throw new Error('Invariant violated: model has no snapshots');
-      return this.snapshots[length - 1];
+      return this._snapshots[length - 1];
+    }
+    /**
+     * the latest persisted snapshot or the first snapshot if the model was never persisted
+     *
+     * @method previousSnapshot
+     */
+
+  }, {
+    key: "persistedSnapshot",
+    get: function get() {
+      return findLast(this._snapshots, function (ss) {
+        return ss.persisted;
+      }) || this._snapshots[0];
     }
   }, {
     key: "dirtyAttributes",

--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -1100,15 +1100,14 @@ function () {
     }
     /**
      * have any changes been made since this record was last persisted?
-     * @property isPersisted
+     * @property hasUnpersistedChanges
      * @type {Boolean}
      */
 
   }, {
-    key: "isPersisted",
+    key: "hasUnpersistedChanges",
     get: function get() {
-      if (this.isDirty) return false;
-      return this.previousSnapshot.persisted;
+      return this.isDirty || !this.previousSnapshot.persisted;
     }
     /**
      * True if the model has not been sent to the store

--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -163,10 +163,12 @@ function uniqueBy(array, key) {
 }
 /**
  * recursively walk an object and call the `iteratee` function for
- * each property
+ * each property. returns an array of results of calls to the iteratee.
+ * @method walk
  * @param {*} obj
  * @param {Function} iteratee
- * @param {*} prefix
+ * @param {String} prefix
+ * @returns Array
  */
 
 function walk(obj, iteratee, prefix) {
@@ -186,8 +188,10 @@ function walk(obj, iteratee, prefix) {
  * toward object a. object a is walked and compared against values in
  * object b. if a property exists in object b, but not in object a, it
  * will not be counted as a difference.
+ * @method diff
  * @param {Object} a
  * @param {Object} b
+ * @returns Array<String>
  */
 
 function diff() {

--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -161,17 +161,35 @@ function uniqueByReducer(key) {
 function uniqueBy(array, key) {
   return array.reduce(uniqueByReducer(key), []);
 }
-function walk(value, iteratee, prop, path) {
-  if (value != null && _typeof(value) === 'object') {
-    return Object.keys(value).map(function (prop) {
-      return walk(value[prop], iteratee, prop, [path, prop].filter(function (x) {
+/**
+ * recursively walk an object and call the `iteratee` function for
+ * each property
+ * @param {*} obj
+ * @param {Function} iteratee
+ * @param {*} prefix
+ */
+
+function walk(obj, iteratee, prefix) {
+  if (obj != null && _typeof(obj) === 'object') {
+    return Object.keys(obj).map(function (prop) {
+      return walk(obj[prop], iteratee, [prefix, prop].filter(function (x) {
         return x;
       }).join('.'));
     });
   }
 
-  return iteratee(value, path);
+  return iteratee(obj, prefix);
 }
+/**
+ * deeply compare objects a and b and return object paths for attributes
+ * which differ. it is important to note that this comparison is biased
+ * toward object a. object a is walked and compared against values in
+ * object b. if a property exists in object b, but not in object a, it
+ * will not be counted as a difference.
+ * @param {Object} a
+ * @param {Object} b
+ */
+
 function diff() {
   var a = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
   var b = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -155,17 +155,35 @@ function uniqueByReducer(key) {
 function uniqueBy(array, key) {
   return array.reduce(uniqueByReducer(key), []);
 }
-function walk(value, iteratee, prop, path) {
-  if (value != null && _typeof(value) === 'object') {
-    return Object.keys(value).map(function (prop) {
-      return walk(value[prop], iteratee, prop, [path, prop].filter(function (x) {
+/**
+ * recursively walk an object and call the `iteratee` function for
+ * each property
+ * @param {*} obj
+ * @param {Function} iteratee
+ * @param {*} prefix
+ */
+
+function walk(obj, iteratee, prefix) {
+  if (obj != null && _typeof(obj) === 'object') {
+    return Object.keys(obj).map(function (prop) {
+      return walk(obj[prop], iteratee, [prefix, prop].filter(function (x) {
         return x;
       }).join('.'));
     });
   }
 
-  return iteratee(value, path);
+  return iteratee(obj, prefix);
 }
+/**
+ * deeply compare objects a and b and return object paths for attributes
+ * which differ. it is important to note that this comparison is biased
+ * toward object a. object a is walked and compared against values in
+ * object b. if a property exists in object b, but not in object a, it
+ * will not be counted as a difference.
+ * @param {Object} a
+ * @param {Object} b
+ */
+
 function diff() {
   var a = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
   var b = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -157,10 +157,12 @@ function uniqueBy(array, key) {
 }
 /**
  * recursively walk an object and call the `iteratee` function for
- * each property
+ * each property. returns an array of results of calls to the iteratee.
+ * @method walk
  * @param {*} obj
  * @param {Function} iteratee
- * @param {*} prefix
+ * @param {String} prefix
+ * @returns Array
  */
 
 function walk(obj, iteratee, prefix) {
@@ -180,8 +182,10 @@ function walk(obj, iteratee, prefix) {
  * toward object a. object a is walked and compared against values in
  * object b. if a property exists in object b, but not in object a, it
  * will not be counted as a difference.
+ * @method diff
  * @param {Object} a
  * @param {Object} b
+ * @returns Array<String>
  */
 
 function diff() {

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -162,7 +162,7 @@ function uniqueBy(array, key) {
  * @param {*} obj
  * @param {Function} iteratee
  * @param {String} prefix
- * @returns Array
+ * @return Array
  */
 
 function walk(obj, iteratee, prefix) {
@@ -185,7 +185,7 @@ function walk(obj, iteratee, prefix) {
  * @method diff
  * @param {Object} a
  * @param {Object} b
- * @returns Array<String>
+ * @return Array<String>
  */
 
 function diff() {
@@ -405,7 +405,7 @@ function () {
 
 var schema = new Schema();
 
-var _class, _descriptor, _descriptor2, _descriptor3, _temp;
+var _class, _descriptor, _descriptor2, _descriptor3, _descriptor4, _temp;
 
 function ownKeys$1(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
@@ -488,13 +488,15 @@ function () {
 
     _classCallCheck(this, Model);
 
-    _initializerDefineProperty(this, "_dirtyRelationships", _descriptor, this);
+    _initializerDefineProperty(this, "_disposed", _descriptor, this);
 
-    _initializerDefineProperty(this, "_dirtyAttributes", _descriptor2, this);
+    _initializerDefineProperty(this, "_dirtyRelationships", _descriptor2, this);
+
+    _initializerDefineProperty(this, "_dirtyAttributes", _descriptor3, this);
 
     this.isInFlight = false;
 
-    _initializerDefineProperty(this, "errors", _descriptor3, this);
+    _initializerDefineProperty(this, "errors", _descriptor4, this);
 
     this._snapshots = [];
 
@@ -518,6 +520,13 @@ function () {
    * @property endpoint
    * @static
    */
+
+  /**
+    * has this object been destroyed?
+    * @property _disposed
+    * @type {Boolean}
+    * @default false
+    */
 
 
   _createClass(Model, [{
@@ -686,7 +695,7 @@ function () {
                   _this.isInFlight = false;
 
                   if (!(response.status === 202 || response.status === 204)) {
-                    _context.next = 17;
+                    _context.next = 18;
                     break;
                   }
 
@@ -722,15 +731,17 @@ function () {
                     _this.store.createModelsFromData(json.included);
                   }
 
+                  _this.dispose();
+
                   return _context.abrupt("return", _this);
 
-                case 17:
+                case 18:
                   _this.errors = {
                     status: response.status
                   };
                   return _context.abrupt("return", _this);
 
-                case 19:
+                case 20:
                 case "end":
                   return _context.stop();
               }
@@ -815,6 +826,8 @@ function () {
   }, {
     key: "dispose",
     value: function dispose() {
+      this._disposed = true;
+
       this._disposers.forEach(function (dispose) {
         return dispose();
       });
@@ -1271,21 +1284,28 @@ function () {
   }]);
 
   return Model;
-}(), _temp), (_descriptor = _applyDecoratedDescriptor(_class.prototype, "_dirtyRelationships", [observable], {
+}(), _temp), (_descriptor = _applyDecoratedDescriptor(_class.prototype, "_disposed", [observable], {
+  configurable: true,
+  enumerable: true,
+  writable: true,
+  initializer: function initializer() {
+    return false;
+  }
+}), _descriptor2 = _applyDecoratedDescriptor(_class.prototype, "_dirtyRelationships", [observable], {
   configurable: true,
   enumerable: true,
   writable: true,
   initializer: function initializer() {
     return new Set();
   }
-}), _descriptor2 = _applyDecoratedDescriptor(_class.prototype, "_dirtyAttributes", [observable], {
+}), _descriptor3 = _applyDecoratedDescriptor(_class.prototype, "_dirtyAttributes", [observable], {
   configurable: true,
   enumerable: true,
   writable: true,
   initializer: function initializer() {
     return new Set();
   }
-}), _applyDecoratedDescriptor(_class.prototype, "isNew", [computed], Object.getOwnPropertyDescriptor(_class.prototype, "isNew"), _class.prototype), _descriptor3 = _applyDecoratedDescriptor(_class.prototype, "errors", [observable], {
+}), _applyDecoratedDescriptor(_class.prototype, "isNew", [computed], Object.getOwnPropertyDescriptor(_class.prototype, "isNew"), _class.prototype), _descriptor4 = _applyDecoratedDescriptor(_class.prototype, "errors", [observable], {
   configurable: true,
   enumerable: true,
   writable: true,

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -8,14 +8,16 @@ import _createClass from '@babel/runtime/helpers/createClass';
 import _applyDecoratedDescriptor from '@babel/runtime/helpers/applyDecoratedDescriptor';
 import '@babel/runtime/helpers/initializerWarningHelper';
 import _typeof from '@babel/runtime/helpers/typeof';
-import { transaction, set, observable, computed, extendObservable, toJS, action } from 'mobx';
+import { transaction, set, observable, computed, extendObservable, reaction, toJS, action } from 'mobx';
 import moment from 'moment';
 import uuidv1 from 'uuid/v1';
 import jqueryParam from 'jquery-param';
 import pluralize from 'pluralize';
-import cloneDeep from 'lodash/cloneDeep';
 import dig from 'lodash/get';
 import flattenDeep from 'lodash/flattenDeep';
+import cloneDeep from 'lodash/cloneDeep';
+import isEqual from 'lodash/isEqual';
+import isObject from 'lodash/isObject';
 import _possibleConstructorReturn from '@babel/runtime/helpers/possibleConstructorReturn';
 import _getPrototypeOf from '@babel/runtime/helpers/getPrototypeOf';
 import _assertThisInitialized from '@babel/runtime/helpers/assertThisInitialized';
@@ -163,6 +165,16 @@ function walk(value, iteratee, prop, path) {
 
   return iteratee(value, path);
 }
+function diff() {
+  var a = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+  var b = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  return flattenDeep(walk(a, function (prevValue, path) {
+    var currValue = dig(b, path);
+    return prevValue === currValue ? undefined : path;
+  })).filter(function (x) {
+    return x;
+  });
+}
 
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
@@ -218,7 +230,9 @@ function ObjectPromiseProxy(promise, target) {
               }); // Update target isInFlight
 
               target.isInFlight = false;
-              target.setPreviousSnapshot();
+
+              target._takeSnapshot(true);
+
               transaction(function () {
                 // NOTE: This resolves an issue where a record is persisted but the
                 // index key is still a temp uuid. We can't simply remove the temp
@@ -366,7 +380,7 @@ function () {
 
 var schema = new Schema();
 
-var _class, _descriptor, _descriptor2, _temp;
+var _class, _descriptor, _descriptor2, _descriptor3, _temp;
 
 function ownKeys$1(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
@@ -451,15 +465,17 @@ function () {
 
     _initializerDefineProperty(this, "_dirtyRelationships", _descriptor, this);
 
+    _initializerDefineProperty(this, "_dirtyAttributes", _descriptor2, this);
+
     this.isInFlight = false;
 
-    _initializerDefineProperty(this, "errors", _descriptor2, this);
+    _initializerDefineProperty(this, "errors", _descriptor3, this);
 
-    this.previousSnapshot = {};
+    this.snapshots = [];
 
     this._makeObservable(initialAttributes);
 
-    this.setPreviousSnapshot();
+    this._takeSnapshot(!this.isNew);
   }
   /**
    * The type of the model. Defined on the class. Defaults to the underscored version of the class name
@@ -506,7 +522,8 @@ function () {
         _this2.relationships = previousSnapshot.relationships;
         _this2.errors = {};
       });
-      this.setPreviousSnapshot();
+
+      this._takeSnapshot();
     }
     /**
      * creates or updates a record.
@@ -518,6 +535,8 @@ function () {
   }, {
     key: "save",
     value: function save() {
+      var _this3 = this;
+
       var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
       if (!options.skip_validations && !this.validate()) {
@@ -544,6 +563,21 @@ function () {
         relationships: relationships,
         attributes: attributes
       }));
+
+      if (relationships) {
+        relationships.forEach(function (rel) {
+          if (Array.isArray(_this3[rel])) {
+            _this3[rel].forEach(function (item, i) {
+              if (item.isNew) {
+                throw new Error("Invariant violated: tried to save a relationship to an unpersisted record: \"".concat(rel, "[").concat(i, "]\""));
+              }
+            });
+          } else if (_this3[rel].isNew) {
+            throw new Error("Invariant violated: tried to save a relationship to an unpersisted record: \"".concat(rel, "\""));
+          }
+        });
+      }
+
       var response = this.store.fetch(url, {
         method: method,
         body: body
@@ -699,6 +733,62 @@ function () {
     value: function _makeObservable(initialAttributes) {
       var defaultAttributes = this.defaultAttributes;
       extendObservable(this, _objectSpread$1({}, defaultAttributes, {}, initialAttributes));
+
+      this._listenForChanges();
+    }
+    /**
+     * sets up a reaction for each top-level attribute so we can compare
+     * values after each mutation and keep track of dirty attr states
+     * if an attr is different than the last snapshot, add it to the
+     * _dirtyAttributes set
+     * if it's the same as the last snapshot, make sure it's _not_ in the
+     * _dirtyAttributes set
+     * @method _listenForChanges
+     */
+
+  }, {
+    key: "_listenForChanges",
+    value: function _listenForChanges() {
+      var _this4 = this;
+
+      this._disposers = Object.keys(this.attributes).map(function (attr) {
+        return reaction(function () {
+          return _this4.attributes[attr];
+        }, function (value) {
+          var previousValue = _this4.previousSnapshot.attributes[attr];
+
+          if (isEqual(previousValue, value)) {
+            _this4._dirtyAttributes.delete(attr);
+          } else if (isObject(value)) {
+            // handles Objects and Arrays
+            // clear out any dirty attrs that start with this attr prefix
+            // then we can reset them if they are still (or newly) dirty
+            Array.from(_this4._dirtyAttributes).forEach(function (path) {
+              if (path.indexOf("".concat(attr, ".")) === 0) {
+                _this4._dirtyAttributes.delete(path);
+              }
+            });
+            diff(previousValue, value).forEach(function (property) {
+              _this4._dirtyAttributes.add("".concat(attr, ".").concat(property));
+            });
+          } else {
+            _this4._dirtyAttributes.add(attr);
+          }
+        });
+      });
+    }
+    /**
+     * call this when destroying an object to make sure that we clean up
+     * any event listeners and don't leak memory
+     * @method dispose
+     */
+
+  }, {
+    key: "dispose",
+    value: function dispose() {
+      this._disposers.forEach(function (dispose) {
+        return dispose();
+      });
     }
     /**
      * The current state of defined attributes and relationships of the instance
@@ -725,8 +815,34 @@ function () {
      * @method setPreviousSnapshot
      */
     value: function setPreviousSnapshot() {
-      this._dirtyRelationships = new Set();
-      this.previousSnapshot = this.snapshot;
+      this._takeSnapshot();
+    }
+  }, {
+    key: "_takeSnapshot",
+    value: function _takeSnapshot() {
+      var persisted = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : false;
+
+      this._dirtyRelationships.clear();
+
+      this._dirtyAttributes.clear();
+
+      var _this$snapshot = this.snapshot,
+          attributes = _this$snapshot.attributes,
+          relationships = _this$snapshot.relationships;
+
+      if (persisted) {
+        this.snapshots = [{
+          persisted: true,
+          attributes: attributes,
+          relationships: relationships
+        }];
+      } else {
+        this.snapshots.push({
+          persisted: false,
+          attributes: attributes,
+          relationships: relationships
+        });
+      }
     }
     /**
      * a list of any property paths which have been changed since the previous
@@ -773,7 +889,7 @@ function () {
      * @return {Object} data in JSON::API format
      */
     value: function jsonapi() {
-      var _this3 = this;
+      var _this5 = this;
 
       var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
       var attributeDefinitions = this.attributeDefinitions,
@@ -791,7 +907,7 @@ function () {
       }
 
       var attributes = filteredAttributeNames.reduce(function (attrs, key) {
-        var value = _this3[key];
+        var value = _this5[key];
 
         if (value) {
           var DataType = attributeDefinitions[key].dataType;
@@ -823,7 +939,7 @@ function () {
           return options.relationships.includes(name);
         });
         var relationships = filteredRelationshipNames.reduce(function (rels, key) {
-          rels[key] = toJS(_this3.relationships[key]);
+          rels[key] = toJS(_this5.relationships[key]);
           stringifyIds(rels[key]);
           return rels;
         }, {});
@@ -845,11 +961,11 @@ function () {
   }, {
     key: "updateAttributes",
     value: function updateAttributes(attributes) {
-      var _this4 = this;
+      var _this6 = this;
 
       transaction(function () {
         Object.keys(attributes).forEach(function (key) {
-          _this4[key] = attributes[key];
+          _this6[key] = attributes[key];
         });
       });
     }
@@ -896,10 +1012,21 @@ function () {
      * ```
      * @property isDirty
      * @type {Boolean}
-     * @default false
      */
     get: function get() {
-      return this.dirtyAttributes.length > 0;
+      return this._dirtyAttributes.size > 0 || this._dirtyRelationships.size > 0;
+    }
+    /**
+     * have any changes been made since this record was last persisted?
+     * @property isPersisted
+     * @type {Boolean}
+     */
+
+  }, {
+    key: "isPersisted",
+    get: function get() {
+      if (this.isDirty) return false;
+      return this.previousSnapshot.persisted;
     }
     /**
      * True if the model has not been sent to the store
@@ -940,19 +1067,19 @@ function () {
       };
     }
   }, {
+    key: "previousSnapshot",
+    get: function get() {
+      var length = this.snapshots.length;
+      if (length === 0) throw new Error('Invariant violated: model has no snapshots');
+      return this.snapshots[length - 1];
+    }
+  }, {
     key: "dirtyAttributes",
     get: function get() {
-      var _this5 = this;
-
       var relationships = Array.from(this._dirtyRelationships).map(function (property) {
         return "relationships.".concat(property);
       });
-      var attributes = flattenDeep(walk(this.previousSnapshot.attributes, function (prevValue, path) {
-        var currValue = dig(_this5.snapshot.attributes, path);
-        return prevValue === currValue ? undefined : path;
-      })).filter(function (x) {
-        return x;
-      });
+      var attributes = Array.from(this._dirtyAttributes);
       return [].concat(_toConsumableArray(relationships), _toConsumableArray(attributes));
     }
     /**
@@ -977,10 +1104,10 @@ function () {
   }, {
     key: "attributes",
     get: function get() {
-      var _this6 = this;
+      var _this7 = this;
 
       return this.attributeNames.reduce(function (attributes, key) {
-        var value = toJS(_this6[key]);
+        var value = toJS(_this7[key]);
 
         if (!value) {
           delete attributes[key];
@@ -1075,7 +1202,14 @@ function () {
   initializer: function initializer() {
     return new Set();
   }
-}), _applyDecoratedDescriptor(_class.prototype, "isNew", [computed], Object.getOwnPropertyDescriptor(_class.prototype, "isNew"), _class.prototype), _descriptor2 = _applyDecoratedDescriptor(_class.prototype, "errors", [observable], {
+}), _descriptor2 = _applyDecoratedDescriptor(_class.prototype, "_dirtyAttributes", [observable], {
+  configurable: true,
+  enumerable: true,
+  writable: true,
+  initializer: function initializer() {
+    return new Set();
+  }
+}), _applyDecoratedDescriptor(_class.prototype, "isNew", [computed], Object.getOwnPropertyDescriptor(_class.prototype, "isNew"), _class.prototype), _descriptor3 = _applyDecoratedDescriptor(_class.prototype, "errors", [observable], {
   configurable: true,
   enumerable: true,
   writable: true,
@@ -1084,7 +1218,7 @@ function () {
   }
 })), _class);
 
-var _class$1, _descriptor$1, _descriptor2$1, _descriptor3, _temp$1;
+var _class$1, _descriptor$1, _descriptor2$1, _descriptor3$1, _temp$1;
 
 function ownKeys$2(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
@@ -1140,7 +1274,7 @@ function () {
       });
     };
 
-    _initializerDefineProperty(this, "remove", _descriptor3, this);
+    _initializerDefineProperty(this, "remove", _descriptor3$1, this);
 
     this.findOne = function (type, id) {
       var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
@@ -1842,7 +1976,7 @@ function () {
       return model;
     };
   }
-}), _descriptor3 = _applyDecoratedDescriptor(_class$1.prototype, "remove", [action], {
+}), _descriptor3$1 = _applyDecoratedDescriptor(_class$1.prototype, "remove", [action], {
   configurable: true,
   enumerable: true,
   writable: true,

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -1094,15 +1094,14 @@ function () {
     }
     /**
      * have any changes been made since this record was last persisted?
-     * @property isPersisted
+     * @property hasUnpersistedChanges
      * @type {Boolean}
      */
 
   }, {
-    key: "isPersisted",
+    key: "hasUnpersistedChanges",
     get: function get() {
-      if (this.isDirty) return false;
-      return this.previousSnapshot.persisted;
+      return this.isDirty || !this.previousSnapshot.persisted;
     }
     /**
      * True if the model has not been sent to the store

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -476,6 +476,14 @@ describe('Model', () => {
       todo.title = 'Buy something else'
       expect(todo.isPersisted).toBe(false)
     })
+
+    it('is false after nested attribute mutation', async () => {
+      const todo = new Organization({ title: 'Buy Milk', options: { color: 'red' } })
+      todo.isPersisted = true
+      expect(todo.isPersisted).toBe(true)
+      todo.options.color = 'blue'
+      expect(todo.isPersisted).toBe(false)
+    })
   })
 
   describe('.dirtyAttributes', () => {

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -943,7 +943,7 @@ describe('Model', () => {
     })
   })
 
-  describe('.delete', () => {
+  describe('.destroy', () => {
     it('makes request and removes model from the store store', async () => {
       fetch.mockResponses([JSON.stringify({}), { status: 204 }])
       const todo = store.add('organizations', { id: 1, title: 'Buy Milk' })
@@ -955,6 +955,32 @@ describe('Model', () => {
       expect(fetch.mock.calls[0][1].method).toEqual('DELETE')
       expect(store.findAll('organizations', { fromServer: false }))
         .toHaveLength(0)
+    })
+
+    it('calls dispose', async () => {
+      fetch.mockResponses([JSON.stringify({}), { status: 204 }])
+      const todo = store.add('organizations', { id: 1, title: 'Buy Milk' })
+      todo.dispose = jest.fn()
+      await todo.destroy()
+      expect(todo.dispose.mock.calls).toHaveLength(1)
+    })
+  })
+
+  describe('.dispose', () => {
+    it('sets _disposed = true', () => {
+      const todo = store.add('organizations', { id: 1, title: 'Buy Milk' })
+      expect(todo._disposed).toBe(false)
+      todo.dispose()
+      expect(todo._disposed).toBe(true)
+    })
+
+    it('no longer tracks dirty changes', () => {
+      const todo = store.add('organizations', { id: 1, title: 'Buy Milk' })
+      expect(todo.isDirty).toBe(false)
+      todo.dispose()
+      todo.title = 'I Changed'
+      // dirty status is unchanged because the object has been disposed
+      expect(todo.isDirty).toBe(false)
     })
   })
 })

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -863,19 +863,6 @@ describe('Model', () => {
       expect(todo.isPersisted).toBe(true)
     })
 
-    it('sets isPersisted = true on related records when save succeeds', async () => {
-      const note = store.add('notes', {
-        id: 10,
-        description: 'Example description'
-      })
-      const todo = store.add('organizations', { title: 'Buy Milk' })
-      todo.notes.add(note)
-      fetch.mockResponse(mockTodoResponse)
-      expect(note.isPersisted).toBe(false)
-      await todo.save()
-      expect(note.isPersisted).toBe(true)
-    })
-
     it('includes all model errors from the server', async () => {
       const note = store.add('notes', {
         id: 10,
@@ -906,12 +893,10 @@ describe('Model', () => {
 
     it('does not set isPersisted after save fails', async () => {
       const note = store.add('notes', {
-        id: 10,
         description: ''
       })
-      const todo = store.add('organizations', { title: 'Good title' })
-      todo.notes.add(note)
 
+      expect(note.isPersisted).toBe(false)
       // Mock the API response
       fetch.mockResponse(mockNoteWithErrorResponse, { status: 422 })
 

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -471,7 +471,7 @@ describe('Model', () => {
 
     it('is false after attribute mutation', async () => {
       const todo = new Organization({ title: 'Buy Milk' })
-      todo._takeSnapshot(true)
+      todo._takeSnapshot({ persisted: true })
       expect(todo.isPersisted).toBe(true)
       todo.title = 'Buy something else'
       expect(todo.isPersisted).toBe(false)
@@ -479,7 +479,7 @@ describe('Model', () => {
 
     it('is false after nested attribute mutation', async () => {
       const todo = new Organization({ title: 'Buy Milk', options: { color: 'red' } })
-      todo._takeSnapshot(true)
+      todo._takeSnapshot({ persisted: true })
       expect(todo.isPersisted).toBe(true)
       todo.options.color = 'blue'
       expect(todo.isPersisted).toBe(false)

--- a/src/Model.js
+++ b/src/Model.js
@@ -312,7 +312,7 @@ class Model {
   @observable errors = {}
 
   /**
-   * The previous state of defined attributes and relationships of the instance
+   * a list of snapshots that have been taken since the record was either last persisted or since it was instantiated
    *
    * @property snapshots
    * @type {Array<Snapshot>}

--- a/src/Model.js
+++ b/src/Model.js
@@ -203,7 +203,7 @@ class Model {
    */
   constructor (initialAttributes = {}) {
     this._makeObservable(initialAttributes)
-    this._takeSnapshot()
+    this._takeSnapshot(!this.isNew)
   }
 
   /**

--- a/src/Model.js
+++ b/src/Model.js
@@ -513,6 +513,7 @@ class Model {
    * _dirtyAttributes set
    * if it's the same as the last snapshot, make sure it's _not_ in the
    * _dirtyAttributes set
+   * @method _listenForChanges
    */
   _listenForChanges () {
     this._disposers = Object.keys(this.attributes).map((attr) => {
@@ -541,6 +542,7 @@ class Model {
   /**
    * call this when destroying an object to make sure that we clean up
    * any event listeners and don't leak memory
+   * @method dispose
    */
   dispose () {
     this._disposers.forEach((dispose) => dispose())

--- a/src/Model.js
+++ b/src/Model.js
@@ -281,12 +281,11 @@ class Model {
 
   /**
    * have any changes been made since this record was last persisted?
-   * @property isPersisted
+   * @property hasUnpersistedChanges
    * @type {Boolean}
    */
-  get isPersisted () {
-    if (this.isDirty) return false
-    return this.previousSnapshot.persisted
+  get hasUnpersistedChanges () {
+    return this.isDirty || !this.previousSnapshot.persisted
   }
 
   /**

--- a/src/Model.js
+++ b/src/Model.js
@@ -222,8 +222,27 @@ class Model {
    * @static
    */
 
-   @observable _dirtyRelationships = new Set()
-   @observable _dirtyAttributes = new Set()
+  /**
+    * has this object been destroyed?
+    * @property _disposed
+    * @type {Boolean}
+    * @default false
+    */
+  @observable _disposed = false
+
+  /**
+    * set of relationships which have changed since last snapshot
+    * @property _dirtyRelationships
+    * @type {Set}
+    */
+  @observable _dirtyRelationships = new Set()
+
+  /**
+    * set of attributes which have changed since last snapshot
+    * @property _dirtyAttributes
+    * @type {Set}
+    */
+  @observable _dirtyAttributes = new Set()
 
   /**
    * True if the instance has been modified from its persisted state
@@ -475,6 +494,8 @@ class Model {
             _this.store.createModelsFromData(json.included)
           }
 
+          _this.dispose()
+
           return _this
         } else {
           _this.errors = { status: response.status }
@@ -548,6 +569,7 @@ class Model {
    * @method dispose
    */
   dispose () {
+    this._disposed = true
     this._disposers.forEach((dispose) => dispose())
   }
 

--- a/src/Model.js
+++ b/src/Model.js
@@ -1,6 +1,7 @@
 import {
   computed,
   extendObservable,
+  intercept,
   set,
   toJS,
   transaction,
@@ -213,7 +214,6 @@ class Model {
    * @default false
    */
   isPersisted = false
-
 
   /**
    * The type of the model. Defined on the class. Defaults to the underscored version of the class name
@@ -481,11 +481,18 @@ class Model {
    * @method _makeObservable
    */
   _makeObservable (initialAttributes) {
-     const { defaultAttributes } = this
+     const { defaultAttributes, attributeDefinitions } = this
 
      extendObservable(this, {
        ...defaultAttributes,
        ...initialAttributes
+     })
+
+     Object.keys(attributeDefinitions).map((attr) => {
+      intercept(this, attr, (change) => {
+        this.isPersisted = false
+        return change
+      })
      })
    }
 

--- a/src/Model.js
+++ b/src/Model.js
@@ -203,7 +203,7 @@ class Model {
    */
   constructor (initialAttributes = {}) {
     this._makeObservable(initialAttributes)
-    this._takeSnapshot(!this.isNew)
+    this._takeSnapshot({ persisted: !this.isNew })
   }
 
   /**
@@ -585,7 +585,8 @@ class Model {
     return this.snapshots[length - 1]
   }
 
-  _takeSnapshot (persisted = false) {
+  _takeSnapshot (options = {}) {
+    const persisted = options.persisted || false
     this._dirtyRelationships.clear()
     this._dirtyAttributes.clear()
     const { attributes, relationships } = this.snapshot

--- a/src/Model.js
+++ b/src/Model.js
@@ -206,6 +206,16 @@ class Model {
   }
 
   /**
+   * Property used to capture the state of the record between being fetched and saved.
+   *
+   * @property isPersisted
+   * @type Boolean
+   * @default false
+   */
+  isPersisted = false
+
+
+  /**
    * The type of the model. Defined on the class. Defaults to the underscored version of the class name
    * (eg 'calendar_events').
    *

--- a/src/Model.js
+++ b/src/Model.js
@@ -375,6 +375,20 @@ class Model {
       { relationships, attributes }
     ))
 
+    if (relationships) {
+      relationships.forEach((rel) => {
+        if (Array.isArray(this[rel])) {
+          this[rel].forEach((item, i) => {
+            if (item.isNew) {
+              throw new Error(`Invariant violated: tried to save a relationship to an unpersisted record: "${rel}[${i}]"`)
+            }
+          })
+        } else if (this[rel].isNew) {
+          throw new Error(`Invariant violated: tried to save a relationship to an unpersisted record: "${rel}"`)
+        }
+      })
+    }
+
     const response = this.store.fetch(url, { method, body })
 
     return new ObjectPromiseProxy(response, this)

--- a/src/ObjectPromiseProxy.js
+++ b/src/ObjectPromiseProxy.js
@@ -30,7 +30,7 @@ function ObjectPromiseProxy (promise, target) {
         })
         // Update target isInFlight
         target.isInFlight = false
-        target._takeSnapshot(true)
+        target._takeSnapshot({ persisted: true })
 
         transaction(() => {
           // NOTE: This resolves an issue where a record is persisted but the

--- a/src/ObjectPromiseProxy.js
+++ b/src/ObjectPromiseProxy.js
@@ -30,7 +30,9 @@ function ObjectPromiseProxy (promise, target) {
         })
         // Update target isInFlight
         target.isInFlight = false
+        target.isPersisted = true
         target.setPreviousSnapshot()
+
         transaction(() => {
           // NOTE: This resolves an issue where a record is persisted but the
           // index key is still a temp uuid. We can't simply remove the temp
@@ -41,6 +43,7 @@ function ObjectPromiseProxy (promise, target) {
           target.store.data[target.type].records[tmpId] = target
           target.store.data[target.type].records[target.id] = target
         })
+
         return target
       } else {
         target.isInFlight = false

--- a/src/ObjectPromiseProxy.js
+++ b/src/ObjectPromiseProxy.js
@@ -30,8 +30,7 @@ function ObjectPromiseProxy (promise, target) {
         })
         // Update target isInFlight
         target.isInFlight = false
-        target.isPersisted = true
-        target.setPreviousSnapshot()
+        target._takeSnapshot(true)
 
         transaction(() => {
           // NOTE: This resolves an issue where a record is persisted but the

--- a/src/Store.js
+++ b/src/Store.js
@@ -623,7 +623,6 @@ class Store {
         const { id, attributes = {}, relationships = {} } = dataObject
         const ModelKlass = this.modelTypeIndex[type]
         const record = new ModelKlass({ store, relationships, ...attributes })
-        record._takeSnapshot(true)
         this.data[type].cache[url].push(id)
         this.data[type].records[id] = record
 
@@ -658,8 +657,6 @@ class Store {
       }
 
       const record = this.createOrUpdateModel(data)
-
-      record._takeSnapshot(true)
 
       this.data[type].cache[url] = []
       this.data[type].cache[url].push(record.id)

--- a/src/Store.js
+++ b/src/Store.js
@@ -623,7 +623,7 @@ class Store {
         const { id, attributes = {}, relationships = {} } = dataObject
         const ModelKlass = this.modelTypeIndex[type]
         const record = new ModelKlass({ store, relationships, ...attributes })
-
+        record.isPersisted = true
         this.data[type].cache[url].push(id)
         this.data[type].records[id] = record
 
@@ -659,6 +659,7 @@ class Store {
 
       const record = this.createOrUpdateModel(data)
 
+      record.isPersisted = true
       this.data[type].cache[url] = []
       this.data[type].cache[url].push(record.id)
 

--- a/src/Store.js
+++ b/src/Store.js
@@ -623,7 +623,7 @@ class Store {
         const { id, attributes = {}, relationships = {} } = dataObject
         const ModelKlass = this.modelTypeIndex[type]
         const record = new ModelKlass({ store, relationships, ...attributes })
-        record.isPersisted = true
+        record._takeSnapshot(true)
         this.data[type].cache[url].push(id)
         this.data[type].records[id] = record
 
@@ -659,7 +659,8 @@ class Store {
 
       const record = this.createOrUpdateModel(data)
 
-      record.isPersisted = true
+      record._takeSnapshot(true)
+
       this.data[type].cache[url] = []
       this.data[type].cache[url].push(record.id)
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -149,7 +149,7 @@ export function stringifyIds (object) {
  * each property
  * @param {*} obj
  * @param {Function} iteratee
- * @param {*} prefix
+ * @param {String} prefix
  */
 export function walk (obj, iteratee, prefix) {
   if (obj != null && typeof obj === 'object') {

--- a/src/utils.js
+++ b/src/utils.js
@@ -144,15 +144,31 @@ export function stringifyIds (object) {
   })
 }
 
-export function walk (value, iteratee, prop, path) {
-  if (value != null && typeof value === 'object') {
-    return Object.keys(value).map((prop) => {
-      return walk(value[prop], iteratee, prop, [path, prop].filter(x => x).join('.'))
+/**
+ * recursively walk an object and call the `iteratee` function for
+ * each property
+ * @param {*} obj
+ * @param {Function} iteratee
+ * @param {*} prefix
+ */
+export function walk (obj, iteratee, prefix) {
+  if (obj != null && typeof obj === 'object') {
+    return Object.keys(obj).map((prop) => {
+      return walk(obj[prop], iteratee, [prefix, prop].filter(x => x).join('.'))
     })
   }
-  return iteratee(value, path)
+  return iteratee(obj, prefix)
 }
 
+/**
+ * deeply compare objects a and b and return object paths for attributes
+ * which differ. it is important to note that this comparison is biased
+ * toward object a. object a is walked and compared against values in
+ * object b. if a property exists in object b, but not in object a, it
+ * will not be counted as a difference.
+ * @param {Object} a
+ * @param {Object} b
+ */
 export function diff (a = {}, b = {}) {
   return flattenDeep(walk(a, (prevValue, path) => {
     const currValue = dig(b, path)

--- a/src/utils.js
+++ b/src/utils.js
@@ -146,10 +146,12 @@ export function stringifyIds (object) {
 
 /**
  * recursively walk an object and call the `iteratee` function for
- * each property
+ * each property. returns an array of results of calls to the iteratee.
+ * @method walk
  * @param {*} obj
  * @param {Function} iteratee
  * @param {String} prefix
+ * @return Array
  */
 export function walk (obj, iteratee, prefix) {
   if (obj != null && typeof obj === 'object') {
@@ -166,8 +168,10 @@ export function walk (obj, iteratee, prefix) {
  * toward object a. object a is walked and compared against values in
  * object b. if a property exists in object b, but not in object a, it
  * will not be counted as a difference.
+ * @method diff
  * @param {Object} a
  * @param {Object} b
+ * @return Array<String>
  */
 export function diff (a = {}, b = {}) {
   return flattenDeep(walk(a, (prevValue, path) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,8 @@
 import uuidv1 from 'uuid/v1'
 import jqueryParam from 'jquery-param'
 import pluralize from 'pluralize'
+import dig from 'lodash/get'
+import flattenDeep from 'lodash/flattenDeep'
 
 const pending = {}
 const counter = {}
@@ -149,4 +151,11 @@ export function walk (value, iteratee, prop, path) {
     })
   }
   return iteratee(value, path)
+}
+
+export function diff (a = {}, b = {}) {
+  return flattenDeep(walk(a, (prevValue, path) => {
+    const currValue = dig(b, path)
+    return prevValue === currValue ? undefined : path
+  })).filter((x) => x)
 }


### PR DESCRIPTION
At one point a snapshot only happened alongside saving a record, so we could use the last snapshot as a "source of truth" for determining if a record was dirty or not. Recently, we have introduced the idea of taking snapshots at various points as "rollback targets" without persisting these snapshots to the api. So we now need to distinguish between a record being "dirty" (changes made since last snapshot) and a record being "persisted" (having unsaved changes). 

We introduced ~`isPersisted`~ `hasUnpersistedChanges` to be that extra flag. ~As I'm typing this out, I'm realizing that `isPersisted` is probably a bad name. Technically, a record is referred to as "persisted" if it _has ever been_ persisted. Maybe we should rename `isPersisted` to something like `hasUnpersistedChanges`? Idk. I want to be careful to avoid the word "saved" here—as tempting as it is, because it just isn't specific enough. Is it "saved" as in a snapshot was taken? or is it "saved" as in persisted?~

other changes made in this PR:
* we moved the dirty check work (walking the attribute tree and diffing properties) from read time to write time. this should speed up calls to `isDirty`.
* we are also introducing the data model concept of a list of snapshots. I don't think we're quite ready for this yet, but this will hopefully start to lay the groundwork for things like undo/redo.