### PR TITLE
Fix store delete method

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -271,8 +271,8 @@ function ObjectPromiseProxy(promise, target) {
                 // uuid id as its only reference to the newly persisted record.
                 // TODO: Figure out a way to update associated records to use the
                 // newly persisted id.
-                target.store.data[target.type].records.set(tmpId, target);
-                target.store.data[target.type].records.set(target.id, target);
+                target.store.data[target.type].records.set(String(tmpId), target);
+                target.store.data[target.type].records.set(String(target.id), target);
               });
               return _context.abrupt("return", target);
 
@@ -1824,8 +1824,6 @@ function () {
   }, {
     key: "createOrUpdateModel",
     value: function createOrUpdateModel(dataObject) {
-      var _this4 = this;
-
       var _dataObject$attribute = dataObject.attributes,
           attributes = _dataObject$attribute === void 0 ? {} : _dataObject$attribute,
           id = dataObject.id,
@@ -1838,8 +1836,6 @@ function () {
         // Update existing object attributes
         Object.keys(attributes).forEach(function (key) {
           mobx.set(record, key, attributes[key]);
-
-          _this4.data[type].records.set(id, record);
         }); // If relationships are present, update relationships
 
         if (relationships) {
@@ -1848,8 +1844,6 @@ function () {
             if (!relationships[key].meta) {
               // defensive against existingRecord.relationships being undefined
               mobx.set(record, 'relationships', _objectSpread$2({}, record.relationships, _defineProperty({}, key, relationships[key])));
-
-              _this4.data[type].records.set(id, record);
             }
           });
         }
@@ -1862,9 +1856,9 @@ function () {
           attributes: attributes,
           relationships: relationships
         });
-        this.data[type].records.set(record.id, record);
       }
 
+      this.data[type].records.set(String(record.id), record);
       return record;
     }
     /**
@@ -1877,15 +1871,15 @@ function () {
   }, {
     key: "createModelsFromData",
     value: function createModelsFromData(data) {
-      var _this5 = this;
+      var _this4 = this;
 
       return mobx.transaction(function () {
         return data.map(function (dataObject) {
           // Only build objects for which we have a type defined.
           // And ignore silently anything else included in the JSON response.
           // TODO: Put some console message in development mode
-          if (_this5.getType(dataObject.type)) {
-            return _this5.createOrUpdateModel(dataObject);
+          if (_this4.getType(dataObject.type)) {
+            return _this4.createOrUpdateModel(dataObject);
           }
         });
       });
@@ -1952,7 +1946,7 @@ function () {
       var _fetchAll = _asyncToGenerator(
       /*#__PURE__*/
       _regeneratorRuntime.mark(function _callee(type, queryParams) {
-        var _this6 = this;
+        var _this5 = this;
 
         var store, url, response, json;
         return _regeneratorRuntime.wrap(function _callee$(_context) {
@@ -1992,17 +1986,17 @@ function () {
                         attributes = _dataObject$attribute2 === void 0 ? {} : _dataObject$attribute2,
                         _dataObject$relations2 = dataObject.relationships,
                         relationships = _dataObject$relations2 === void 0 ? {} : _dataObject$relations2;
-                    var ModelKlass = _this6.modelTypeIndex[type];
+                    var ModelKlass = _this5.modelTypeIndex[type];
                     var record = new ModelKlass(_objectSpread$2({
                       store: store,
                       relationships: relationships
                     }, attributes));
 
-                    var cachedIds = _this6.data[type].cache.get(url);
+                    var cachedIds = _this5.data[type].cache.get(url);
 
-                    _this6.data[type].cache.set(url, [].concat(_toConsumableArray(cachedIds), [id]));
+                    _this5.data[type].cache.set(url, [].concat(_toConsumableArray(cachedIds), [id]));
 
-                    _this6.data[type].records.set(id, record);
+                    _this5.data[type].records.set(String(id), record);
 
                     return record;
                   });
@@ -2107,17 +2101,17 @@ function () {
   enumerable: true,
   writable: true,
   initializer: function initializer() {
-    var _this7 = this;
+    var _this6 = this;
 
     return function (type, attributes) {
       var id = dbOrNewId(attributes);
 
-      var model = _this7.createModel(type, id, {
+      var model = _this6.createModel(type, id, {
         attributes: attributes
       }); // Add the model to the type records index
 
 
-      _this7.data[type].records.set(String(id), model);
+      _this6.data[type].records.set(String(id), model);
 
       return model;
     };
@@ -2127,10 +2121,10 @@ function () {
   enumerable: true,
   writable: true,
   initializer: function initializer() {
-    var _this8 = this;
+    var _this7 = this;
 
     return function (type, id) {
-      _this8.data[type].records.delete(String(id));
+      _this7.data[type].records.delete(String(id));
     };
   }
 })), _class$1);

--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -2125,15 +2125,7 @@ function () {
     var _this8 = this;
 
     return function (type, id) {
-      var records = _this8.getRecords(type);
-
-      _this8.data[type].records = records.reduce(function (hash, record) {
-        if (String(record.id) !== String(id)) {
-          hash[record.id] = record;
-        }
-
-        return hash;
-      }, {});
+      delete _this8.data[type].records[id];
     };
   }
 })), _class$1);

--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -271,8 +271,8 @@ function ObjectPromiseProxy(promise, target) {
                 // uuid id as its only reference to the newly persisted record.
                 // TODO: Figure out a way to update associated records to use the
                 // newly persisted id.
-                target.store.data[target.type].records[tmpId] = target;
-                target.store.data[target.type].records[target.id] = target;
+                target.store.data[target.type].records.set(tmpId, target);
+                target.store.data[target.type].records.set(target.id, target);
               });
               return _context.abrupt("return", target);
 
@@ -1506,8 +1506,8 @@ function () {
     value: function reset(type) {
       if (type) {
         this.data[type] = {
-          records: {},
-          cache: {}
+          records: mobx.observable.map({}),
+          cache: mobx.observable.map({})
         };
       } else {
         this.initializeObservableDataProperty();
@@ -1578,8 +1578,8 @@ function () {
 
       types.forEach(function (modelKlass) {
         _this2.data[modelKlass.type] = {
-          records: {},
-          cache: {}
+          records: mobx.observable.map({}),
+          cache: mobx.observable.map({})
         };
       });
     }
@@ -1666,7 +1666,7 @@ function () {
         throw new Error("Could not find a collection for type '".concat(type, "'"));
       }
 
-      var record = this.getType(type).records[id];
+      var record = this.getType(type).records.get(String(id));
       if (!record || record === 'undefined') return;
       return record;
     }
@@ -1681,7 +1681,7 @@ function () {
   }, {
     key: "getRecords",
     value: function getRecords(type) {
-      var records = Object.values(this.getType(type).records).filter(function (value) {
+      var records = Array.from(this.getType(type).records.values()).filter(function (value) {
         return value && value !== 'undefined';
       }); // NOTE: Handles a scenario where the store keeps around a reference
       // to a newly persisted record by its temp uuid. This is required
@@ -1739,7 +1739,7 @@ function () {
   }, {
     key: "getCachedIds",
     value: function getCachedIds(type, url) {
-      var ids = this.getType(type).cache[url];
+      var ids = this.getType(type).cache.get(url);
       if (!ids) return [];
       var idsSet = new Set(mobx.toJS(ids));
       return Array.from(idsSet);
@@ -1747,7 +1747,7 @@ function () {
     /**
      * Gets records from store based on cached query
      *
-     * @method getCachedIds
+     * @method getCachedId
      * @param {String} type
      * @param {String} url
      * @return {Array} array of ids
@@ -1756,7 +1756,7 @@ function () {
   }, {
     key: "getCachedId",
     value: function getCachedId(type, id) {
-      return this.getType(type).cache[id];
+      return this.getType(type).cache.get(String(id));
     }
     /**
      * Get multiple records by id
@@ -1837,8 +1837,9 @@ function () {
       if (record) {
         // Update existing object attributes
         Object.keys(attributes).forEach(function (key) {
-          mobx.set(record, key, attributes[key]);
-          mobx.set(_this4.data[type].records, id, record);
+          mobx.set(record, key, attributes[key]); // set(this.data[type].records, id, record)
+
+          _this4.data[type].records.set(id, record);
         }); // If relationships are present, update relationships
 
         if (relationships) {
@@ -1846,7 +1847,10 @@ function () {
             // Don't try to create relationship if meta included false
             if (!relationships[key].meta) {
               // defensive against existingRecord.relationships being undefined
-              mobx.set(record, 'relationships', _objectSpread$2({}, record.relationships, _defineProperty({}, key, relationships[key])));
+              record.relationships = _objectSpread$2({}, record.relationships, _defineProperty({}, key, relationships[key])); // set(record, 'relationships', )
+
+              _this4.data[type].records.set(id, record);
+
               mobx.set(_this4.data[type].records, id, record);
             }
           });
@@ -1859,8 +1863,9 @@ function () {
         record = this.createModel(type, id, {
           attributes: attributes,
           relationships: relationships
-        });
-        this.data[type].records[record.id] = record;
+        }); // this.data[type].records[record.id] = record
+
+        this.data[type].records.set(record.id, record);
       }
 
       return record;
@@ -1972,7 +1977,7 @@ function () {
                   break;
                 }
 
-                this.data[type].cache[url] = [];
+                this.data[type].cache.set(url, []);
                 _context.next = 9;
                 return response.json();
 
@@ -1996,9 +2001,12 @@ function () {
                       relationships: relationships
                     }, attributes));
 
-                    _this6.data[type].cache[url].push(id);
+                    var cachedIds = _this6.data[type].cache.get(url);
 
-                    _this6.data[type].records[id] = record;
+                    _this6.data[type].cache.set(url, [].concat(_toConsumableArray(cachedIds), [id]));
+
+                    _this6.data[type].records.set(id, record);
+
                     return record;
                   });
                 }));
@@ -2051,7 +2059,7 @@ function () {
                 response = _context2.sent;
 
                 if (!(response.status === 200)) {
-                  _context2.next = 16;
+                  _context2.next = 15;
                   break;
                 }
 
@@ -2067,14 +2075,13 @@ function () {
                 }
 
                 record = this.createOrUpdateModel(data);
-                this.data[type].cache[url] = [];
-                this.data[type].cache[url].push(record.id);
+                this.data[type].cache.set(url, [record.id]);
                 return _context2.abrupt("return", record);
 
-              case 16:
+              case 15:
                 return _context2.abrupt("return", null);
 
-              case 17:
+              case 16:
               case "end":
                 return _context2.stop();
             }
@@ -2113,7 +2120,8 @@ function () {
       }); // Add the model to the type records index
 
 
-      _this7.data[type].records[id] = model;
+      _this7.data[type].records.set(String(id), model);
+
       return model;
     };
   }
@@ -2125,7 +2133,7 @@ function () {
     var _this8 = this;
 
     return function (type, id) {
-      delete _this8.data[type].records[id];
+      _this8.data[type].records.delete(String(id));
     };
   }
 })), _class$1);

--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -1861,8 +1861,7 @@ function () {
         record = this.createModel(type, id, {
           attributes: attributes,
           relationships: relationships
-        }); // this.data[type].records[record.id] = record
-
+        });
         this.data[type].records.set(record.id, record);
       }
 

--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -1837,7 +1837,7 @@ function () {
       if (record) {
         // Update existing object attributes
         Object.keys(attributes).forEach(function (key) {
-          mobx.set(record, key, attributes[key]); // set(this.data[type].records, id, record)
+          mobx.set(record, key, attributes[key]);
 
           _this4.data[type].records.set(id, record);
         }); // If relationships are present, update relationships
@@ -1847,11 +1847,9 @@ function () {
             // Don't try to create relationship if meta included false
             if (!relationships[key].meta) {
               // defensive against existingRecord.relationships being undefined
-              record.relationships = _objectSpread$2({}, record.relationships, _defineProperty({}, key, relationships[key])); // set(record, 'relationships', )
+              record.relationships = _objectSpread$2({}, record.relationships, _defineProperty({}, key, relationships[key]));
 
               _this4.data[type].records.set(id, record);
-
-              mobx.set(_this4.data[type].records, id, record);
             }
           });
         }

--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -1847,7 +1847,7 @@ function () {
             // Don't try to create relationship if meta included false
             if (!relationships[key].meta) {
               // defensive against existingRecord.relationships being undefined
-              record.relationships = _objectSpread$2({}, record.relationships, _defineProperty({}, key, relationships[key]));
+              mobx.set(record, 'relationships', _objectSpread$2({}, record.relationships, _defineProperty({}, key, relationships[key])));
 
               _this4.data[type].records.set(id, record);
             }

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -265,8 +265,8 @@ function ObjectPromiseProxy(promise, target) {
                 // uuid id as its only reference to the newly persisted record.
                 // TODO: Figure out a way to update associated records to use the
                 // newly persisted id.
-                target.store.data[target.type].records[tmpId] = target;
-                target.store.data[target.type].records[target.id] = target;
+                target.store.data[target.type].records.set(tmpId, target);
+                target.store.data[target.type].records.set(target.id, target);
               });
               return _context.abrupt("return", target);
 
@@ -1500,8 +1500,8 @@ function () {
     value: function reset(type) {
       if (type) {
         this.data[type] = {
-          records: {},
-          cache: {}
+          records: observable.map({}),
+          cache: observable.map({})
         };
       } else {
         this.initializeObservableDataProperty();
@@ -1572,8 +1572,8 @@ function () {
 
       types.forEach(function (modelKlass) {
         _this2.data[modelKlass.type] = {
-          records: {},
-          cache: {}
+          records: observable.map({}),
+          cache: observable.map({})
         };
       });
     }
@@ -1660,7 +1660,7 @@ function () {
         throw new Error("Could not find a collection for type '".concat(type, "'"));
       }
 
-      var record = this.getType(type).records[id];
+      var record = this.getType(type).records.get(String(id));
       if (!record || record === 'undefined') return;
       return record;
     }
@@ -1675,7 +1675,7 @@ function () {
   }, {
     key: "getRecords",
     value: function getRecords(type) {
-      var records = Object.values(this.getType(type).records).filter(function (value) {
+      var records = Array.from(this.getType(type).records.values()).filter(function (value) {
         return value && value !== 'undefined';
       }); // NOTE: Handles a scenario where the store keeps around a reference
       // to a newly persisted record by its temp uuid. This is required
@@ -1733,7 +1733,7 @@ function () {
   }, {
     key: "getCachedIds",
     value: function getCachedIds(type, url) {
-      var ids = this.getType(type).cache[url];
+      var ids = this.getType(type).cache.get(url);
       if (!ids) return [];
       var idsSet = new Set(toJS(ids));
       return Array.from(idsSet);
@@ -1741,7 +1741,7 @@ function () {
     /**
      * Gets records from store based on cached query
      *
-     * @method getCachedIds
+     * @method getCachedId
      * @param {String} type
      * @param {String} url
      * @return {Array} array of ids
@@ -1750,7 +1750,7 @@ function () {
   }, {
     key: "getCachedId",
     value: function getCachedId(type, id) {
-      return this.getType(type).cache[id];
+      return this.getType(type).cache.get(String(id));
     }
     /**
      * Get multiple records by id
@@ -1831,8 +1831,9 @@ function () {
       if (record) {
         // Update existing object attributes
         Object.keys(attributes).forEach(function (key) {
-          set(record, key, attributes[key]);
-          set(_this4.data[type].records, id, record);
+          set(record, key, attributes[key]); // set(this.data[type].records, id, record)
+
+          _this4.data[type].records.set(id, record);
         }); // If relationships are present, update relationships
 
         if (relationships) {
@@ -1840,7 +1841,10 @@ function () {
             // Don't try to create relationship if meta included false
             if (!relationships[key].meta) {
               // defensive against existingRecord.relationships being undefined
-              set(record, 'relationships', _objectSpread$2({}, record.relationships, _defineProperty({}, key, relationships[key])));
+              record.relationships = _objectSpread$2({}, record.relationships, _defineProperty({}, key, relationships[key])); // set(record, 'relationships', )
+
+              _this4.data[type].records.set(id, record);
+
               set(_this4.data[type].records, id, record);
             }
           });
@@ -1853,8 +1857,9 @@ function () {
         record = this.createModel(type, id, {
           attributes: attributes,
           relationships: relationships
-        });
-        this.data[type].records[record.id] = record;
+        }); // this.data[type].records[record.id] = record
+
+        this.data[type].records.set(record.id, record);
       }
 
       return record;
@@ -1966,7 +1971,7 @@ function () {
                   break;
                 }
 
-                this.data[type].cache[url] = [];
+                this.data[type].cache.set(url, []);
                 _context.next = 9;
                 return response.json();
 
@@ -1990,9 +1995,12 @@ function () {
                       relationships: relationships
                     }, attributes));
 
-                    _this6.data[type].cache[url].push(id);
+                    var cachedIds = _this6.data[type].cache.get(url);
 
-                    _this6.data[type].records[id] = record;
+                    _this6.data[type].cache.set(url, [].concat(_toConsumableArray(cachedIds), [id]));
+
+                    _this6.data[type].records.set(id, record);
+
                     return record;
                   });
                 }));
@@ -2045,7 +2053,7 @@ function () {
                 response = _context2.sent;
 
                 if (!(response.status === 200)) {
-                  _context2.next = 16;
+                  _context2.next = 15;
                   break;
                 }
 
@@ -2061,14 +2069,13 @@ function () {
                 }
 
                 record = this.createOrUpdateModel(data);
-                this.data[type].cache[url] = [];
-                this.data[type].cache[url].push(record.id);
+                this.data[type].cache.set(url, [record.id]);
                 return _context2.abrupt("return", record);
 
-              case 16:
+              case 15:
                 return _context2.abrupt("return", null);
 
-              case 17:
+              case 16:
               case "end":
                 return _context2.stop();
             }
@@ -2107,7 +2114,8 @@ function () {
       }); // Add the model to the type records index
 
 
-      _this7.data[type].records[id] = model;
+      _this7.data[type].records.set(String(id), model);
+
       return model;
     };
   }
@@ -2119,7 +2127,7 @@ function () {
     var _this8 = this;
 
     return function (type, id) {
-      delete _this8.data[type].records[id];
+      _this8.data[type].records.delete(String(id));
     };
   }
 })), _class$1);

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -1841,7 +1841,7 @@ function () {
             // Don't try to create relationship if meta included false
             if (!relationships[key].meta) {
               // defensive against existingRecord.relationships being undefined
-              record.relationships = _objectSpread$2({}, record.relationships, _defineProperty({}, key, relationships[key]));
+              set(record, 'relationships', _objectSpread$2({}, record.relationships, _defineProperty({}, key, relationships[key])));
 
               _this4.data[type].records.set(id, record);
             }

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -1855,8 +1855,7 @@ function () {
         record = this.createModel(type, id, {
           attributes: attributes,
           relationships: relationships
-        }); // this.data[type].records[record.id] = record
-
+        });
         this.data[type].records.set(record.id, record);
       }
 

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -2119,15 +2119,7 @@ function () {
     var _this8 = this;
 
     return function (type, id) {
-      var records = _this8.getRecords(type);
-
-      _this8.data[type].records = records.reduce(function (hash, record) {
-        if (String(record.id) !== String(id)) {
-          hash[record.id] = record;
-        }
-
-        return hash;
-      }, {});
+      delete _this8.data[type].records[id];
     };
   }
 })), _class$1);

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -1831,7 +1831,7 @@ function () {
       if (record) {
         // Update existing object attributes
         Object.keys(attributes).forEach(function (key) {
-          set(record, key, attributes[key]); // set(this.data[type].records, id, record)
+          set(record, key, attributes[key]);
 
           _this4.data[type].records.set(id, record);
         }); // If relationships are present, update relationships
@@ -1841,11 +1841,9 @@ function () {
             // Don't try to create relationship if meta included false
             if (!relationships[key].meta) {
               // defensive against existingRecord.relationships being undefined
-              record.relationships = _objectSpread$2({}, record.relationships, _defineProperty({}, key, relationships[key])); // set(record, 'relationships', )
+              record.relationships = _objectSpread$2({}, record.relationships, _defineProperty({}, key, relationships[key]));
 
               _this4.data[type].records.set(id, record);
-
-              set(_this4.data[type].records, id, record);
             }
           });
         }

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -265,8 +265,8 @@ function ObjectPromiseProxy(promise, target) {
                 // uuid id as its only reference to the newly persisted record.
                 // TODO: Figure out a way to update associated records to use the
                 // newly persisted id.
-                target.store.data[target.type].records.set(tmpId, target);
-                target.store.data[target.type].records.set(target.id, target);
+                target.store.data[target.type].records.set(String(tmpId), target);
+                target.store.data[target.type].records.set(String(target.id), target);
               });
               return _context.abrupt("return", target);
 
@@ -1818,8 +1818,6 @@ function () {
   }, {
     key: "createOrUpdateModel",
     value: function createOrUpdateModel(dataObject) {
-      var _this4 = this;
-
       var _dataObject$attribute = dataObject.attributes,
           attributes = _dataObject$attribute === void 0 ? {} : _dataObject$attribute,
           id = dataObject.id,
@@ -1832,8 +1830,6 @@ function () {
         // Update existing object attributes
         Object.keys(attributes).forEach(function (key) {
           set(record, key, attributes[key]);
-
-          _this4.data[type].records.set(id, record);
         }); // If relationships are present, update relationships
 
         if (relationships) {
@@ -1842,8 +1838,6 @@ function () {
             if (!relationships[key].meta) {
               // defensive against existingRecord.relationships being undefined
               set(record, 'relationships', _objectSpread$2({}, record.relationships, _defineProperty({}, key, relationships[key])));
-
-              _this4.data[type].records.set(id, record);
             }
           });
         }
@@ -1856,9 +1850,9 @@ function () {
           attributes: attributes,
           relationships: relationships
         });
-        this.data[type].records.set(record.id, record);
       }
 
+      this.data[type].records.set(String(record.id), record);
       return record;
     }
     /**
@@ -1871,15 +1865,15 @@ function () {
   }, {
     key: "createModelsFromData",
     value: function createModelsFromData(data) {
-      var _this5 = this;
+      var _this4 = this;
 
       return transaction(function () {
         return data.map(function (dataObject) {
           // Only build objects for which we have a type defined.
           // And ignore silently anything else included in the JSON response.
           // TODO: Put some console message in development mode
-          if (_this5.getType(dataObject.type)) {
-            return _this5.createOrUpdateModel(dataObject);
+          if (_this4.getType(dataObject.type)) {
+            return _this4.createOrUpdateModel(dataObject);
           }
         });
       });
@@ -1946,7 +1940,7 @@ function () {
       var _fetchAll = _asyncToGenerator(
       /*#__PURE__*/
       _regeneratorRuntime.mark(function _callee(type, queryParams) {
-        var _this6 = this;
+        var _this5 = this;
 
         var store, url, response, json;
         return _regeneratorRuntime.wrap(function _callee$(_context) {
@@ -1986,17 +1980,17 @@ function () {
                         attributes = _dataObject$attribute2 === void 0 ? {} : _dataObject$attribute2,
                         _dataObject$relations2 = dataObject.relationships,
                         relationships = _dataObject$relations2 === void 0 ? {} : _dataObject$relations2;
-                    var ModelKlass = _this6.modelTypeIndex[type];
+                    var ModelKlass = _this5.modelTypeIndex[type];
                     var record = new ModelKlass(_objectSpread$2({
                       store: store,
                       relationships: relationships
                     }, attributes));
 
-                    var cachedIds = _this6.data[type].cache.get(url);
+                    var cachedIds = _this5.data[type].cache.get(url);
 
-                    _this6.data[type].cache.set(url, [].concat(_toConsumableArray(cachedIds), [id]));
+                    _this5.data[type].cache.set(url, [].concat(_toConsumableArray(cachedIds), [id]));
 
-                    _this6.data[type].records.set(id, record);
+                    _this5.data[type].records.set(String(id), record);
 
                     return record;
                   });
@@ -2101,17 +2095,17 @@ function () {
   enumerable: true,
   writable: true,
   initializer: function initializer() {
-    var _this7 = this;
+    var _this6 = this;
 
     return function (type, attributes) {
       var id = dbOrNewId(attributes);
 
-      var model = _this7.createModel(type, id, {
+      var model = _this6.createModel(type, id, {
         attributes: attributes
       }); // Add the model to the type records index
 
 
-      _this7.data[type].records.set(String(id), model);
+      _this6.data[type].records.set(String(id), model);
 
       return model;
     };
@@ -2121,10 +2115,10 @@ function () {
   enumerable: true,
   writable: true,
   initializer: function initializer() {
-    var _this8 = this;
+    var _this7 = this;
 
     return function (type, id) {
-      _this8.data[type].records.delete(String(id));
+      _this7.data[type].records.delete(String(id));
     };
   }
 })), _class$1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -279,10 +279,7 @@ describe('Model', () => {
     })
 
     it('builds relatedToMany relationship with existing models', async () => {
-      store.add('notes', {
-        id: 1,
-        description: 'Example description'
-      })
+      store.add('notes', { id: 1, description: 'Example description' })
 
       fetch.mockResponse(exampleRelatedToManyResponse)
       const todo = await store.findOne('organizations', 1)

--- a/spec/Store.spec.js
+++ b/spec/Store.spec.js
@@ -66,7 +66,7 @@ const mockTodoData = {
     id: '1',
     type: 'todos',
     attributes: {
-      id: 1,
+      id: '1',
       title: 'Do taxes'
     }
   }
@@ -427,10 +427,11 @@ describe('Store', () => {
       const todoData = {
         attributes: { title: 'hello!' },
         relationships: {
-          category: { data: { id: '5', type: 'categories' } }
+          category: { data: { id: category.id, type: 'categories' } }
         }
       }
       const todo = store.createModel('todos', 1, todoData)
+      expect(todo.id).toEqual(1)
       expect(todo.category.id).toEqual(category.id)
       expect(todo.category.name).toEqual(category.name)
     })
@@ -440,7 +441,7 @@ describe('Store', () => {
       const todoData = {
         attributes: { title: 'hello!' },
         relationships: {
-          tags: { data: [{ id: '3', type: 'tags' }] }
+          tags: { data: [{ id: tag.id, type: 'tags' }] }
         }
       }
       const todo = store.createModel('todos', 1, todoData)
@@ -454,7 +455,7 @@ describe('Store', () => {
       const todoData = {
         attributes: { title: 'hello!' },
         relationships: {
-          note: { data: { id: '17', type: 'notes' } }
+          note: { data: { id: note.id, type: 'notes' } }
         }
       }
       const todo = store.createModel('todos', 1, todoData)
@@ -467,7 +468,7 @@ describe('Store', () => {
       const todoData = {
         attributes: { title: 'hello!' },
         relationships: {
-          notes: { data: [{ id: '3', type: 'notes' }] }
+          notes: { data: [{ id: note.id, type: 'notes' }] }
         }
       }
       const todo = store.createModel('todos', 1, todoData)

--- a/src/ObjectPromiseProxy.js
+++ b/src/ObjectPromiseProxy.js
@@ -39,8 +39,8 @@ function ObjectPromiseProxy (promise, target) {
           // uuid id as its only reference to the newly persisted record.
           // TODO: Figure out a way to update associated records to use the
           // newly persisted id.
-          target.store.data[target.type].records[tmpId] = target
-          target.store.data[target.type].records[target.id] = target
+          target.store.data[target.type].records.set(tmpId, target)
+          target.store.data[target.type].records.set(target.id, target)
         })
 
         return target

--- a/src/ObjectPromiseProxy.js
+++ b/src/ObjectPromiseProxy.js
@@ -39,8 +39,8 @@ function ObjectPromiseProxy (promise, target) {
           // uuid id as its only reference to the newly persisted record.
           // TODO: Figure out a way to update associated records to use the
           // newly persisted id.
-          target.store.data[target.type].records.set(tmpId, target)
-          target.store.data[target.type].records.set(target.id, target)
+          target.store.data[target.type].records.set(String(tmpId), target)
+          target.store.data[target.type].records.set(String(target.id), target)
         })
 
         return target

--- a/src/Store.js
+++ b/src/Store.js
@@ -563,7 +563,6 @@ class Store {
       // Update existing object attributes
       Object.keys(attributes).forEach(key => {
         set(record, key, attributes[key])
-        this.data[type].records.set(id, record)
       })
 
       // If relationships are present, update relationships
@@ -573,17 +572,15 @@ class Store {
           if (!relationships[key].meta) {
             // defensive against existingRecord.relationships being undefined
             set(record, 'relationships', { ...record.relationships, [key]: relationships[key] })
-            this.data[type].records.set(id, record)
           }
         })
       }
-
       record._takeSnapshot({ persisted: true })
     } else {
       record = this.createModel(type, id, { attributes, relationships })
-      this.data[type].records.set(record.id, record)
     }
 
+    this.data[type].records.set(String(record.id), record)
     return record
   }
 
@@ -665,7 +662,7 @@ class Store {
         const record = new ModelKlass({ store, relationships, ...attributes })
         const cachedIds = this.data[type].cache.get(url)
         this.data[type].cache.set(url, [...cachedIds, id])
-        this.data[type].records.set(id, record)
+        this.data[type].records.set(String(id), record)
         return record
       }))
     } else {

--- a/src/Store.js
+++ b/src/Store.js
@@ -572,7 +572,7 @@ class Store {
           // Don't try to create relationship if meta included false
           if (!relationships[key].meta) {
             // defensive against existingRecord.relationships being undefined
-            record.relationships = { ...record.relationships, [key]: relationships[key] }
+            set(record, 'relationships', { ...record.relationships, [key]: relationships[key] })
             this.data[type].records.set(id, record)
           }
         })

--- a/src/Store.js
+++ b/src/Store.js
@@ -89,14 +89,7 @@ class Store {
    */
   @action
   remove = (type, id) => {
-    const records = this.getRecords(type)
-
-    this.data[type].records = records.reduce((hash, record) => {
-      if (String(record.id) !== String(id)) {
-        hash[record.id] = record
-      }
-      return hash
-    }, {})
+    delete this.data[type].records[id]
   }
 
   /**

--- a/src/Store.js
+++ b/src/Store.js
@@ -563,7 +563,6 @@ class Store {
       // Update existing object attributes
       Object.keys(attributes).forEach(key => {
         set(record, key, attributes[key])
-        // set(this.data[type].records, id, record)
         this.data[type].records.set(id, record)
       })
 
@@ -574,9 +573,7 @@ class Store {
           if (!relationships[key].meta) {
             // defensive against existingRecord.relationships being undefined
             record.relationships = { ...record.relationships, [key]: relationships[key] }
-            // set(record, 'relationships', )
             this.data[type].records.set(id, record)
-            set(this.data[type].records, id, record)
           }
         })
       }

--- a/src/Store.js
+++ b/src/Store.js
@@ -581,7 +581,6 @@ class Store {
       record._takeSnapshot({ persisted: true })
     } else {
       record = this.createModel(type, id, { attributes, relationships })
-      // this.data[type].records[record.id] = record
       this.data[type].records.set(record.id, record)
     }
 
@@ -665,10 +664,8 @@ class Store {
         const ModelKlass = this.modelTypeIndex[type]
         const record = new ModelKlass({ store, relationships, ...attributes })
         const cachedIds = this.data[type].cache.get(url)
-
         this.data[type].cache.set(url, [...cachedIds, id])
         this.data[type].records.set(id, record)
-
         return record
       }))
     } else {


### PR DESCRIPTION
We moved the `records` and `cache` attributes on the main `Store#data` observable object. This allows us to use the set, get, and delete methods. The impetus for this was to get the performance of `Store#remove` down to `O(1)` instead `O(n)`.

So, records and cache are read and written to like so.
```JavaScript
this.data[type].records[id] = record
// becomes
this.data[type.records.set(String(id), record)

this.data[type].records[id]
// becomes
this.data[type].records.get(id)

// and we can delete records simply
this.data[type].records.delete(id)
```