### PR TITLE
Remove moment

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -15,7 +15,6 @@ var _applyDecoratedDescriptor = _interopDefault(require('@babel/runtime/helpers/
 require('@babel/runtime/helpers/initializerWarningHelper');
 var _typeof = _interopDefault(require('@babel/runtime/helpers/typeof'));
 var mobx = require('mobx');
-var moment = _interopDefault(require('moment'));
 var uuidv1 = _interopDefault(require('uuid/v1'));
 var jqueryParam = _interopDefault(require('jquery-param'));
 var pluralize = _interopDefault(require('pluralize'));
@@ -425,7 +424,6 @@ function _objectSpread$1(target) { for (var i = 1; i < arguments.length; i++) { 
  * @return {Array} an array of booleans representing results of validations
  */
 
-
 function validateProperties(model, propertyNames, propertyDefinitions) {
   return propertyNames.map(function (property) {
     var validator = propertyDefinitions[property].validator;
@@ -480,6 +478,7 @@ function stringifyIds(object) {
 /**
  @class Model
  */
+
 
 var Model = (_class = (_temp =
 /*#__PURE__*/
@@ -998,7 +997,7 @@ function () {
           if (DataType.name === 'Array' || DataType.name === 'Object') {
             attr = mobx.toJS(value);
           } else if (DataType.name === 'Date') {
-            attr = moment(value).toISOString();
+            attr = value instanceof Date || value._isAMomentObject ? value : new Date(Date.parse(value)).toISOString();
           } else {
             attr = DataType(value);
           }
@@ -2166,7 +2165,8 @@ function defaultValueForDescriptor(descriptor, DataType) {
     var value = descriptor.initializer();
 
     if (DataType.name === 'Date') {
-      return moment(value).toDate();
+      if (value instanceof Date || value._isAMomentObject) return value;
+      return new Date(Date.parse(value));
     } else {
       return DataType(value);
     }
@@ -2182,7 +2182,7 @@ function defaultValueForDescriptor(descriptor, DataType) {
  * Attributes can be defined with a default.
  * ```
  * class Todo extends Model {
- *   @attribute(Date) start_time = moment()
+ *   @attribute(Date) start_time = new Date()
  * }
  * ```
  * @method attribute

--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -161,6 +161,18 @@ function uniqueBy(array, key) {
   return array.reduce(uniqueByReducer(key), []);
 }
 /**
+ * convert a value into a date, pass Date or Moment instances thru
+ * untouched
+ * @method makeDate
+ * @param {*} value
+ * @return {Date|Moment}
+ */
+
+function makeDate(value) {
+  if (value instanceof Date || value._isAMomentObject) return value;
+  return new Date(Date.parse(value)).toISOString();
+}
+/**
  * recursively walk an object and call the `iteratee` function for
  * each property. returns an array of results of calls to the iteratee.
  * @method walk
@@ -997,7 +1009,7 @@ function () {
           if (DataType.name === 'Array' || DataType.name === 'Object') {
             attr = mobx.toJS(value);
           } else if (DataType.name === 'Date') {
-            attr = value instanceof Date || value._isAMomentObject ? value : new Date(Date.parse(value)).toISOString();
+            attr = makeDate(value).toISOString();
           } else {
             attr = DataType(value);
           }
@@ -2165,8 +2177,7 @@ function defaultValueForDescriptor(descriptor, DataType) {
     var value = descriptor.initializer();
 
     if (DataType.name === 'Date') {
-      if (value instanceof Date || value._isAMomentObject) return value;
-      return new Date(Date.parse(value));
+      return makeDate(value);
     } else {
       return DataType(value);
     }

--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -170,7 +170,7 @@ function uniqueBy(array, key) {
 
 function makeDate(value) {
   if (value instanceof Date || value._isAMomentObject) return value;
-  return new Date(Date.parse(value)).toISOString();
+  return new Date(Date.parse(value));
 }
 /**
  * recursively walk an object and call the `iteratee` function for

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -155,6 +155,18 @@ function uniqueBy(array, key) {
   return array.reduce(uniqueByReducer(key), []);
 }
 /**
+ * convert a value into a date, pass Date or Moment instances thru
+ * untouched
+ * @method makeDate
+ * @param {*} value
+ * @return {Date|Moment}
+ */
+
+function makeDate(value) {
+  if (value instanceof Date || value._isAMomentObject) return value;
+  return new Date(Date.parse(value)).toISOString();
+}
+/**
  * recursively walk an object and call the `iteratee` function for
  * each property. returns an array of results of calls to the iteratee.
  * @method walk
@@ -991,7 +1003,7 @@ function () {
           if (DataType.name === 'Array' || DataType.name === 'Object') {
             attr = toJS(value);
           } else if (DataType.name === 'Date') {
-            attr = value instanceof Date || value._isAMomentObject ? value : new Date(Date.parse(value)).toISOString();
+            attr = makeDate(value).toISOString();
           } else {
             attr = DataType(value);
           }
@@ -2159,8 +2171,7 @@ function defaultValueForDescriptor(descriptor, DataType) {
     var value = descriptor.initializer();
 
     if (DataType.name === 'Date') {
-      if (value instanceof Date || value._isAMomentObject) return value;
-      return new Date(Date.parse(value));
+      return makeDate(value);
     } else {
       return DataType(value);
     }

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -164,7 +164,7 @@ function uniqueBy(array, key) {
 
 function makeDate(value) {
   if (value instanceof Date || value._isAMomentObject) return value;
-  return new Date(Date.parse(value)).toISOString();
+  return new Date(Date.parse(value));
 }
 /**
  * recursively walk an object and call the `iteratee` function for

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -9,7 +9,6 @@ import _applyDecoratedDescriptor from '@babel/runtime/helpers/applyDecoratedDesc
 import '@babel/runtime/helpers/initializerWarningHelper';
 import _typeof from '@babel/runtime/helpers/typeof';
 import { transaction, set, observable, computed, extendObservable, reaction, toJS, action } from 'mobx';
-import moment from 'moment';
 import uuidv1 from 'uuid/v1';
 import jqueryParam from 'jquery-param';
 import pluralize from 'pluralize';
@@ -419,7 +418,6 @@ function _objectSpread$1(target) { for (var i = 1; i < arguments.length; i++) { 
  * @return {Array} an array of booleans representing results of validations
  */
 
-
 function validateProperties(model, propertyNames, propertyDefinitions) {
   return propertyNames.map(function (property) {
     var validator = propertyDefinitions[property].validator;
@@ -474,6 +472,7 @@ function stringifyIds(object) {
 /**
  @class Model
  */
+
 
 var Model = (_class = (_temp =
 /*#__PURE__*/
@@ -992,7 +991,7 @@ function () {
           if (DataType.name === 'Array' || DataType.name === 'Object') {
             attr = toJS(value);
           } else if (DataType.name === 'Date') {
-            attr = moment(value).toISOString();
+            attr = value instanceof Date || value._isAMomentObject ? value : new Date(Date.parse(value)).toISOString();
           } else {
             attr = DataType(value);
           }
@@ -2160,7 +2159,8 @@ function defaultValueForDescriptor(descriptor, DataType) {
     var value = descriptor.initializer();
 
     if (DataType.name === 'Date') {
-      return moment(value).toDate();
+      if (value instanceof Date || value._isAMomentObject) return value;
+      return new Date(Date.parse(value));
     } else {
       return DataType(value);
     }
@@ -2176,7 +2176,7 @@ function defaultValueForDescriptor(descriptor, DataType) {
  * Attributes can be defined with a default.
  * ```
  * class Todo extends Model {
- *   @attribute(Date) start_time = moment()
+ *   @attribute(Date) start_time = new Date()
  * }
  * ```
  * @method attribute

--- a/docs/classes/Model.html
+++ b/docs/classes/Model.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.0.25</em>
+            <em>API Docs for: 1.0.26</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -84,7 +84,7 @@
 
 
         <div class="foundat">
-            Defined in: <a href="../files/src_Model.js.html#l196"><code>src&#x2F;Model.js:196</code></a>
+            Defined in: <a href="../files/src_Model.js.html#l81"><code>src&#x2F;Model.js:81</code></a>
         </div>
 
 
@@ -129,10 +129,6 @@
 
                             </li>
                             <li class="index-item method">
-                                <a href="#method_attribute">attribute</a>
-
-                            </li>
-                            <li class="index-item method">
                                 <a href="#method_attributeDefinitions">attributeDefinitions</a>
 
                             </li>
@@ -150,10 +146,6 @@
                             </li>
                             <li class="index-item method">
                                 <a href="#method_defaultAttributes">defaultAttributes</a>
-
-                            </li>
-                            <li class="index-item method">
-                                <a href="#method_defaultValueForDescriptor">defaultValueForDescriptor</a>
 
                             </li>
                             <li class="index-item method">
@@ -225,15 +217,7 @@
 
                             </li>
                             <li class="index-item method">
-                                <a href="#method_validatePresence">validatePresence</a>
-
-                            </li>
-                            <li class="index-item method">
                                 <a href="#method_validateProperties">validateProperties</a>
-
-                            </li>
-                            <li class="index-item method">
-                                <a href="#method_validates">validates</a>
 
                             </li>
                     </ul>
@@ -319,7 +303,7 @@
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l649"><code>src&#x2F;Model.js:649</code></a>
+        <a href="../files/src_Model.js.html#l534"><code>src&#x2F;Model.js:534</code></a>
         </p>
 
 
@@ -367,7 +351,7 @@ and relationships of the snapshot to be applied. also reset errors</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l532"><code>src&#x2F;Model.js:532</code></a>
+        <a href="../files/src_Model.js.html#l417"><code>src&#x2F;Model.js:417</code></a>
         </p>
 
 
@@ -403,7 +387,7 @@ _dirtyAttributes set</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l515"><code>src&#x2F;Model.js:515</code></a>
+        <a href="../files/src_Model.js.html#l400"><code>src&#x2F;Model.js:400</code></a>
         </p>
 
 
@@ -441,7 +425,7 @@ observable</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l626"><code>src&#x2F;Model.js:626</code></a>
+        <a href="../files/src_Model.js.html#l511"><code>src&#x2F;Model.js:511</code></a>
         </p>
 
 
@@ -475,40 +459,6 @@ if not persisted, push this snapshot to the top of the stack</p>
 
 
 </div>
-<div id="method_attribute" class="method item">
-    <h3 class="name"><code>attribute</code></h3>
-
-        <span class="paren">()</span>
-
-
-
-
-
-
-
-
-    <div class="meta">
-                <p>
-                Defined in
-        <a href="../files/src_Model.js.html#l99"><code>src&#x2F;Model.js:99</code></a>
-        </p>
-
-
-
-    </div>
-
-    <div class="description">
-        <p>Defines attributes that will be serialized and deserialized. Takes one argument, a class that the attribute will be coerced to.
-This can be a Javascript primitive or another class. <code>id</code> cannot be defined as it is assumed to exist.
-Attributes can be defined with a default.</p>
-<pre class="code prettyprint"><code>class Todo extends Model {</code></pre>
-
-    </div>
-
-
-
-
-</div>
 <div id="method_attributeDefinitions" class="method item">
     <h3 class="name"><code>attributeDefinitions</code></h3>
 
@@ -527,7 +477,7 @@ Attributes can be defined with a default.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l715"><code>src&#x2F;Model.js:715</code></a>
+        <a href="../files/src_Model.js.html#l600"><code>src&#x2F;Model.js:600</code></a>
         </p>
 
 
@@ -568,7 +518,7 @@ Attributes can be defined with a default.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l757"><code>src&#x2F;Model.js:757</code></a>
+        <a href="../files/src_Model.js.html#l642"><code>src&#x2F;Model.js:642</code></a>
         </p>
 
 
@@ -609,7 +559,7 @@ Attributes can be defined with a default.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l697"><code>src&#x2F;Model.js:697</code></a>
+        <a href="../files/src_Model.js.html#l582"><code>src&#x2F;Model.js:582</code></a>
         </p>
 
 
@@ -649,7 +599,7 @@ Attributes can be defined with a default.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l200"><code>src&#x2F;Model.js:200</code></a>
+        <a href="../files/src_Model.js.html#l85"><code>src&#x2F;Model.js:85</code></a>
         </p>
 
 
@@ -683,7 +633,7 @@ Attributes can be defined with a default.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l777"><code>src&#x2F;Model.js:777</code></a>
+        <a href="../files/src_Model.js.html#l662"><code>src&#x2F;Model.js:662</code></a>
         </p>
 
 
@@ -706,37 +656,6 @@ Attributes can be defined with a default.</p>
 
 
 </div>
-<div id="method_defaultValueForDescriptor" class="method item">
-    <h3 class="name"><code>defaultValueForDescriptor</code></h3>
-
-        <span class="paren">()</span>
-
-
-
-
-
-
-
-
-    <div class="meta">
-                <p>
-                Defined in
-        <a href="../files/src_Model.js.html#l79"><code>src&#x2F;Model.js:79</code></a>
-        </p>
-
-
-
-    </div>
-
-    <div class="description">
-        <p>Helper method for apply the correct defaults to attributes.</p>
-
-    </div>
-
-
-
-
-</div>
 <div id="method_destroy" class="method item">
     <h3 class="name"><code>destroy</code></h3>
 
@@ -755,7 +674,7 @@ Attributes can be defined with a default.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l446"><code>src&#x2F;Model.js:446</code></a>
+        <a href="../files/src_Model.js.html#l331"><code>src&#x2F;Model.js:331</code></a>
         </p>
 
 
@@ -798,7 +717,7 @@ Attributes can be defined with a default.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l666"><code>src&#x2F;Model.js:666</code></a>
+        <a href="../files/src_Model.js.html#l551"><code>src&#x2F;Model.js:551</code></a>
         </p>
 
 
@@ -846,7 +765,7 @@ todo.dirtyAttributes
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l565"><code>src&#x2F;Model.js:565</code></a>
+        <a href="../files/src_Model.js.html#l450"><code>src&#x2F;Model.js:450</code></a>
         </p>
 
 
@@ -881,7 +800,7 @@ any event listeners and don't leak memory</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l747"><code>src&#x2F;Model.js:747</code></a>
+        <a href="../files/src_Model.js.html#l622"><code>src&#x2F;Model.js:622</code></a>
         </p>
 
 
@@ -922,7 +841,7 @@ any event listeners and don't leak memory</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l737"><code>src&#x2F;Model.js:737</code></a>
+        <a href="../files/src_Model.js.html#l632"><code>src&#x2F;Model.js:632</code></a>
         </p>
 
 
@@ -963,7 +882,7 @@ any event listeners and don't leak memory</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l794"><code>src&#x2F;Model.js:794</code></a>
+        <a href="../files/src_Model.js.html#l679"><code>src&#x2F;Model.js:679</code></a>
         </p>
 
 
@@ -1004,7 +923,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l617"><code>src&#x2F;Model.js:617</code></a>
+        <a href="../files/src_Model.js.html#l502"><code>src&#x2F;Model.js:502</code></a>
         </p>
 
 
@@ -1035,7 +954,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l606"><code>src&#x2F;Model.js:606</code></a>
+        <a href="../files/src_Model.js.html#l491"><code>src&#x2F;Model.js:491</code></a>
         </p>
 
 
@@ -1069,7 +988,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l726"><code>src&#x2F;Model.js:726</code></a>
+        <a href="../files/src_Model.js.html#l611"><code>src&#x2F;Model.js:611</code></a>
         </p>
 
 
@@ -1110,7 +1029,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l767"><code>src&#x2F;Model.js:767</code></a>
+        <a href="../files/src_Model.js.html#l652"><code>src&#x2F;Model.js:652</code></a>
         </p>
 
 
@@ -1148,7 +1067,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l342"><code>src&#x2F;Model.js:342</code></a>
+        <a href="../files/src_Model.js.html#l227"><code>src&#x2F;Model.js:227</code></a>
         </p>
 
 
@@ -1187,7 +1106,7 @@ kpi.name
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l359"><code>src&#x2F;Model.js:359</code></a>
+        <a href="../files/src_Model.js.html#l244"><code>src&#x2F;Model.js:244</code></a>
         </p>
 
 
@@ -1228,7 +1147,7 @@ state if the model was never persisted</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l369"><code>src&#x2F;Model.js:369</code></a>
+        <a href="../files/src_Model.js.html#l254"><code>src&#x2F;Model.js:254</code></a>
         </p>
 
 
@@ -1282,7 +1201,7 @@ state if the model was never persisted</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l597"><code>src&#x2F;Model.js:597</code></a>
+        <a href="../files/src_Model.js.html#l482"><code>src&#x2F;Model.js:482</code></a>
         </p>
 
 
@@ -1316,7 +1235,7 @@ state if the model was never persisted</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l575"><code>src&#x2F;Model.js:575</code></a>
+        <a href="../files/src_Model.js.html#l460"><code>src&#x2F;Model.js:460</code></a>
         </p>
 
 
@@ -1368,7 +1287,7 @@ snapshot.title
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l687"><code>src&#x2F;Model.js:687</code></a>
+        <a href="../files/src_Model.js.html#l572"><code>src&#x2F;Model.js:572</code></a>
         </p>
 
 
@@ -1417,7 +1336,7 @@ snapshot.title
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l422"><code>src&#x2F;Model.js:422</code></a>
+        <a href="../files/src_Model.js.html#l307"><code>src&#x2F;Model.js:307</code></a>
         </p>
 
 
@@ -1461,59 +1380,6 @@ Default is to check all validations, but they can be selectively run via options
 
 
 </div>
-<div id="method_validatePresence" class="method item">
-    <h3 class="name"><code>validatePresence</code></h3>
-
-        <div class="args">
-            <span class="paren">(</span><ul class="args-list inline commas">
-                <li class="arg">
-                        <code>value</code>
-                </li>
-            </ul><span class="paren">)</span>
-        </div>
-
-
-
-
-
-
-
-
-    <div class="meta">
-                <p>
-                Defined in
-        <a href="../files/src_Model.js.html#l26"><code>src&#x2F;Model.js:26</code></a>
-        </p>
-
-
-
-    </div>
-
-    <div class="description">
-        <p>returns <code>true</code> as long as the <code>value</code> is not <code>null</code>, <code>undefined</code>, or <code>''</code></p>
-
-    </div>
-
-        <div class="params">
-            <h4>Parameters:</h4>
-
-            <ul class="params-list">
-                <li class="param">
-                        <code class="param-name">value</code>
-                        <span class="type">Object</span>
-
-
-                    <div class="param-description">
-                         
-                    </div>
-
-                </li>
-            </ul>
-        </div>
-
-
-
-</div>
 <div id="method_validateProperties" class="method item">
     <h3 class="name"><code>validateProperties</code></h3>
 
@@ -1544,7 +1410,7 @@ Default is to check all validations, but they can be selectively run via options
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l42"><code>src&#x2F;Model.js:42</code></a>
+        <a href="../files/src_Model.js.html#l20"><code>src&#x2F;Model.js:20</code></a>
         </p>
 
 
@@ -1608,45 +1474,6 @@ Default is to check all validations, but they can be selectively run via options
 
 
 </div>
-<div id="method_validates" class="method item">
-    <h3 class="name"><code>validates</code></h3>
-
-        <span class="paren">()</span>
-
-
-
-
-
-
-
-
-    <div class="meta">
-                <p>
-                Defined in
-        <a href="../files/src_Model.js.html#l133"><code>src&#x2F;Model.js:133</code></a>
-        </p>
-
-
-
-    </div>
-
-    <div class="description">
-        <p>Defines validations for attributes that will be applied before saving. Takes one argument, a function to validate
-the attribute. The default validator is <code>presence</code>: not <code>null</code>, <code>undefined</code>, or <code>''</code>.</p>
-<pre class="code prettyprint"><code>function nonzero(value =&gt; value !== 0)
-
-class Todo extends Model {
-  <code>@validates</code>
-  <code>@attribute</code>(nonzero) numberOfAssignees
-}
-</code></pre>
-
-    </div>
-
-
-
-
-</div>
             </div>
 
             <div id="properties" class="api-class-tabpanel">
@@ -1663,7 +1490,7 @@ class Todo extends Model {
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l240"><code>src&#x2F;Model.js:240</code></a>
+        <a href="../files/src_Model.js.html#l125"><code>src&#x2F;Model.js:125</code></a>
         </p>
 
 
@@ -1688,7 +1515,7 @@ class Todo extends Model {
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l233"><code>src&#x2F;Model.js:233</code></a>
+        <a href="../files/src_Model.js.html#l118"><code>src&#x2F;Model.js:118</code></a>
         </p>
 
 
@@ -1713,7 +1540,7 @@ class Todo extends Model {
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l225"><code>src&#x2F;Model.js:225</code></a>
+        <a href="../files/src_Model.js.html#l110"><code>src&#x2F;Model.js:110</code></a>
         </p>
 
 
@@ -1740,7 +1567,7 @@ class Todo extends Model {
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l218"><code>src&#x2F;Model.js:218</code></a>
+        <a href="../files/src_Model.js.html#l103"><code>src&#x2F;Model.js:103</code></a>
         </p>
 
 
@@ -1766,7 +1593,7 @@ Defaults to the underscored version of the class name</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l320"><code>src&#x2F;Model.js:320</code></a>
+        <a href="../files/src_Model.js.html#l205"><code>src&#x2F;Model.js:205</code></a>
         </p>
 
 
@@ -1796,7 +1623,7 @@ kpi.errors
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l282"><code>src&#x2F;Model.js:282</code></a>
+        <a href="../files/src_Model.js.html#l167"><code>src&#x2F;Model.js:167</code></a>
         </p>
 
 
@@ -1821,7 +1648,7 @@ kpi.errors
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l247"><code>src&#x2F;Model.js:247</code></a>
+        <a href="../files/src_Model.js.html#l132"><code>src&#x2F;Model.js:132</code></a>
         </p>
 
 
@@ -1867,7 +1694,7 @@ kpi.isDirty
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l303"><code>src&#x2F;Model.js:303</code></a>
+        <a href="../files/src_Model.js.html#l188"><code>src&#x2F;Model.js:188</code></a>
         </p>
 
 
@@ -1901,7 +1728,7 @@ kpi.isInFlight
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l291"><code>src&#x2F;Model.js:291</code></a>
+        <a href="../files/src_Model.js.html#l176"><code>src&#x2F;Model.js:176</code></a>
         </p>
 
 
@@ -1926,7 +1753,7 @@ kpi.isInFlight
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l333"><code>src&#x2F;Model.js:333</code></a>
+        <a href="../files/src_Model.js.html#l218"><code>src&#x2F;Model.js:218</code></a>
         </p>
 
 
@@ -1953,7 +1780,7 @@ kpi.isInFlight
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l210"><code>src&#x2F;Model.js:210</code></a>
+        <a href="../files/src_Model.js.html#l95"><code>src&#x2F;Model.js:95</code></a>
         </p>
 
 

--- a/docs/classes/RelatedRecordsArray.html
+++ b/docs/classes/RelatedRecordsArray.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.0.25</em>
+            <em>API Docs for: 1.0.26</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Schema.html
+++ b/docs/classes/Schema.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.0.25</em>
+            <em>API Docs for: 1.0.26</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Store.html
+++ b/docs/classes/Store.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.0.25</em>
+            <em>API Docs for: 1.0.26</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -1097,8 +1097,8 @@ first look for the local result (unless <code>fromServer</code> is <code>true</c
 <p>store.findAll('todos', {
 queryParams: {
 filter: {
-start_time: moment(),
-end_time: moment()
+start_time: '2020-06-01T00:00:00.000Z',
+end_time: '2020-06-02T00:00:00.000Z'
 }
 }
 })</p>

--- a/docs/data.json
+++ b/docs/data.json
@@ -3,7 +3,7 @@
         "name": "mobx-async-store",
         "description": "Asyc Data Store for mobx",
         "url": "https://github.com/artemis-ag/mobx-async-store",
-        "version": "1.0.25"
+        "version": "1.0.26"
     },
     "files": {
         "src/decorators/attributes.js": {
@@ -98,7 +98,7 @@
             "plugin_for": [],
             "extension_for": [],
             "file": "src/Model.js",
-            "line": 196
+            "line": 81
         },
         "Store": {
             "name": "Store",
@@ -295,21 +295,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 26,
-            "description": "returns `true` as long as the `value` is not `null`, `undefined`, or `''`",
-            "itemtype": "method",
-            "name": "validatePresence",
-            "params": [
-                {
-                    "name": "value",
-                    "description": ""
-                }
-            ],
-            "class": "Model"
-        },
-        {
-            "file": "src/Model.js",
-            "line": 42,
+            "line": 20,
             "description": "Maps the passed-in property names through and runs validations against those properties",
             "itemtype": "method",
             "name": "validateProperties",
@@ -338,31 +324,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 79,
-            "description": "Helper method for apply the correct defaults to attributes.",
-            "itemtype": "method",
-            "name": "defaultValueForDescriptor",
-            "class": "Model"
-        },
-        {
-            "file": "src/Model.js",
-            "line": 99,
-            "description": "Defines attributes that will be serialized and deserialized. Takes one argument, a class that the attribute will be coerced to.\nThis can be a Javascript primitive or another class. `id` cannot be defined as it is assumed to exist.\nAttributes can be defined with a default.\n```\nclass Todo extends Model {",
-            "itemtype": "method",
-            "name": "attribute",
-            "class": "Model"
-        },
-        {
-            "file": "src/Model.js",
-            "line": 133,
-            "description": "Defines validations for attributes that will be applied before saving. Takes one argument, a function to validate\nthe attribute. The default validator is `presence`: not `null`, `undefined`, or `''`.\n```\nfunction nonzero(value => value !== 0)\n\nclass Todo extends Model {\n  `@validates`\n  `@attribute`(nonzero) numberOfAssignees\n}\n```",
-            "itemtype": "method",
-            "name": "validates",
-            "class": "Model"
-        },
-        {
-            "file": "src/Model.js",
-            "line": 200,
+            "line": 85,
             "description": "Initializer for model",
             "itemtype": "method",
             "name": "constructor",
@@ -370,7 +332,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 210,
+            "line": 95,
             "description": "The type of the model. Defined on the class. Defaults to the underscored version of the class name\n(eg 'calendar_events').",
             "itemtype": "property",
             "name": "type",
@@ -379,7 +341,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 218,
+            "line": 103,
             "description": "The canonical path to the resource on the server. Defined on the class.\nDefaults to the underscored version of the class name",
             "itemtype": "property",
             "name": "endpoint",
@@ -388,7 +350,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 225,
+            "line": 110,
             "description": "has this object been destroyed?",
             "itemtype": "property",
             "name": "_disposed",
@@ -398,7 +360,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 233,
+            "line": 118,
             "description": "set of relationships which have changed since last snapshot",
             "itemtype": "property",
             "name": "_dirtyRelationships",
@@ -407,7 +369,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 240,
+            "line": 125,
             "description": "set of attributes which have changed since last snapshot",
             "itemtype": "property",
             "name": "_dirtyAttributes",
@@ -416,7 +378,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 247,
+            "line": 132,
             "description": "True if the instance has been modified from its persisted state\n\nNOTE that isDirty does _NOT_ track changes to the related objects\nbut it _does_ track changes to the relationships themselves.\n\nFor example, adding or removing a related object will mark this record as dirty,\nbut changing a related object's properties will not mark this record as dirty.\n\nThe caller is reponsible for asking related objects about their\nown dirty state.\n\n```\nkpi = store.add('kpis', { name: 'A good thing to measure' })\nkpi.isDirty\n=> true\nkpi.name\n=> \"A good thing to measure\"\nawait kpi.save()\nkpi.isDirty\n=> false\nkpi.name = \"Another good thing to measure\"\nkpi.isDirty\n=> true\nawait kpi.save()\nkpi.isDirty\n=> false\n```",
             "itemtype": "property",
             "name": "isDirty",
@@ -425,7 +387,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 282,
+            "line": 167,
             "description": "have any changes been made since this record was last persisted?",
             "itemtype": "property",
             "name": "hasUnpersistedChanges",
@@ -434,7 +396,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 291,
+            "line": 176,
             "description": "True if the model has not been sent to the store",
             "itemtype": "property",
             "name": "isNew",
@@ -443,7 +405,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 303,
+            "line": 188,
             "description": "True if the instance is coming from / going to the server\n```\nkpi = store.find('kpis', 5)\n// fetch started\nkpi.isInFlight\n=> true\n// fetch finished\nkpi.isInFlight\n=> false\n```",
             "itemtype": "property",
             "name": "isInFlight",
@@ -453,7 +415,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 320,
+            "line": 205,
             "description": "A hash of errors from the server\n```\nkpi = store.find('kpis', 5)\nkpi.errors\n=> { authorization: \"You do not have access to this resource\" }\n```",
             "itemtype": "property",
             "name": "errors",
@@ -463,7 +425,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 333,
+            "line": 218,
             "description": "a list of snapshots that have been taken since the record was either last persisted or since it was instantiated",
             "itemtype": "property",
             "name": "snapshots",
@@ -473,7 +435,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 342,
+            "line": 227,
             "description": "restores data to its last snapshot state\n```\nkpi = store.find('kpis', 5)\nkpi.name\n=> \"A good thing to measure\"\nkpi.name = \"Another good thing to measure\"\nkpi.rollback()\nkpi.name\n=> \"A good thing to measure\"\n```",
             "itemtype": "method",
             "name": "rollback",
@@ -481,7 +443,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 359,
+            "line": 244,
             "description": "restores data to its last persisted state or the oldest snapshot\nstate if the model was never persisted",
             "itemtype": "method",
             "name": "rollbackToPersisted",
@@ -489,7 +451,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 369,
+            "line": 254,
             "description": "creates or updates a record.",
             "itemtype": "method",
             "name": "save",
@@ -508,7 +470,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 422,
+            "line": 307,
             "description": "Checks all validations, adding errors where necessary and returning `false` if any are not valid\nDefault is to check all validations, but they can be selectively run via options:\n - attributes - an array of names of attributes to validate\n - relationships - an array of names of relationships to validate",
             "itemtype": "method",
             "name": "validate",
@@ -527,7 +489,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 446,
+            "line": 331,
             "description": "deletes a record from the store and server",
             "itemtype": "method",
             "name": "destroy",
@@ -539,7 +501,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 515,
+            "line": 400,
             "description": "Magic method that makes changes to records\nobservable",
             "itemtype": "method",
             "name": "_makeObservable",
@@ -547,7 +509,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 532,
+            "line": 417,
             "description": "sets up a reaction for each top-level attribute so we can compare\nvalues after each mutation and keep track of dirty attr states\nif an attr is different than the last snapshot, add it to the\n_dirtyAttributes set\nif it's the same as the last snapshot, make sure it's _not_ in the\n_dirtyAttributes set",
             "itemtype": "method",
             "name": "_listenForChanges",
@@ -555,7 +517,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 565,
+            "line": 450,
             "description": "call this when destroying an object to make sure that we clean up\nany event listeners and don't leak memory",
             "itemtype": "method",
             "name": "dispose",
@@ -563,7 +525,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 575,
+            "line": 460,
             "description": "The current state of defined attributes and relationships of the instance\nReally just an alias for attributes\n```\ntodo = store.find('todos', 5)\ntodo.title\n=> \"Buy the eggs\"\nsnapshot = todo.snapshot\ntodo.title = \"Buy the eggs and bacon\"\nsnapshot.title\n=> \"Buy the eggs and bacon\"\n```",
             "itemtype": "method",
             "name": "snapshot",
@@ -575,7 +537,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 597,
+            "line": 482,
             "description": "Sets previous snapshot to current snapshot",
             "itemtype": "method",
             "name": "setPreviousSnapshot",
@@ -583,7 +545,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 606,
+            "line": 491,
             "description": "the latest snapshot",
             "itemtype": "method",
             "name": "previousSnapshot",
@@ -591,7 +553,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 617,
+            "line": 502,
             "description": "the latest persisted snapshot or the first snapshot if the model was never persisted",
             "itemtype": "method",
             "name": "previousSnapshot",
@@ -599,7 +561,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 626,
+            "line": 511,
             "description": "take a snapshot of the current model state.\nif persisted, clear the stack and push this snapshot to the top\nif not persisted, push this snapshot to the top of the stack",
             "itemtype": "method",
             "name": "_takeSnapshot",
@@ -614,7 +576,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 649,
+            "line": 534,
             "description": "set the current attributes and relationships to the attributes\nand relationships of the snapshot to be applied. also reset errors",
             "itemtype": "method",
             "name": "_applySnapshot",
@@ -629,7 +591,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 666,
+            "line": 551,
             "description": "a list of any property paths which have been changed since the previous\nsnapshot\n```\nconst todo = new Todo({ title: 'Buy Milk' })\ntodo.dirtyAttributes\n=> []\ntodo.title = 'Buy Cheese'\ntodo.dirtyAttributes\n=> ['title']\n```",
             "itemtype": "method",
             "name": "dirtyAttributes",
@@ -641,7 +603,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 687,
+            "line": 572,
             "description": "shortcut to get the static",
             "itemtype": "method",
             "name": "type",
@@ -653,7 +615,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 697,
+            "line": 582,
             "description": "current attributes of record",
             "itemtype": "method",
             "name": "attributes",
@@ -665,7 +627,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 715,
+            "line": 600,
             "description": "Getter find the attribute definition for the model type.",
             "itemtype": "method",
             "name": "attributeDefinitions",
@@ -677,7 +639,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 726,
+            "line": 611,
             "description": "Getter find the relationship definitions for the model type.",
             "itemtype": "method",
             "name": "relationshipDefinitions",
@@ -689,7 +651,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 737,
+            "line": 622,
             "description": "Getter to check if the record has errors.",
             "itemtype": "method",
             "name": "hasErrors",
@@ -701,7 +663,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 747,
+            "line": 632,
             "description": "Getter to check if the record has errors.",
             "itemtype": "method",
             "name": "hasErrors",
@@ -713,7 +675,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 757,
+            "line": 642,
             "description": "Getter to just get the names of a records attributes.",
             "itemtype": "method",
             "name": "attributeNames",
@@ -725,7 +687,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 767,
+            "line": 652,
             "description": "Getter to just get the names of a records relationships.",
             "itemtype": "method",
             "name": "relationshipNames",
@@ -737,7 +699,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 777,
+            "line": 662,
             "description": "getter method to get the default attributes",
             "itemtype": "method",
             "name": "defaultAttributes",
@@ -749,7 +711,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 794,
+            "line": 679,
             "description": "getter method to get data in api compliance format\nTODO: Figure out how to handle unpersisted ids",
             "itemtype": "method",
             "name": "jsonapi",
@@ -918,7 +880,7 @@
         {
             "file": "src/Store.js",
             "line": 161,
-            "description": "finds all of the instances of a given type. If there are instances available in the store,\nit will return those, otherwise it will trigger a fetch\n\n  store.findAll('todos')\n  // fetch triggered\n  => [event1, event2, event3]\n  store.findAll('todos')\n  // no fetch triggered\n  => [event1, event2, event3]\n\npassing `fromServer` as an option will always trigger a\nfetch if `true` and never trigger a fetch if `false`.\nOtherwise, it will trigger the default behavior\n\n  store.findAll('todos', { fromServer: false })\n  // no fetch triggered\n  => []\n\n  store.findAll('todos')\n  // fetch triggered\n  => [event1, event2, event3]\n\n  // async stuff happens on the server\n  store.findAll('todos')\n  // no fetch triggered\n  => [event1, event2, event3]\n\n  store.findAll('todos', { fromServer: true })\n  // fetch triggered\n  => [event1, event2, event3, event4]\n\nQuery params can be passed as part of the options hash.\nThe response will be cached, so the next time `findAll`\nis called with identical params and values, the store will\nfirst look for the local result (unless `fromServer` is `true`)\n\n  store.findAll('todos', {\n    queryParams: {\n      filter: {\n        start_time: moment(),\n        end_time: moment()\n      }\n    }\n  })",
+            "description": "finds all of the instances of a given type. If there are instances available in the store,\nit will return those, otherwise it will trigger a fetch\n\n  store.findAll('todos')\n  // fetch triggered\n  => [event1, event2, event3]\n  store.findAll('todos')\n  // no fetch triggered\n  => [event1, event2, event3]\n\npassing `fromServer` as an option will always trigger a\nfetch if `true` and never trigger a fetch if `false`.\nOtherwise, it will trigger the default behavior\n\n  store.findAll('todos', { fromServer: false })\n  // no fetch triggered\n  => []\n\n  store.findAll('todos')\n  // fetch triggered\n  => [event1, event2, event3]\n\n  // async stuff happens on the server\n  store.findAll('todos')\n  // no fetch triggered\n  => [event1, event2, event3]\n\n  store.findAll('todos', { fromServer: true })\n  // fetch triggered\n  => [event1, event2, event3, event4]\n\nQuery params can be passed as part of the options hash.\nThe response will be cached, so the next time `findAll`\nis called with identical params and values, the store will\nfirst look for the local result (unless `fromServer` is `true`)\n\n  store.findAll('todos', {\n    queryParams: {\n      filter: {\n        start_time: '2020-06-01T00:00:00.000Z',\n        end_time: '2020-06-02T00:00:00.000Z'\n      }\n    }\n  })",
             "itemtype": "method",
             "name": "findAll",
             "params": [
@@ -1552,6 +1514,25 @@
         {
             "file": "src/utils.js",
             "line": 147,
+            "description": "convert a value into a date, pass Date or Moment instances thru\nuntouched",
+            "itemtype": "method",
+            "name": "makeDate",
+            "params": [
+                {
+                    "name": "value",
+                    "description": "",
+                    "type": "*"
+                }
+            ],
+            "return": {
+                "description": "",
+                "type": "Date|Moment"
+            },
+            "class": ""
+        },
+        {
+            "file": "src/utils.js",
+            "line": 159,
             "description": "recursively walk an object and call the `iteratee` function for\neach property. returns an array of results of calls to the iteratee.",
             "itemtype": "method",
             "name": "walk",
@@ -1579,7 +1560,7 @@
         },
         {
             "file": "src/utils.js",
-            "line": 165,
+            "line": 177,
             "description": "deeply compare objects a and b and return object paths for attributes\nwhich differ. it is important to note that this comparison is biased\ntoward object a. object a is walked and compared against values in\nobject b. if a property exists in object b, but not in object a, it\nwill not be counted as a difference.",
             "itemtype": "method",
             "name": "diff",

--- a/docs/files/src_Model.js.html
+++ b/docs/files/src_Model.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.0.25</em>
+            <em>API Docs for: 1.0.26</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -93,9 +93,7 @@ import {
   observable
 } from &#x27;mobx&#x27;
 
-import moment from &#x27;moment&#x27;
-
-import { diff } from &#x27;./utils&#x27;
+import { diff, makeDate } from &#x27;./utils&#x27;
 
 import ObjectPromiseProxy from &#x27;./ObjectPromiseProxy&#x27;
 import schema from &#x27;./schema&#x27;
@@ -103,26 +101,6 @@ import cloneDeep from &#x27;lodash/cloneDeep&#x27;
 import isEqual from &#x27;lodash/isEqual&#x27;
 import isObject from &#x27;lodash/isObject&#x27;
 import findLast from &#x27;lodash/findLast&#x27;
-
-function isPresent (value) {
-  return value !== null &amp;&amp; value !== undefined &amp;&amp; value !== &#x27;&#x27;
-}
-
-/**
- * returns &#x60;true&#x60; as long as the &#x60;value&#x60; is not &#x60;null&#x60;, &#x60;undefined&#x60;, or &#x60;&#x27;&#x27;&#x60;
- * @method validatePresence
- * @param value
- */
-
-function validatePresence (value) {
-  return {
-    isValid: isPresent(value),
-    errors: [{
-      key: &#x27;blank&#x27;,
-      message: &#x27;can\&#x27;t be blank&#x27;
-    }]
-  }
-}
 
 /**
  * Maps the passed-in property names through and runs validations against those properties
@@ -160,99 +138,6 @@ function stringifyIds (object) {
     }
   })
 }
-
-/**
- * Helper method for apply the correct defaults to attributes.
- * @method defaultValueForDescriptor
- */
-function defaultValueForDescriptor (descriptor, DataType) {
-  if (typeof descriptor.initializer === &#x27;function&#x27;) {
-    const value = descriptor.initializer()
-    if (DataType.name === &#x27;Date&#x27;) {
-      return moment(value).toDate()
-    } else {
-      return DataType(value)
-    }
-  }
-
-  if (DataType.name === &#x27;String&#x27;) return &#x27;&#x27;
-  if (DataType.name === &#x27;Array&#x27;) return []
-
-  return null
-}
-
-/**
- * Defines attributes that will be serialized and deserialized. Takes one argument, a class that the attribute will be coerced to.
- * This can be a Javascript primitive or another class. &#x60;id&#x60; cannot be defined as it is assumed to exist.
- * Attributes can be defined with a default.
- * &#x60;&#x60;&#x60;
- * class Todo extends Model {
- *   @attribute(Date) start_time = moment()
- * }
- * &#x60;&#x60;&#x60;
- * @method attribute
- */
-export function attribute (dataType = (obj) =&gt; obj) {
-  return function (target, property, descriptor) {
-    const { type } = target.constructor
-    const defaultValue = defaultValueForDescriptor(descriptor, dataType)
-    // Update the schema
-    schema.addAttribute({
-      dataType,
-      defaultValue,
-      property,
-      type
-    })
-    // Return custom descriptor
-    return {
-      get () {
-        return defaultValue
-      },
-      set (value) {
-        set(target, property, value)
-      }
-    }
-  }
-}
-
-/**
- * Defines validations for attributes that will be applied before saving. Takes one argument, a function to validate
- * the attribute. The default validator is &#x60;presence&#x60;: not &#x60;null&#x60;, &#x60;undefined&#x60;, or &#x60;&#x27;&#x27;&#x60;.
- * &#x60;&#x60;&#x60;
- * function nonzero(value =&gt; value !== 0)
- *
- * class Todo extends Model {
- *   &#x60;@validates&#x60;
- *   &#x60;@attribute&#x60;(nonzero) numberOfAssignees
- * }
- * &#x60;&#x60;&#x60;
- * @method validates
- */
-
- export function validates (target, property) {
-   let validator = validatePresence
-
-   if (typeof target === &#x27;function&#x27;) {
-     validator = target
-
-     return function (target, property) {
-       const { type } = target.constructor
-
-       schema.addValidation({
-         property,
-         type,
-         validator
-       })
-     }
-   } else {
-     const { type } = target.constructor
-     schema.addValidation({
-       property,
-       type,
-       validator
-     })
-   }
- }
 
 /*
  * Defines a many-to-one relationship. Defaults to the class with camelized name of the property.
@@ -908,7 +793,7 @@ class Model {
         if (DataType.name === &#x27;Array&#x27; || DataType.name === &#x27;Object&#x27;) {
           attr = toJS(value)
         } else if (DataType.name === &#x27;Date&#x27;) {
-          attr = moment(value).toISOString()
+          attr = makeDate(value).toISOString()
         } else {
           attr = DataType(value)
         }

--- a/docs/files/src_Store.js.html
+++ b/docs/files/src_Store.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.0.25</em>
+            <em>API Docs for: 1.0.26</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -283,8 +283,8 @@ class Store {
    *   store.findAll(&#x27;todos&#x27;, {
    *     queryParams: {
    *       filter: {
-   *         start_time: moment(),
-   *         end_time: moment()
+   *         start_time: &#x27;2020-06-01T00:00:00.000Z&#x27;,
+   *         end_time: &#x27;2020-06-02T00:00:00.000Z&#x27;
    *       }
    *     }
    *   })

--- a/docs/files/src_decorators_attributes.js.html
+++ b/docs/files/src_decorators_attributes.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.0.25</em>
+            <em>API Docs for: 1.0.26</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -83,9 +83,9 @@
 
 <div class="file">
     <pre class="code prettyprint linenums">
-import moment from &#x27;moment&#x27;
 import { set } from &#x27;mobx&#x27;
 import schema from &#x27;../schema&#x27;
+import { makeDate } from &#x27;../utils&#x27;
 
 /**
  * returns &#x60;true&#x60; as long as the &#x60;value&#x60; is not &#x60;null&#x60;, &#x60;undefined&#x60;, or &#x60;&#x27;&#x27;&#x60;
@@ -121,7 +121,7 @@ function defaultValueForDescriptor (descriptor, DataType) {
   if (typeof descriptor.initializer === &#x27;function&#x27;) {
     const value = descriptor.initializer()
     if (DataType.name === &#x27;Date&#x27;) {
-      return moment(value).toDate()
+      return makeDate(value)
     } else {
       return DataType(value)
     }
@@ -139,7 +139,7 @@ function defaultValueForDescriptor (descriptor, DataType) {
  * Attributes can be defined with a default.
  * &#x60;&#x60;&#x60;
  * class Todo extends Model {
- *   @attribute(Date) start_time = moment()
+ *   @attribute(Date) start_time = new Date()
  * }
  * &#x60;&#x60;&#x60;
  * @method attribute

--- a/docs/files/src_decorators_relationships.js.html
+++ b/docs/files/src_decorators_relationships.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.0.25</em>
+            <em>API Docs for: 1.0.26</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_schema.js.html
+++ b/docs/files/src_schema.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.0.25</em>
+            <em>API Docs for: 1.0.26</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_utils.js.html
+++ b/docs/files/src_utils.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.0.25</em>
+            <em>API Docs for: 1.0.26</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -227,6 +227,18 @@ export function stringifyIds (object) {
       stringifyIds(property)
     }
   })
+}
+
+/**
+ * convert a value into a date, pass Date or Moment instances thru
+ * untouched
+ * @method makeDate
+ * @param {*} value
+ * @return {Date|Moment}
+ */
+export function makeDate (value) {
+  if (value instanceof Date || value._isAMomentObject) return value
+  return new Date(Date.parse(value)).toISOString()
 }
 
 /**

--- a/docs/files/src_utils.js.html
+++ b/docs/files/src_utils.js.html
@@ -238,7 +238,7 @@ export function stringifyIds (object) {
  */
 export function makeDate (value) {
   if (value instanceof Date || value._isAMomentObject) return value
-  return new Date(Date.parse(value)).toISOString()
+  return new Date(Date.parse(value))
 }
 
 /**

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
                 <h1><img src="./assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.0.25</em>
+            <em>API Docs for: 1.0.26</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "jsonapi-serializer": "^3.6.4",
     "lodash": "^4.17.15",
     "mobx": "5.5.0",
-    "moment": "^2.24.0",
     "pluralize": "^8.0.0",
     "react-native-uuid": "^1.4.9",
     "uuid": "^3.3.2"
@@ -38,7 +37,6 @@
     "jest-fetch-mock": "^2.1.2",
     "mobx": "5.5.0",
     "mobx-react": "^5.4.3",
-    "moment": "^2.24.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "rollup": "^1.0.0",

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -1,6 +1,5 @@
 /* global fetch */
 import { autorun, isObservable } from 'mobx'
-import moment from 'moment'
 
 import {
   Model,
@@ -18,8 +17,7 @@ import {
   exampleRelatedToManyIncludedWithNoiseResponse
 } from './fixtures/exampleRelationalResponses'
 
-// YYYY-MM-DD
-const timestamp = moment()
+const timestamp = new Date(Date.now())
 
 class Note extends Model {
   static type = 'notes'
@@ -137,7 +135,8 @@ const mockTodoData = {
     type: 'organizations',
     attributes: {
       title: 'Do taxes',
-      created_at: timestamp.format('YYYY-MM-DD')
+      // YYYY-MM-DD
+      created_at: timestamp.toISOString().split('T')[0]
     }
   }
 }
@@ -469,7 +468,7 @@ describe('Model', () => {
     it('a snapshot of the current attributes and relationship', async () => {
       const todo = new Organization({ title: 'Buy Milk' })
       expect(todo.snapshot.attributes).toEqual({
-        due_at: moment(timestamp).toDate(),
+        due_at: timestamp,
         tags: [],
         title: 'Buy Milk',
         options: {}
@@ -479,7 +478,7 @@ describe('Model', () => {
     it('doesn\'t exclude falsey values', async () => {
       const todo = new Organization({ title: '' })
       expect(todo.snapshot.attributes).toEqual({
-        due_at: moment(timestamp).toDate(),
+        due_at: timestamp,
         tags: [],
         title: '',
         options: {}
@@ -492,7 +491,7 @@ describe('Model', () => {
       const todo = new Organization({ title: 'Buy Milk' })
       todo.title = 'something different'
       expect(todo.previousSnapshot.attributes).toEqual({
-        due_at: moment(timestamp).toDate(),
+        due_at: timestamp,
         tags: [],
         title: 'Buy Milk',
         options: {}
@@ -627,7 +626,7 @@ describe('Model', () => {
           id: '1',
           type: 'organizations',
           attributes: {
-            due_at: moment(timestamp).toISOString(),
+            due_at: timestamp.toISOString(),
             tags: [],
             title: 'Buy Milk',
             options: {}
@@ -651,7 +650,7 @@ describe('Model', () => {
           id: '11',
           type: 'organizations',
           attributes: {
-            due_at: moment(timestamp).toISOString(),
+            due_at: timestamp.toISOString(),
             tags: [],
             title: 'Buy Milk',
             options: {}
@@ -921,7 +920,7 @@ describe('Model', () => {
         data: {
           type: 'organizations',
           attributes: {
-            due_at: moment(timestamp).toDate().toISOString(),
+            due_at: timestamp.toISOString(),
             tags: [],
             title: 'Buy Milk',
             options: {}
@@ -932,8 +931,9 @@ describe('Model', () => {
       // from the server
       expect(todo.id).toEqual('1')
       // Check that the `created_at` attribute is populated
+      // YYYY-MM-DD
       expect(todo.created_at)
-        .toEqual(timestamp.format('YYYY-MM-DD'))
+        .toEqual(timestamp.toISOString().split('T')[0])
     })
 
     it('sets hasUnpersistedChanges = false when save succeeds', async () => {

--- a/src/Model.js
+++ b/src/Model.js
@@ -8,9 +8,7 @@ import {
   observable
 } from 'mobx'
 
-import moment from 'moment'
-
-import { diff } from './utils'
+import { diff, makeDate } from './utils'
 
 import ObjectPromiseProxy from './ObjectPromiseProxy'
 import schema from './schema'
@@ -710,7 +708,7 @@ class Model {
         if (DataType.name === 'Array' || DataType.name === 'Object') {
           attr = toJS(value)
         } else if (DataType.name === 'Date') {
-          attr = moment(value).toISOString()
+          attr = makeDate(value).toISOString()
         } else {
           attr = DataType(value)
         }

--- a/src/Model.js
+++ b/src/Model.js
@@ -19,26 +19,6 @@ import isEqual from 'lodash/isEqual'
 import isObject from 'lodash/isObject'
 import findLast from 'lodash/findLast'
 
-function isPresent (value) {
-  return value !== null && value !== undefined && value !== ''
-}
-
-/**
- * returns `true` as long as the `value` is not `null`, `undefined`, or `''`
- * @method validatePresence
- * @param value
- */
-
-function validatePresence (value) {
-  return {
-    isValid: isPresent(value),
-    errors: [{
-      key: 'blank',
-      message: 'can\'t be blank'
-    }]
-  }
-}
-
 /**
  * Maps the passed-in property names through and runs validations against those properties
  * @method validateProperties
@@ -75,99 +55,6 @@ function stringifyIds (object) {
     }
   })
 }
-
-/**
- * Helper method for apply the correct defaults to attributes.
- * @method defaultValueForDescriptor
- */
-function defaultValueForDescriptor (descriptor, DataType) {
-  if (typeof descriptor.initializer === 'function') {
-    const value = descriptor.initializer()
-    if (DataType.name === 'Date') {
-      return moment(value).toDate()
-    } else {
-      return DataType(value)
-    }
-  }
-
-  if (DataType.name === 'String') return ''
-  if (DataType.name === 'Array') return []
-
-  return null
-}
-
-/**
- * Defines attributes that will be serialized and deserialized. Takes one argument, a class that the attribute will be coerced to.
- * This can be a Javascript primitive or another class. `id` cannot be defined as it is assumed to exist.
- * Attributes can be defined with a default.
- * ```
- * class Todo extends Model {
- *   @attribute(Date) start_time = moment()
- * }
- * ```
- * @method attribute
- */
-export function attribute (dataType = (obj) => obj) {
-  return function (target, property, descriptor) {
-    const { type } = target.constructor
-    const defaultValue = defaultValueForDescriptor(descriptor, dataType)
-    // Update the schema
-    schema.addAttribute({
-      dataType,
-      defaultValue,
-      property,
-      type
-    })
-    // Return custom descriptor
-    return {
-      get () {
-        return defaultValue
-      },
-      set (value) {
-        set(target, property, value)
-      }
-    }
-  }
-}
-
-/**
- * Defines validations for attributes that will be applied before saving. Takes one argument, a function to validate
- * the attribute. The default validator is `presence`: not `null`, `undefined`, or `''`.
- * ```
- * function nonzero(value => value !== 0)
- *
- * class Todo extends Model {
- *   `@validates`
- *   `@attribute`(nonzero) numberOfAssignees
- * }
- * ```
- * @method validates
- */
-
- export function validates (target, property) {
-   let validator = validatePresence
-
-   if (typeof target === 'function') {
-     validator = target
-
-     return function (target, property) {
-       const { type } = target.constructor
-
-       schema.addValidation({
-         property,
-         type,
-         validator
-       })
-     }
-   } else {
-     const { type } = target.constructor
-     schema.addValidation({
-       property,
-       type,
-       validator
-     })
-   }
- }
 
 /*
  * Defines a many-to-one relationship. Defaults to the class with camelized name of the property.

--- a/src/Store.js
+++ b/src/Store.js
@@ -198,8 +198,8 @@ class Store {
    *   store.findAll('todos', {
    *     queryParams: {
    *       filter: {
-   *         start_time: moment(),
-   *         end_time: moment()
+   *         start_time: '2020-06-01T00:00:00.000Z',
+   *         end_time: '2020-06-02T00:00:00.000Z'
    *       }
    *     }
    *   })

--- a/src/decorators/attributes.js
+++ b/src/decorators/attributes.js
@@ -1,6 +1,6 @@
-import moment from 'moment'
 import { set } from 'mobx'
 import schema from '../schema'
+import { makeDate } from '../utils'
 
 /**
  * returns `true` as long as the `value` is not `null`, `undefined`, or `''`
@@ -36,7 +36,7 @@ function defaultValueForDescriptor (descriptor, DataType) {
   if (typeof descriptor.initializer === 'function') {
     const value = descriptor.initializer()
     if (DataType.name === 'Date') {
-      return moment(value).toDate()
+      return makeDate(value)
     } else {
       return DataType(value)
     }
@@ -54,7 +54,7 @@ function defaultValueForDescriptor (descriptor, DataType) {
  * Attributes can be defined with a default.
  * ```
  * class Todo extends Model {
- *   @attribute(Date) start_time = moment()
+ *   @attribute(Date) start_time = new Date()
  * }
  * ```
  * @method attribute

--- a/src/utils.js
+++ b/src/utils.js
@@ -153,7 +153,7 @@ export function stringifyIds (object) {
  */
 export function makeDate (value) {
   if (value instanceof Date || value._isAMomentObject) return value
-  return new Date(Date.parse(value)).toISOString()
+  return new Date(Date.parse(value))
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -145,6 +145,18 @@ export function stringifyIds (object) {
 }
 
 /**
+ * convert a value into a date, pass Date or Moment instances thru
+ * untouched
+ * @method makeDate
+ * @param {*} value
+ * @return {Date|Moment}
+ */
+export function makeDate (value) {
+  if (value instanceof Date || value._isAMomentObject) return value
+  return new Date(Date.parse(value)).toISOString()
+}
+
+/**
  * recursively walk an object and call the `iteratee` function for
  * each property. returns an array of results of calls to the iteratee.
  * @method walk


### PR DESCRIPTION
`moment` is enormous, and we don't use it for anything useful in here, so let's say goodbye.

while doing this i found a bunch of fns duplicted in `src/Model.js` and in `src/decorators/attribute.js`. I can't find anyone importing `attribute` from `src/Model`, so I went ahead and deleted it.