### PR TITLE
Replace jquery-param with qs

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -16,7 +16,7 @@ require('@babel/runtime/helpers/initializerWarningHelper');
 var _typeof = _interopDefault(require('@babel/runtime/helpers/typeof'));
 var mobx = require('mobx');
 var uuidv1 = _interopDefault(require('uuid/v1'));
-var jqueryParam = _interopDefault(require('jquery-param'));
+var qs = _interopDefault(require('qs'));
 var pluralize = _interopDefault(require('pluralize'));
 var dig = _interopDefault(require('lodash/get'));
 var flattenDeep = _interopDefault(require('lodash/flattenDeep'));
@@ -29,6 +29,19 @@ var _getPrototypeOf = _interopDefault(require('@babel/runtime/helpers/getPrototy
 var _assertThisInitialized = _interopDefault(require('@babel/runtime/helpers/assertThisInitialized'));
 var _inherits = _interopDefault(require('@babel/runtime/helpers/inherits'));
 var _wrapNativeSuper = _interopDefault(require('@babel/runtime/helpers/wrapNativeSuper'));
+
+var QueryString = {
+  parse: function parse(str) {
+    return qs.parse(str, {
+      ignoreQueryPrefix: true
+    });
+  },
+  stringify: function stringify(str) {
+    return qs.stringify(str, {
+      arrayFormat: 'brackets'
+    });
+  }
+};
 
 var pending = {};
 var counter = {};
@@ -76,7 +89,7 @@ function requestUrl(baseUrl, endpoint) {
   var queryParamString = '';
 
   if (Object.keys(queryParams).length > 0) {
-    queryParamString = "?".concat(jqueryParam(queryParams));
+    queryParamString = "?".concat(QueryString.stringify(queryParams));
   }
 
   var idForPath = '';
@@ -2672,6 +2685,7 @@ function (_Array) {
 
 exports.Model = Model;
 exports.ObjectPromiseProxy = ObjectPromiseProxy;
+exports.QueryString = QueryString;
 exports.Store = Store;
 exports.attribute = attribute;
 exports.relatedToMany = relatedToMany;

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -10,7 +10,7 @@ import '@babel/runtime/helpers/initializerWarningHelper';
 import _typeof from '@babel/runtime/helpers/typeof';
 import { transaction, set, observable, computed, extendObservable, reaction, toJS, action } from 'mobx';
 import uuidv1 from 'uuid/v1';
-import jqueryParam from 'jquery-param';
+import qs from 'qs';
 import pluralize from 'pluralize';
 import dig from 'lodash/get';
 import flattenDeep from 'lodash/flattenDeep';
@@ -23,6 +23,19 @@ import _getPrototypeOf from '@babel/runtime/helpers/getPrototypeOf';
 import _assertThisInitialized from '@babel/runtime/helpers/assertThisInitialized';
 import _inherits from '@babel/runtime/helpers/inherits';
 import _wrapNativeSuper from '@babel/runtime/helpers/wrapNativeSuper';
+
+var QueryString = {
+  parse: function parse(str) {
+    return qs.parse(str, {
+      ignoreQueryPrefix: true
+    });
+  },
+  stringify: function stringify(str) {
+    return qs.stringify(str, {
+      arrayFormat: 'brackets'
+    });
+  }
+};
 
 var pending = {};
 var counter = {};
@@ -70,7 +83,7 @@ function requestUrl(baseUrl, endpoint) {
   var queryParamString = '';
 
   if (Object.keys(queryParams).length > 0) {
-    queryParamString = "?".concat(jqueryParam(queryParams));
+    queryParamString = "?".concat(QueryString.stringify(queryParams));
   }
 
   var idForPath = '';
@@ -2664,4 +2677,4 @@ function (_Array) {
   return RelatedRecordsArray;
 }(_wrapNativeSuper(Array));
 
-export { Model, ObjectPromiseProxy, Store, attribute, relatedToMany, relatedToOne, validates };
+export { Model, ObjectPromiseProxy, QueryString, Store, attribute, relatedToMany, relatedToOne, validates };

--- a/docs/classes/Model.html
+++ b/docs/classes/Model.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.1.0</em>
+            <em>API Docs for: 1.2.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/RelatedRecordsArray.html
+++ b/docs/classes/RelatedRecordsArray.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.1.0</em>
+            <em>API Docs for: 1.2.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Schema.html
+++ b/docs/classes/Schema.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.1.0</em>
+            <em>API Docs for: 1.2.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Store.html
+++ b/docs/classes/Store.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.1.0</em>
+            <em>API Docs for: 1.2.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/data.json
+++ b/docs/data.json
@@ -3,7 +3,7 @@
         "name": "mobx-async-store",
         "description": "Asyc Data Store for mobx",
         "url": "https://github.com/artemis-ag/mobx-async-store",
-        "version": "1.1.0"
+        "version": "1.2.0"
     },
     "files": {
         "src/decorators/attributes.js": {

--- a/docs/files/src_Model.js.html
+++ b/docs/files/src_Model.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.1.0</em>
+            <em>API Docs for: 1.2.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_Store.js.html
+++ b/docs/files/src_Store.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.1.0</em>
+            <em>API Docs for: 1.2.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_attributes.js.html
+++ b/docs/files/src_decorators_attributes.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.1.0</em>
+            <em>API Docs for: 1.2.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_relationships.js.html
+++ b/docs/files/src_decorators_relationships.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.1.0</em>
+            <em>API Docs for: 1.2.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_schema.js.html
+++ b/docs/files/src_schema.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.1.0</em>
+            <em>API Docs for: 1.2.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_utils.js.html
+++ b/docs/files/src_utils.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.1.0</em>
+            <em>API Docs for: 1.2.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -84,7 +84,7 @@
 <div class="file">
     <pre class="code prettyprint linenums">
 import uuidv1 from &#x27;uuid/v1&#x27;
-import jqueryParam from &#x27;jquery-param&#x27;
+import QueryString from &#x27;./QueryString&#x27;
 import pluralize from &#x27;pluralize&#x27;
 import dig from &#x27;lodash/get&#x27;
 import flattenDeep from &#x27;lodash/flattenDeep&#x27;
@@ -129,7 +129,7 @@ export function singularizeType (recordType) {
 export function requestUrl (baseUrl, endpoint, queryParams = {}, id) {
   let queryParamString = &#x27;&#x27;
   if (Object.keys(queryParams).length &gt; 0) {
-    queryParamString = &#x60;?${jqueryParam(queryParams)}&#x60;
+    queryParamString = &#x60;?${QueryString.stringify(queryParams)}&#x60;
   }
   let idForPath = &#x27;&#x27;
   if (id) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
                 <h1><img src="./assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.1.0</em>
+            <em>API Docs for: 1.2.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",
@@ -9,7 +9,7 @@
     "lodash": "^4.17.15",
     "mobx": "5.5.0",
     "pluralize": "^8.0.0",
-    "query-string": "^6.13.1",
+    "qs": "^6.9.4",
     "react-native-uuid": "^1.4.9",
     "uuid": "^3.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",
   "dependencies": {
-    "jquery-param": "^1.0.1",
     "jsonapi-serializer": "^3.6.4",
     "lodash": "^4.17.15",
     "mobx": "5.5.0",
     "pluralize": "^8.0.0",
+    "query-string": "^6.13.1",
     "react-native-uuid": "^1.4.9",
     "uuid": "^3.3.2"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -51,7 +51,7 @@ export default [
 			'@babel/runtime/helpers/possibleConstructorReturn',
 			'@babel/runtime/helpers/typeof',
 			'@babel/runtime/regenerator',
-			'jquery-param',
+			'query-string',
 			'jsonapi-serializer',
 			'mobx',
 			'moment',

--- a/spec/QueryString.spec.js
+++ b/spec/QueryString.spec.js
@@ -1,0 +1,22 @@
+import QueryString from '../src/QueryString'
+
+describe('QueryString', () => {
+  const queryString = 'fields[articles][]=title&fields[articles][]=body&fields[people]=name'
+  const params = { fields: { articles: [ 'title', 'body' ], people: 'name' } }
+
+  describe('stringify', () => {
+    it('stringifies a deeply nested param object', () => {
+      expect(decodeURI(QueryString.stringify(params))).toBe(queryString)
+    })
+  })
+
+  describe('parse', () => {
+    it('parses a deeply nested query string', () => {
+      expect(QueryString.parse(queryString)).toEqual(params)
+    })
+
+    it('ignores leading ?', () => {
+      expect(QueryString.parse(`?${queryString}`)).toEqual(params)
+    })
+  })
+})

--- a/src/QueryString.js
+++ b/src/QueryString.js
@@ -1,0 +1,8 @@
+import qs from 'qs'
+
+const QueryString = {
+  parse: (str) => qs.parse(str, { ignoreQueryPrefix: true }),
+  stringify: (str) => qs.stringify(str, { arrayFormat: 'brackets' })
+}
+
+export default QueryString

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import Model from './Model'
 import Store from './Store'
+import QueryString from './QueryString'
 import { attribute, validates } from './decorators/attributes'
 import { relatedToMany, relatedToOne } from './decorators/relationships'
 import ObjectPromiseProxy from './ObjectPromiseProxy'
@@ -11,5 +12,6 @@ export {
   relatedToMany,
   relatedToOne,
   validates,
-  ObjectPromiseProxy
+  ObjectPromiseProxy,
+  QueryString
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 import uuidv1 from 'uuid/v1'
-import queryString from 'query-string'
+import QueryString from './QueryString'
 import pluralize from 'pluralize'
 import dig from 'lodash/get'
 import flattenDeep from 'lodash/flattenDeep'
@@ -44,7 +44,7 @@ export function singularizeType (recordType) {
 export function requestUrl (baseUrl, endpoint, queryParams = {}, id) {
   let queryParamString = ''
   if (Object.keys(queryParams).length > 0) {
-    queryParamString = `?${queryString.stringify(queryParams, { arrayFormat: 'bracket' })}`
+    queryParamString = `?${QueryString.stringify(queryParams)}`
   }
   let idForPath = ''
   if (id) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 import uuidv1 from 'uuid/v1'
-import jqueryParam from 'jquery-param'
+import queryString from 'query-string'
 import pluralize from 'pluralize'
 import dig from 'lodash/get'
 import flattenDeep from 'lodash/flattenDeep'
@@ -44,7 +44,7 @@ export function singularizeType (recordType) {
 export function requestUrl (baseUrl, endpoint, queryParams = {}, id) {
   let queryParamString = ''
   if (Object.keys(queryParams).length > 0) {
-    queryParamString = `?${jqueryParam(queryParams)}`
+    queryParamString = `?${queryString.stringify(queryParams, { arrayFormat: 'bracket' })}`
   }
   let idForPath = ''
   if (id) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4769,6 +4769,11 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@^6.9.4:
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
+  integrity sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==
+
 qs@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-1.0.2.tgz#50a93e2b5af6691c31bcea5dae78ee6ea1903768"
@@ -4778,15 +4783,6 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
-
-query-string@^6.13.1:
-  version "6.13.1"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.1.tgz#d913ccfce3b4b3a713989fe6d39466d92e71ccad"
-  integrity sha512-RfoButmcK+yCta1+FuU8REvisx1oEzhMKwhLUNcepQTPGcNMp1sIqjnfCtfnvGSQZQEhaBHvccujtWoUV3TTbA==
-  dependencies:
-    decode-uri-component "^0.2.0"
-    split-on-first "^1.0.0"
-    strict-uri-encode "^2.0.0"
 
 raf@^3.4.1:
   version "3.4.1"
@@ -5499,11 +5495,6 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
   integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
 
-split-on-first@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
-  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
-
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -5553,11 +5544,6 @@ stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
-
-strict-uri-encode@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
-  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3726,11 +3726,6 @@ jest@^24.7.1:
     import-local "^2.0.0"
     jest-cli "^24.9.0"
 
-jquery-param@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/jquery-param/-/jquery-param-1.0.2.tgz#42ca2a9b244f133f55fa718fd2b62cf55bca0891"
-  integrity sha512-4DvI/PRdNbTLef+slsmsPW16tPaCUpInbwh6FfKw9S/Q/0xOrGIB4AsUHOeccICuiWtXwNiDCLszy7bavQlXrA==
-
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
@@ -4784,6 +4779,15 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+query-string@^6.13.1:
+  version "6.13.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.1.tgz#d913ccfce3b4b3a713989fe6d39466d92e71ccad"
+  integrity sha512-RfoButmcK+yCta1+FuU8REvisx1oEzhMKwhLUNcepQTPGcNMp1sIqjnfCtfnvGSQZQEhaBHvccujtWoUV3TTbA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
@@ -5495,6 +5499,11 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
   integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -5544,6 +5553,11 @@ stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
just to illustrate that behavior is not changing, here's a snippet of a session in a node console:
```
> params
{ fields: { articles: [ 'title', 'body' ], people: 'name' } }
> decodeURI(jqueryParam(params))
'fields[articles][]=title&fields[articles][]=body&fields[people]=name'
> decodeURI(qs.stringify(params, { arrayFormat: 'brackets' }))
'fields[articles][]=title&fields[articles][]=body&fields[people]=name'
```

I considered using `query-string`, since it's much smaller, but this didn't instill confidence:
```
> queryString.stringify(params, { arrayFormat: 'bracket' })
'fields=%5Bobject%20Object%5D'
```