### PR TITLE
Model instance equality methods

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -21,7 +21,7 @@ var pluralize = _interopDefault(require('pluralize'));
 var dig = _interopDefault(require('lodash/get'));
 var flattenDeep = _interopDefault(require('lodash/flattenDeep'));
 var cloneDeep = _interopDefault(require('lodash/cloneDeep'));
-var isEqual = _interopDefault(require('lodash/isEqual'));
+var _isEqual = _interopDefault(require('lodash/isEqual'));
 var isObject = _interopDefault(require('lodash/isObject'));
 var findLast = _interopDefault(require('lodash/findLast'));
 var _possibleConstructorReturn = _interopDefault(require('@babel/runtime/helpers/possibleConstructorReturn'));
@@ -814,7 +814,7 @@ function () {
         }, function (value) {
           var previousValue = _this3.previousSnapshot.attributes[attr];
 
-          if (isEqual(previousValue, value)) {
+          if (_isEqual(previousValue, value)) {
             _this3._dirtyAttributes.delete(attr);
           } else if (isObject(value)) {
             // handles Objects and Arrays
@@ -1062,15 +1062,56 @@ function () {
         });
       });
     }
+    /**
+     * clone this object, deeply copy attrs and relationships (related
+     * objects are not cloned, but the relationships themselves are)
+     *
+     * @method clone
+     * @return {Object}
+     */
+
   }, {
     key: "clone",
     value: function clone() {
       var attributes = cloneDeep(this.snapshot.attributes);
-      var relationships = this.relationships;
+      var relationships = cloneDeep(this.snapshot.relationships);
       return this.store.createModel(this.type, this.id, {
         attributes: attributes,
         relationships: relationships
       });
+    }
+    /**
+     * Comparison by value
+     * returns `true` if this object has the same attrs and relationships
+     * as the "other" object, ignores differences in internal state like
+     * attribute "dirtyness" or errors
+     *
+     * @method isEqual
+     * @param {Object} other
+     * @return {Object}
+     */
+
+  }, {
+    key: "isEqual",
+    value: function isEqual(other) {
+      if (!other) return false;
+      return _isEqual(this.attributes, other.attributes) && _isEqual(this.relationships, other.relationships);
+    }
+    /**
+     * Comparison by identity
+     * returns `true` if this object has the same type and id as the
+     * "other" object, ignores differences in attrs and relationships
+     *
+     * @method isSame
+     * @param {Object} other
+     * @return {Object}
+     */
+
+  }, {
+    key: "isSame",
+    value: function isSame(other) {
+      if (!other) return false;
+      return this.type === other.type && this.id === other.id;
     }
   }, {
     key: "isDirty",

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -15,7 +15,7 @@ import pluralize from 'pluralize';
 import dig from 'lodash/get';
 import flattenDeep from 'lodash/flattenDeep';
 import cloneDeep from 'lodash/cloneDeep';
-import isEqual from 'lodash/isEqual';
+import _isEqual from 'lodash/isEqual';
 import isObject from 'lodash/isObject';
 import findLast from 'lodash/findLast';
 import _possibleConstructorReturn from '@babel/runtime/helpers/possibleConstructorReturn';
@@ -808,7 +808,7 @@ function () {
         }, function (value) {
           var previousValue = _this3.previousSnapshot.attributes[attr];
 
-          if (isEqual(previousValue, value)) {
+          if (_isEqual(previousValue, value)) {
             _this3._dirtyAttributes.delete(attr);
           } else if (isObject(value)) {
             // handles Objects and Arrays
@@ -1056,15 +1056,56 @@ function () {
         });
       });
     }
+    /**
+     * clone this object, deeply copy attrs and relationships (related
+     * objects are not cloned, but the relationships themselves are)
+     *
+     * @method clone
+     * @return {Object}
+     */
+
   }, {
     key: "clone",
     value: function clone() {
       var attributes = cloneDeep(this.snapshot.attributes);
-      var relationships = this.relationships;
+      var relationships = cloneDeep(this.snapshot.relationships);
       return this.store.createModel(this.type, this.id, {
         attributes: attributes,
         relationships: relationships
       });
+    }
+    /**
+     * Comparison by value
+     * returns `true` if this object has the same attrs and relationships
+     * as the "other" object, ignores differences in internal state like
+     * attribute "dirtyness" or errors
+     *
+     * @method isEqual
+     * @param {Object} other
+     * @return {Object}
+     */
+
+  }, {
+    key: "isEqual",
+    value: function isEqual(other) {
+      if (!other) return false;
+      return _isEqual(this.attributes, other.attributes) && _isEqual(this.relationships, other.relationships);
+    }
+    /**
+     * Comparison by identity
+     * returns `true` if this object has the same type and id as the
+     * "other" object, ignores differences in attrs and relationships
+     *
+     * @method isSame
+     * @param {Object} other
+     * @return {Object}
+     */
+
+  }, {
+    key: "isSame",
+    value: function isSame(other) {
+      if (!other) return false;
+      return this.type === other.type && this.id === other.id;
     }
   }, {
     key: "isDirty",

--- a/docs/classes/Model.html
+++ b/docs/classes/Model.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.0.26</em>
+            <em>API Docs for: 1.1.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Model.html
+++ b/docs/classes/Model.html
@@ -141,6 +141,10 @@
 
                             </li>
                             <li class="index-item method">
+                                <a href="#method_clone">clone</a>
+
+                            </li>
+                            <li class="index-item method">
                                 <a href="#method_constructor">constructor</a>
 
                             </li>
@@ -166,6 +170,14 @@
                             </li>
                             <li class="index-item method">
                                 <a href="#method_hasErrors">hasErrors</a>
+
+                            </li>
+                            <li class="index-item method">
+                                <a href="#method_isEqual">isEqual</a>
+
+                            </li>
+                            <li class="index-item method">
+                                <a href="#method_isSame">isSame</a>
 
                             </li>
                             <li class="index-item method">
@@ -584,6 +596,48 @@ if not persisted, push this snapshot to the top of the stack</p>
 
 
 </div>
+<div id="method_clone" class="method item">
+    <h3 class="name"><code>clone</code></h3>
+
+        <span class="paren">()</span>
+
+        <span class="returns-inline">
+            <span class="type">Object</span>
+        </span>
+
+
+
+
+
+
+
+    <div class="meta">
+                <p>
+                Defined in
+        <a href="../files/src_Model.js.html#l760"><code>src&#x2F;Model.js:760</code></a>
+        </p>
+
+
+
+    </div>
+
+    <div class="description">
+        <p>clone this object, deeply copy attrs and relationships (related
+objects are not cloned, but the relationships themselves are)</p>
+
+    </div>
+
+
+        <div class="returns">
+            <h4>Returns:</h4>
+
+            <div class="returns-description">
+                        <span class="type">Object</span>:
+            </div>
+        </div>
+
+
+</div>
 <div id="method_constructor" class="method item">
     <h3 class="name"><code>constructor</code></h3>
 
@@ -859,6 +913,137 @@ any event listeners and don't leak memory</p>
 
             <div class="returns-description">
                         <span class="type">Boolean</span>:
+            </div>
+        </div>
+
+
+</div>
+<div id="method_isEqual" class="method item">
+    <h3 class="name"><code>isEqual</code></h3>
+
+        <div class="args">
+            <span class="paren">(</span><ul class="args-list inline commas">
+                <li class="arg">
+                        <code>other</code>
+                </li>
+            </ul><span class="paren">)</span>
+        </div>
+
+        <span class="returns-inline">
+            <span class="type">Object</span>
+        </span>
+
+
+
+
+
+
+
+    <div class="meta">
+                <p>
+                Defined in
+        <a href="../files/src_Model.js.html#l773"><code>src&#x2F;Model.js:773</code></a>
+        </p>
+
+
+
+    </div>
+
+    <div class="description">
+        <p>Comparison by value
+returns <code>true</code> if this object has the same attrs and relationships
+as the &quot;other&quot; object, ignores differences in internal state like
+attribute &quot;dirtyness&quot; or errors</p>
+
+    </div>
+
+        <div class="params">
+            <h4>Parameters:</h4>
+
+            <ul class="params-list">
+                <li class="param">
+                        <code class="param-name">other</code>
+                        <span class="type">Object</span>
+
+
+                    <div class="param-description">
+                         
+                    </div>
+
+                </li>
+            </ul>
+        </div>
+
+        <div class="returns">
+            <h4>Returns:</h4>
+
+            <div class="returns-description">
+                        <span class="type">Object</span>:
+            </div>
+        </div>
+
+
+</div>
+<div id="method_isSame" class="method item">
+    <h3 class="name"><code>isSame</code></h3>
+
+        <div class="args">
+            <span class="paren">(</span><ul class="args-list inline commas">
+                <li class="arg">
+                        <code>other</code>
+                </li>
+            </ul><span class="paren">)</span>
+        </div>
+
+        <span class="returns-inline">
+            <span class="type">Object</span>
+        </span>
+
+
+
+
+
+
+
+    <div class="meta">
+                <p>
+                Defined in
+        <a href="../files/src_Model.js.html#l788"><code>src&#x2F;Model.js:788</code></a>
+        </p>
+
+
+
+    </div>
+
+    <div class="description">
+        <p>Comparison by identity
+returns <code>true</code> if this object has the same type and id as the
+&quot;other&quot; object, ignores differences in attrs and relationships</p>
+
+    </div>
+
+        <div class="params">
+            <h4>Parameters:</h4>
+
+            <ul class="params-list">
+                <li class="param">
+                        <code class="param-name">other</code>
+                        <span class="type">Object</span>
+
+
+                    <div class="param-description">
+                         
+                    </div>
+
+                </li>
+            </ul>
+        </div>
+
+        <div class="returns">
+            <h4>Returns:</h4>
+
+            <div class="returns-description">
+                        <span class="type">Object</span>:
             </div>
         </div>
 

--- a/docs/classes/RelatedRecordsArray.html
+++ b/docs/classes/RelatedRecordsArray.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.0.26</em>
+            <em>API Docs for: 1.1.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Schema.html
+++ b/docs/classes/Schema.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.0.26</em>
+            <em>API Docs for: 1.1.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Store.html
+++ b/docs/classes/Store.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.0.26</em>
+            <em>API Docs for: 1.1.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/data.json
+++ b/docs/data.json
@@ -722,6 +722,56 @@
             "class": "Model"
         },
         {
+            "file": "src/Model.js",
+            "line": 760,
+            "description": "clone this object, deeply copy attrs and relationships (related\nobjects are not cloned, but the relationships themselves are)",
+            "itemtype": "method",
+            "name": "clone",
+            "return": {
+                "description": "",
+                "type": "Object"
+            },
+            "class": "Model"
+        },
+        {
+            "file": "src/Model.js",
+            "line": 773,
+            "description": "Comparison by value\nreturns `true` if this object has the same attrs and relationships\nas the \"other\" object, ignores differences in internal state like\nattribute \"dirtyness\" or errors",
+            "itemtype": "method",
+            "name": "isEqual",
+            "params": [
+                {
+                    "name": "other",
+                    "description": "",
+                    "type": "Object"
+                }
+            ],
+            "return": {
+                "description": "",
+                "type": "Object"
+            },
+            "class": "Model"
+        },
+        {
+            "file": "src/Model.js",
+            "line": 788,
+            "description": "Comparison by identity\nreturns `true` if this object has the same type and id as the\n\"other\" object, ignores differences in attrs and relationships",
+            "itemtype": "method",
+            "name": "isSame",
+            "params": [
+                {
+                    "name": "other",
+                    "description": "",
+                    "type": "Object"
+                }
+            ],
+            "return": {
+                "description": "",
+                "type": "Object"
+            },
+            "class": "Model"
+        },
+        {
             "file": "src/Store.js",
             "line": 12,
             "description": "Observable property used to store data and\nhandle changes to state",

--- a/docs/data.json
+++ b/docs/data.json
@@ -3,7 +3,7 @@
         "name": "mobx-async-store",
         "description": "Asyc Data Store for mobx",
         "url": "https://github.com/artemis-ag/mobx-async-store",
-        "version": "1.0.26"
+        "version": "1.1.0"
     },
     "files": {
         "src/decorators/attributes.js": {

--- a/docs/files/src_Model.js.html
+++ b/docs/files/src_Model.js.html
@@ -842,10 +842,46 @@ class Model {
     })
   }
 
+  /**
+   * clone this object, deeply copy attrs and relationships (related
+   * objects are not cloned, but the relationships themselves are)
+   *
+   * @method clone
+   * @return {Object}
+   */
   clone () {
     const attributes = cloneDeep(this.snapshot.attributes)
-    const relationships = this.relationships
+    const relationships = cloneDeep(this.snapshot.relationships)
     return this.store.createModel(this.type, this.id, { attributes, relationships })
+  }
+
+  /**
+   * Comparison by value
+   * returns &#x60;true&#x60; if this object has the same attrs and relationships
+   * as the &quot;other&quot; object, ignores differences in internal state like
+   * attribute &quot;dirtyness&quot; or errors
+   *
+   * @method isEqual
+   * @param {Object} other
+   * @return {Object}
+   */
+  isEqual (other) {
+    if (!other) return false
+    return isEqual(this.attributes, other.attributes) &amp;&amp; isEqual(this.relationships, other.relationships)
+  }
+
+  /**
+   * Comparison by identity
+   * returns &#x60;true&#x60; if this object has the same type and id as the
+   * &quot;other&quot; object, ignores differences in attrs and relationships
+   *
+   * @method isSame
+   * @param {Object} other
+   * @return {Object}
+   */
+  isSame (other) {
+    if (!other) return false
+    return this.type === other.type &amp;&amp; this.id === other.id
   }
 }
 

--- a/docs/files/src_Model.js.html
+++ b/docs/files/src_Model.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.0.26</em>
+            <em>API Docs for: 1.1.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_Store.js.html
+++ b/docs/files/src_Store.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.0.26</em>
+            <em>API Docs for: 1.1.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_attributes.js.html
+++ b/docs/files/src_decorators_attributes.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.0.26</em>
+            <em>API Docs for: 1.1.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_relationships.js.html
+++ b/docs/files/src_decorators_relationships.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.0.26</em>
+            <em>API Docs for: 1.1.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_schema.js.html
+++ b/docs/files/src_schema.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.0.26</em>
+            <em>API Docs for: 1.1.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_utils.js.html
+++ b/docs/files/src_utils.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.0.26</em>
+            <em>API Docs for: 1.1.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
                 <h1><img src="./assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.0.26</em>
+            <em>API Docs for: 1.1.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "1.0.26",
+  "version": "1.1.0",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -861,6 +861,12 @@ describe('Model', () => {
       original.notes[0].description = 'Update!'
       expect(original.notes[0].description).toEqual(clone.notes[0].description)
     })
+
+    it('relationships themselves are cloned, not referenced', () => {
+      original.notes.replace([])
+      expect(original.notes.length).toEqual(0)
+      expect(clone.notes.length).toEqual(1)
+    })
   })
 
   describe('.save', () => {

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -869,6 +869,91 @@ describe('Model', () => {
     })
   })
 
+  describe('.isEqual', () => {
+    let original
+    beforeEach(() => {
+      const note = store.add('notes', {
+        id: 11,
+        description: 'Example description'
+      })
+      original = store.add('organizations', {
+        id: 11,
+        title: 'Buy Milk',
+        options: { color: 'green' }
+      })
+      original.notes.add(note)
+    })
+
+    it('is true for a clone and the original', () => {
+      const clone = original.clone()
+      expect(original.isEqual(clone)).toBe(true)
+    })
+
+    it('is false after attr differences', () => {
+      const clone = original.clone()
+      original.title = 'Buy Cheese'
+      expect(original.isEqual(clone)).toBe(false)
+    })
+
+    it('is false after deep attr changes', () => {
+      const clone = original.clone()
+      original.options.color = 'blue'
+      expect(original.isEqual(clone)).toBe(false)
+    })
+
+    it('is false after a change in relationships', () => {
+      const clone = original.clone()
+      clone.notes.replace([])
+      expect(original.isEqual(clone)).toBe(false)
+    })
+  })
+
+  describe('.isSame', () => {
+    let original
+    beforeEach(() => {
+      const note = store.add('notes', {
+        id: 11,
+        description: 'Example description'
+      })
+      original = store.add('organizations', {
+        id: 11,
+        title: 'Buy Milk',
+        options: { color: 'green' }
+      })
+      original.notes.add(note)
+    })
+
+    it('is false when the other obj is null', () => {
+      expect(original.isSame(null)).toBe(false)
+    })
+
+    it('is false for two different objects', () => {
+      expect(original.isSame(original.notes[0])).toBe(false)
+    })
+
+    it('is false for objects with the same type but different ids', () => {
+      const clone = original.clone()
+      clone.id = 777
+      expect(original.isSame(clone)).toBe(false)
+    })
+
+    it('is true for a clone', () => {
+      const clone = original.clone()
+      expect(original.isSame(clone)).toBe(true)
+    })
+
+    it('ignores differences in attrs', () => {
+      const clone = original.clone()
+      expect(original.isSame(clone)).toBe(true)
+    })
+
+    it('ignores differences in relationships', () => {
+      const clone = original.clone()
+      clone.notes.replace([])
+      expect(original.isSame(clone)).toBe(true)
+    })
+  })
+
   describe('.save', () => {
     xit('handles in flight behavior', (done) => {
       // expect.assertions(3)

--- a/src/Model.js
+++ b/src/Model.js
@@ -759,7 +759,7 @@ class Model {
 
   clone () {
     const attributes = cloneDeep(this.snapshot.attributes)
-    const relationships = this.relationships
+    const relationships = cloneDeep(this.snapshot.relationships)
     return this.store.createModel(this.type, this.id, { attributes, relationships })
   }
 }

--- a/src/Model.js
+++ b/src/Model.js
@@ -757,10 +757,46 @@ class Model {
     })
   }
 
+  /**
+   * clone this object, deeply copy attrs and relationships (related
+   * objects are not cloned, but the relationships themselves are)
+   *
+   * @method clone
+   * @return {Object}
+   */
   clone () {
     const attributes = cloneDeep(this.snapshot.attributes)
     const relationships = cloneDeep(this.snapshot.relationships)
     return this.store.createModel(this.type, this.id, { attributes, relationships })
+  }
+
+  /**
+   * Comparison by value
+   * returns `true` if this object has the same attrs and relationships
+   * as the "other" object, ignores differences in internal state like
+   * attribute "dirtyness" or errors
+   *
+   * @method isEqual
+   * @param {Object} other
+   * @return {Object}
+   */
+  isEqual (other) {
+    if (!other) return false
+    return isEqual(this.attributes, other.attributes) && isEqual(this.relationships, other.relationships)
+  }
+
+  /**
+   * Comparison by identity
+   * returns `true` if this object has the same type and id as the
+   * "other" object, ignores differences in attrs and relationships
+   *
+   * @method isSame
+   * @param {Object} other
+   * @return {Object}
+   */
+  isSame (other) {
+    if (!other) return false
+    return this.type === other.type && this.id === other.id
   }
 }
 


### PR DESCRIPTION
* Define `Model#isEqual`
* Define `Model#isSame`
* fix bug in `Model#clone` where relationships were aliased