### PR TITLE
Fix falsey value snapshots

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -1203,7 +1203,7 @@ function () {
       return this.attributeNames.reduce(function (attributes, key) {
         var value = mobx.toJS(_this7[key]);
 
-        if (!value) {
+        if (value == null) {
           delete attributes[key];
         } else {
           attributes[key] = value;

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -1197,7 +1197,7 @@ function () {
       return this.attributeNames.reduce(function (attributes, key) {
         var value = toJS(_this7[key]);
 
-        if (!value) {
+        if (value == null) {
           delete attributes[key];
         } else {
           attributes[key] = value;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -451,9 +451,32 @@ describe('Model', () => {
     expect(todo.notes.map((x) => x.id)).toEqual([10])
   })
 
-  describe('.previousSnapshot', () => {
-    it('sets snapshot on initialization', async () => {
+  describe('.snapshot', () => {
+    it('a snapshot of the current attributes and relationship', async () => {
       const todo = new Organization({ title: 'Buy Milk' })
+      expect(todo.snapshot.attributes).toEqual({
+        due_at: moment(timestamp).toDate(),
+        tags: [],
+        title: 'Buy Milk',
+        options: {}
+      })
+    })
+
+    it('doesn\'t exclude falsey values', async () => {
+      const todo = new Organization({ title: '' })
+      expect(todo.snapshot.attributes).toEqual({
+        due_at: moment(timestamp).toDate(),
+        tags: [],
+        title: '',
+        options: {}
+      })
+    })
+  })
+
+  describe('.previousSnapshot', () => {
+    it('the previous snapshot', async () => {
+      const todo = new Organization({ title: 'Buy Milk' })
+      todo.title = 'something different'
       expect(todo.previousSnapshot.attributes).toEqual({
         due_at: moment(timestamp).toDate(),
         tags: [],

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -474,7 +474,7 @@ describe('Model', () => {
   })
 
   describe('.previousSnapshot', () => {
-    it('the previous snapshot', async () => {
+    it('return the previous snapshot', async () => {
       const todo = new Organization({ title: 'Buy Milk' })
       todo.title = 'something different'
       expect(todo.previousSnapshot.attributes).toEqual({

--- a/src/Model.js
+++ b/src/Model.js
@@ -703,7 +703,7 @@ class Model {
   get attributes () {
     return this.attributeNames.reduce((attributes, key) => {
       const value = toJS(this[key])
-      if (!value) {
+      if (value == null) {
         delete attributes[key]
       } else {
         attributes[key] = value


### PR DESCRIPTION
`Model#attributes` used to exclude falsey values like `0`, `''`, `false` and assume they meant `undefined` or `null` so we couldn't snapshot any properties which had those values—they just became `undefined`. this fixes that.

we might want to allow `null` at some point, but i guess we haven't needed it yet, so i'm going to go ahead and continue to exclude it.