### PR TITLE
Fix validation error when no relationships are defined

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -1223,7 +1223,7 @@ function () {
     key: "attributeDefinitions",
     get: function get() {
       var type = this.constructor.type;
-      return schema.structure[type];
+      return schema.structure[type] || {};
     }
     /**
      * Getter find the relationship definitions for the model type.
@@ -1236,7 +1236,7 @@ function () {
     key: "relationshipDefinitions",
     get: function get() {
       var type = this.constructor.type;
-      return schema.relations[type];
+      return schema.relations[type] || {};
     }
     /**
      * Getter to check if the record has errors.

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -1217,7 +1217,7 @@ function () {
     key: "attributeDefinitions",
     get: function get() {
       var type = this.constructor.type;
-      return schema.structure[type];
+      return schema.structure[type] || {};
     }
     /**
      * Getter find the relationship definitions for the model type.
@@ -1230,7 +1230,7 @@ function () {
     key: "relationshipDefinitions",
     get: function get() {
       var type = this.constructor.type;
-      return schema.relations[type];
+      return schema.relations[type] || {};
     }
     /**
      * Getter to check if the record has errors.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -31,6 +31,12 @@ class Note extends Model {
   @relatedToOne organization
 }
 
+class Relationshipless extends Model {
+  static type = 'relationshipless'
+  static endpoint = 'relationshipless'
+  @attribute(String) name
+}
+
 function validatesArray (property) {
   return {
     isValid: Array.isArray(property),
@@ -106,7 +112,8 @@ class AppStore extends Store {
   static types = [
     Organization,
     Note,
-    User
+    User,
+    Relationshipless
   ]
 }
 
@@ -744,6 +751,11 @@ describe('Model', () => {
       expect(todo.validate()).toBeFalsy()
       expect(todo.errors.options[0].key).toEqual('blank')
       expect(todo.errors.options[0].data.optionKey).toEqual('baz')
+    })
+
+    it('allows for undefined relationshipDefinitions', () => {
+      const todo = store.add('relationshipless', { name: 'lonely model' })
+      expect(todo.validate()).toBeTruthy()
     })
   })
 

--- a/src/Model.js
+++ b/src/Model.js
@@ -720,7 +720,7 @@ class Model {
    */
   get attributeDefinitions () {
     const { type } = this.constructor
-    return schema.structure[type]
+    return schema.structure[type] || {}
   }
 
   /**
@@ -731,7 +731,7 @@ class Model {
    */
   get relationshipDefinitions () {
     const { type } = this.constructor
-    return schema.relations[type]
+    return schema.relations[type] || {}
   }
 
   /**


### PR DESCRIPTION
The validation step was failing for a model that does not have relationships defined.