### PR TITLE
Static Fetchers

### DIFF
--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -502,11 +502,37 @@ function stringifyIds(object) {
 var Model = (_class = (_temp =
 /*#__PURE__*/
 function () {
-  /**
-   * Initializer for model
-   *
-   * @method constructor
-   */
+  _createClass(Model, null, [{
+    key: "fetchOne",
+
+    /**
+     * @method fetchOne
+     * @param {String} id
+     * @param {Object} params
+     */
+    value: function fetchOne(id) {
+      var params = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+      return this.store.fetchOne(this.type, id, params);
+    }
+    /**
+     * @method fetchAll
+     * @param {Object} params
+     */
+
+  }, {
+    key: "fetchAll",
+    value: function fetchAll() {
+      var params = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+      return this.store.fetchAll(this.type, params);
+    }
+    /**
+     * Initializer for model
+     *
+     * @method constructor
+     */
+
+  }]);
+
   function Model() {
     var initialAttributes = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
@@ -1378,7 +1404,7 @@ function () {
   }
 })), _class);
 
-var _class$1, _descriptor$1, _descriptor2$1, _descriptor3$1, _temp$1;
+var _class$1, _descriptor$1, _descriptor2$1, _descriptor3$1, _class2, _temp$1;
 
 function ownKeys$2(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
@@ -1390,7 +1416,7 @@ function _objectSpread$2(target) { for (var i = 1; i < arguments.length; i++) { 
  * @constructor
  */
 
-var Store = (_class$1 = (_temp$1 =
+var Store = (_class$1 = (_temp$1 = _class2 =
 /*#__PURE__*/
 function () {
   /**
@@ -1416,12 +1442,19 @@ function () {
 
     this.genericErrorMessage = 'Something went wrong.';
 
-    this.add = function (type, data) {
-      if (data.constructor.name === 'Array') {
-        return _this.addModels(type, data);
+    this.add = function (type, attributes) {
+      if (attributes.constructor.name === 'Array') {
+        return _this.addModels(type, attributes);
       } else {
-        return _this.addModel(type, toJS(data));
+        return _this.addModel(type, toJS(attributes));
       }
+    };
+
+    this.build = function (type, attributes) {
+      var id = dbOrNewId(attributes);
+      return _this.createModel(type, id, {
+        attributes: attributes
+      });
     };
 
     _initializerDefineProperty(this, "addModel", _descriptor2$1, this);
@@ -1544,7 +1577,7 @@ function () {
    * ```
    * @method add
    * @param {String} type
-   * @param {Object} properties the properties to use
+   * @param {Object} attributes the properties to use
    * @return {Object} the new record
    */
 
@@ -1612,8 +1645,11 @@ function () {
   }, {
     key: "initializeModelTypeIndex",
     value: function initializeModelTypeIndex() {
+      var _this2 = this;
+
       var types = this.constructor.types;
       this.modelTypeIndex = types.reduce(function (modelTypeIndex, modelKlass) {
+        modelKlass.store = _this2;
         modelTypeIndex[modelKlass.type] = modelKlass;
         return modelTypeIndex;
       }, {});
@@ -1630,13 +1666,13 @@ function () {
   }, {
     key: "initializeObservableDataProperty",
     value: function initializeObservableDataProperty() {
-      var _this2 = this;
+      var _this3 = this;
 
       var types = this.constructor.types; // NOTE: Is there a performance cost to setting
       // each property individually?
 
       types.forEach(function (modelKlass) {
-        _this2.data[modelKlass.type] = {
+        _this3.data[modelKlass.type] = {
           records: observable.map({}),
           cache: observable.map({})
         };
@@ -1829,12 +1865,12 @@ function () {
   }, {
     key: "getRecordsById",
     value: function getRecordsById(type) {
-      var _this3 = this;
+      var _this4 = this;
 
       var ids = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : [];
       // NOTE: Is there a better way to do this?
       return ids.map(function (id) {
-        return _this3.getRecord(type, id);
+        return _this4.getRecord(type, id);
       }).filter(function (record) {
         return record;
       }).filter(function (record) {
@@ -1930,15 +1966,15 @@ function () {
   }, {
     key: "createModelsFromData",
     value: function createModelsFromData(data) {
-      var _this4 = this;
+      var _this5 = this;
 
       return transaction(function () {
         return data.map(function (dataObject) {
           // Only build objects for which we have a type defined.
           // And ignore silently anything else included in the JSON response.
           // TODO: Put some console message in development mode
-          if (_this4.getType(dataObject.type)) {
-            return _this4.createOrUpdateModel(dataObject);
+          if (_this5.getType(dataObject.type)) {
+            return _this5.createOrUpdateModel(dataObject);
           }
         });
       });
@@ -2005,7 +2041,7 @@ function () {
       var _fetchAll = _asyncToGenerator(
       /*#__PURE__*/
       _regeneratorRuntime.mark(function _callee(type, queryParams) {
-        var _this5 = this;
+        var _this6 = this;
 
         var store, url, response, json;
         return _regeneratorRuntime.wrap(function _callee$(_context) {
@@ -2045,17 +2081,17 @@ function () {
                         attributes = _dataObject$attribute2 === void 0 ? {} : _dataObject$attribute2,
                         _dataObject$relations2 = dataObject.relationships,
                         relationships = _dataObject$relations2 === void 0 ? {} : _dataObject$relations2;
-                    var ModelKlass = _this5.modelTypeIndex[type];
+                    var ModelKlass = _this6.modelTypeIndex[type];
                     var record = new ModelKlass(_objectSpread$2({
                       store: store,
                       relationships: relationships
                     }, attributes));
 
-                    var cachedIds = _this5.data[type].cache.get(url);
+                    var cachedIds = _this6.data[type].cache.get(url);
 
-                    _this5.data[type].cache.set(url, [].concat(_toConsumableArray(cachedIds), [id]));
+                    _this6.data[type].cache.set(url, [].concat(_toConsumableArray(cachedIds), [id]));
 
-                    _this5.data[type].records.set(String(id), record);
+                    _this6.data[type].records.set(String(id), record);
 
                     return record;
                   });
@@ -2148,7 +2184,7 @@ function () {
   }]);
 
   return Store;
-}(), _temp$1), (_descriptor$1 = _applyDecoratedDescriptor(_class$1.prototype, "data", [observable], {
+}(), _class2.types = [], _temp$1), (_descriptor$1 = _applyDecoratedDescriptor(_class$1.prototype, "data", [observable], {
   configurable: true,
   enumerable: true,
   writable: true,
@@ -2160,17 +2196,13 @@ function () {
   enumerable: true,
   writable: true,
   initializer: function initializer() {
-    var _this6 = this;
+    var _this7 = this;
 
     return function (type, attributes) {
-      var id = dbOrNewId(attributes);
-
-      var model = _this6.createModel(type, id, {
-        attributes: attributes
-      }); // Add the model to the type records index
+      var model = _this7.build(type, attributes); // Add the model to the type records index
 
 
-      _this6.data[type].records.set(String(id), model);
+      _this7.data[type].records.set(String(model.id), model);
 
       return model;
     };
@@ -2180,10 +2212,10 @@ function () {
   enumerable: true,
   writable: true,
   initializer: function initializer() {
-    var _this7 = this;
+    var _this8 = this;
 
     return function (type, id) {
-      _this7.data[type].records.delete(String(id));
+      _this8.data[type].records.delete(String(id));
     };
   }
 })), _class$1);

--- a/docs/classes/Model.html
+++ b/docs/classes/Model.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.2.0</em>
+            <em>API Docs for: 1.3.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -162,6 +162,14 @@
                             </li>
                             <li class="index-item method">
                                 <a href="#method_dispose">dispose</a>
+
+                            </li>
+                            <li class="index-item method">
+                                <a href="#method_fetchAll">fetchAll</a>
+
+                            </li>
+                            <li class="index-item method">
+                                <a href="#method_fetchOne">fetchOne</a>
 
                             </li>
                             <li class="index-item method">
@@ -315,7 +323,7 @@
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l534"><code>src&#x2F;Model.js:534</code></a>
+        <a href="../files/src_Model.js.html#l551"><code>src&#x2F;Model.js:551</code></a>
         </p>
 
 
@@ -363,7 +371,7 @@ and relationships of the snapshot to be applied. also reset errors</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l417"><code>src&#x2F;Model.js:417</code></a>
+        <a href="../files/src_Model.js.html#l434"><code>src&#x2F;Model.js:434</code></a>
         </p>
 
 
@@ -399,7 +407,7 @@ _dirtyAttributes set</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l400"><code>src&#x2F;Model.js:400</code></a>
+        <a href="../files/src_Model.js.html#l417"><code>src&#x2F;Model.js:417</code></a>
         </p>
 
 
@@ -437,7 +445,7 @@ observable</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l511"><code>src&#x2F;Model.js:511</code></a>
+        <a href="../files/src_Model.js.html#l528"><code>src&#x2F;Model.js:528</code></a>
         </p>
 
 
@@ -489,7 +497,7 @@ if not persisted, push this snapshot to the top of the stack</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l600"><code>src&#x2F;Model.js:600</code></a>
+        <a href="../files/src_Model.js.html#l617"><code>src&#x2F;Model.js:617</code></a>
         </p>
 
 
@@ -530,7 +538,7 @@ if not persisted, push this snapshot to the top of the stack</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l642"><code>src&#x2F;Model.js:642</code></a>
+        <a href="../files/src_Model.js.html#l659"><code>src&#x2F;Model.js:659</code></a>
         </p>
 
 
@@ -571,7 +579,7 @@ if not persisted, push this snapshot to the top of the stack</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l582"><code>src&#x2F;Model.js:582</code></a>
+        <a href="../files/src_Model.js.html#l599"><code>src&#x2F;Model.js:599</code></a>
         </p>
 
 
@@ -614,7 +622,7 @@ if not persisted, push this snapshot to the top of the stack</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l760"><code>src&#x2F;Model.js:760</code></a>
+        <a href="../files/src_Model.js.html#l777"><code>src&#x2F;Model.js:777</code></a>
         </p>
 
 
@@ -653,7 +661,7 @@ objects are not cloned, but the relationships themselves are)</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l85"><code>src&#x2F;Model.js:85</code></a>
+        <a href="../files/src_Model.js.html#l102"><code>src&#x2F;Model.js:102</code></a>
         </p>
 
 
@@ -687,7 +695,7 @@ objects are not cloned, but the relationships themselves are)</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l662"><code>src&#x2F;Model.js:662</code></a>
+        <a href="../files/src_Model.js.html#l679"><code>src&#x2F;Model.js:679</code></a>
         </p>
 
 
@@ -728,7 +736,7 @@ objects are not cloned, but the relationships themselves are)</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l331"><code>src&#x2F;Model.js:331</code></a>
+        <a href="../files/src_Model.js.html#l348"><code>src&#x2F;Model.js:348</code></a>
         </p>
 
 
@@ -771,7 +779,7 @@ objects are not cloned, but the relationships themselves are)</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l551"><code>src&#x2F;Model.js:551</code></a>
+        <a href="../files/src_Model.js.html#l568"><code>src&#x2F;Model.js:568</code></a>
         </p>
 
 
@@ -819,7 +827,7 @@ todo.dirtyAttributes
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l450"><code>src&#x2F;Model.js:450</code></a>
+        <a href="../files/src_Model.js.html#l467"><code>src&#x2F;Model.js:467</code></a>
         </p>
 
 
@@ -832,6 +840,123 @@ any event listeners and don't leak memory</p>
 
     </div>
 
+
+
+
+</div>
+<div id="method_fetchAll" class="method item">
+    <h3 class="name"><code>fetchAll</code></h3>
+
+        <div class="args">
+            <span class="paren">(</span><ul class="args-list inline commas">
+                <li class="arg">
+                        <code>params</code>
+                </li>
+            </ul><span class="paren">)</span>
+        </div>
+
+
+
+
+
+
+
+
+    <div class="meta">
+                <p>
+                Defined in
+        <a href="../files/src_Model.js.html#l94"><code>src&#x2F;Model.js:94</code></a>
+        </p>
+
+
+
+    </div>
+
+    <div class="description">
+        
+    </div>
+
+        <div class="params">
+            <h4>Parameters:</h4>
+
+            <ul class="params-list">
+                <li class="param">
+                        <code class="param-name">params</code>
+                        <span class="type">Object</span>
+
+
+                    <div class="param-description">
+                         
+                    </div>
+
+                </li>
+            </ul>
+        </div>
+
+
+
+</div>
+<div id="method_fetchOne" class="method item">
+    <h3 class="name"><code>fetchOne</code></h3>
+
+        <div class="args">
+            <span class="paren">(</span><ul class="args-list inline commas">
+                <li class="arg">
+                        <code>id</code>
+                </li>
+                <li class="arg">
+                        <code>params</code>
+                </li>
+            </ul><span class="paren">)</span>
+        </div>
+
+
+
+
+
+
+
+
+    <div class="meta">
+                <p>
+                Defined in
+        <a href="../files/src_Model.js.html#l85"><code>src&#x2F;Model.js:85</code></a>
+        </p>
+
+
+
+    </div>
+
+    <div class="description">
+        
+    </div>
+
+        <div class="params">
+            <h4>Parameters:</h4>
+
+            <ul class="params-list">
+                <li class="param">
+                        <code class="param-name">id</code>
+                        <span class="type">String</span>
+
+
+                    <div class="param-description">
+                         
+                    </div>
+
+                </li>
+                <li class="param">
+                        <code class="param-name">params</code>
+                        <span class="type">Object</span>
+
+
+                    <div class="param-description">
+                         
+                    </div>
+
+                </li>
+            </ul>
+        </div>
 
 
 
@@ -854,7 +979,7 @@ any event listeners and don't leak memory</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l622"><code>src&#x2F;Model.js:622</code></a>
+        <a href="../files/src_Model.js.html#l639"><code>src&#x2F;Model.js:639</code></a>
         </p>
 
 
@@ -895,7 +1020,7 @@ any event listeners and don't leak memory</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l632"><code>src&#x2F;Model.js:632</code></a>
+        <a href="../files/src_Model.js.html#l649"><code>src&#x2F;Model.js:649</code></a>
         </p>
 
 
@@ -942,7 +1067,7 @@ any event listeners and don't leak memory</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l773"><code>src&#x2F;Model.js:773</code></a>
+        <a href="../files/src_Model.js.html#l790"><code>src&#x2F;Model.js:790</code></a>
         </p>
 
 
@@ -1008,7 +1133,7 @@ attribute &quot;dirtyness&quot; or errors</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l788"><code>src&#x2F;Model.js:788</code></a>
+        <a href="../files/src_Model.js.html#l805"><code>src&#x2F;Model.js:805</code></a>
         </p>
 
 
@@ -1067,7 +1192,7 @@ returns <code>true</code> if this object has the same type and id as the
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l679"><code>src&#x2F;Model.js:679</code></a>
+        <a href="../files/src_Model.js.html#l696"><code>src&#x2F;Model.js:696</code></a>
         </p>
 
 
@@ -1108,7 +1233,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l502"><code>src&#x2F;Model.js:502</code></a>
+        <a href="../files/src_Model.js.html#l519"><code>src&#x2F;Model.js:519</code></a>
         </p>
 
 
@@ -1139,7 +1264,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l491"><code>src&#x2F;Model.js:491</code></a>
+        <a href="../files/src_Model.js.html#l508"><code>src&#x2F;Model.js:508</code></a>
         </p>
 
 
@@ -1173,7 +1298,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l611"><code>src&#x2F;Model.js:611</code></a>
+        <a href="../files/src_Model.js.html#l628"><code>src&#x2F;Model.js:628</code></a>
         </p>
 
 
@@ -1214,7 +1339,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l652"><code>src&#x2F;Model.js:652</code></a>
+        <a href="../files/src_Model.js.html#l669"><code>src&#x2F;Model.js:669</code></a>
         </p>
 
 
@@ -1252,7 +1377,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l227"><code>src&#x2F;Model.js:227</code></a>
+        <a href="../files/src_Model.js.html#l244"><code>src&#x2F;Model.js:244</code></a>
         </p>
 
 
@@ -1291,7 +1416,7 @@ kpi.name
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l244"><code>src&#x2F;Model.js:244</code></a>
+        <a href="../files/src_Model.js.html#l261"><code>src&#x2F;Model.js:261</code></a>
         </p>
 
 
@@ -1332,7 +1457,7 @@ state if the model was never persisted</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l254"><code>src&#x2F;Model.js:254</code></a>
+        <a href="../files/src_Model.js.html#l271"><code>src&#x2F;Model.js:271</code></a>
         </p>
 
 
@@ -1386,7 +1511,7 @@ state if the model was never persisted</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l482"><code>src&#x2F;Model.js:482</code></a>
+        <a href="../files/src_Model.js.html#l499"><code>src&#x2F;Model.js:499</code></a>
         </p>
 
 
@@ -1420,7 +1545,7 @@ state if the model was never persisted</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l460"><code>src&#x2F;Model.js:460</code></a>
+        <a href="../files/src_Model.js.html#l477"><code>src&#x2F;Model.js:477</code></a>
         </p>
 
 
@@ -1472,7 +1597,7 @@ snapshot.title
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l572"><code>src&#x2F;Model.js:572</code></a>
+        <a href="../files/src_Model.js.html#l589"><code>src&#x2F;Model.js:589</code></a>
         </p>
 
 
@@ -1521,7 +1646,7 @@ snapshot.title
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l307"><code>src&#x2F;Model.js:307</code></a>
+        <a href="../files/src_Model.js.html#l324"><code>src&#x2F;Model.js:324</code></a>
         </p>
 
 
@@ -1675,7 +1800,7 @@ Default is to check all validations, but they can be selectively run via options
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l125"><code>src&#x2F;Model.js:125</code></a>
+        <a href="../files/src_Model.js.html#l142"><code>src&#x2F;Model.js:142</code></a>
         </p>
 
 
@@ -1700,7 +1825,7 @@ Default is to check all validations, but they can be selectively run via options
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l118"><code>src&#x2F;Model.js:118</code></a>
+        <a href="../files/src_Model.js.html#l135"><code>src&#x2F;Model.js:135</code></a>
         </p>
 
 
@@ -1725,7 +1850,7 @@ Default is to check all validations, but they can be selectively run via options
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l110"><code>src&#x2F;Model.js:110</code></a>
+        <a href="../files/src_Model.js.html#l127"><code>src&#x2F;Model.js:127</code></a>
         </p>
 
 
@@ -1752,7 +1877,7 @@ Default is to check all validations, but they can be selectively run via options
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l103"><code>src&#x2F;Model.js:103</code></a>
+        <a href="../files/src_Model.js.html#l120"><code>src&#x2F;Model.js:120</code></a>
         </p>
 
 
@@ -1778,7 +1903,7 @@ Defaults to the underscored version of the class name</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l205"><code>src&#x2F;Model.js:205</code></a>
+        <a href="../files/src_Model.js.html#l222"><code>src&#x2F;Model.js:222</code></a>
         </p>
 
 
@@ -1808,7 +1933,7 @@ kpi.errors
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l167"><code>src&#x2F;Model.js:167</code></a>
+        <a href="../files/src_Model.js.html#l184"><code>src&#x2F;Model.js:184</code></a>
         </p>
 
 
@@ -1833,7 +1958,7 @@ kpi.errors
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l132"><code>src&#x2F;Model.js:132</code></a>
+        <a href="../files/src_Model.js.html#l149"><code>src&#x2F;Model.js:149</code></a>
         </p>
 
 
@@ -1879,7 +2004,7 @@ kpi.isDirty
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l188"><code>src&#x2F;Model.js:188</code></a>
+        <a href="../files/src_Model.js.html#l205"><code>src&#x2F;Model.js:205</code></a>
         </p>
 
 
@@ -1913,7 +2038,7 @@ kpi.isInFlight
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l176"><code>src&#x2F;Model.js:176</code></a>
+        <a href="../files/src_Model.js.html#l193"><code>src&#x2F;Model.js:193</code></a>
         </p>
 
 
@@ -1938,7 +2063,7 @@ kpi.isInFlight
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l218"><code>src&#x2F;Model.js:218</code></a>
+        <a href="../files/src_Model.js.html#l235"><code>src&#x2F;Model.js:235</code></a>
         </p>
 
 
@@ -1965,7 +2090,7 @@ kpi.isInFlight
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l95"><code>src&#x2F;Model.js:95</code></a>
+        <a href="../files/src_Model.js.html#l112"><code>src&#x2F;Model.js:112</code></a>
         </p>
 
 

--- a/docs/classes/RelatedRecordsArray.html
+++ b/docs/classes/RelatedRecordsArray.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.2.0</em>
+            <em>API Docs for: 1.3.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Schema.html
+++ b/docs/classes/Schema.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.2.0</em>
+            <em>API Docs for: 1.3.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Store.html
+++ b/docs/classes/Store.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.2.0</em>
+            <em>API Docs for: 1.3.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -156,6 +156,10 @@
                             </li>
                             <li class="index-item method">
                                 <a href="#method_addModels">addModels</a>
+
+                            </li>
+                            <li class="index-item method">
+                                <a href="#method_build">build</a>
 
                             </li>
                             <li class="index-item method">
@@ -307,7 +311,7 @@
                         <code>type</code>
                 </li>
                 <li class="arg">
-                        <code>properties</code>
+                        <code>attributes</code>
                 </li>
             </ul><span class="paren">)</span>
         </div>
@@ -325,7 +329,7 @@
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l33"><code>src&#x2F;Store.js:33</code></a>
+        <a href="../files/src_Store.js.html#l35"><code>src&#x2F;Store.js:35</code></a>
         </p>
 
 
@@ -357,7 +361,7 @@ kpi.name
 
                 </li>
                 <li class="param">
-                        <code class="param-name">properties</code>
+                        <code class="param-name">attributes</code>
                         <span class="type">Object</span>
 
 
@@ -409,7 +413,7 @@ kpi.name
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l54"><code>src&#x2F;Store.js:54</code></a>
+        <a href="../files/src_Store.js.html#l67"><code>src&#x2F;Store.js:67</code></a>
         </p>
 
 
@@ -487,7 +491,7 @@ kpi.name
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l71"><code>src&#x2F;Store.js:71</code></a>
+        <a href="../files/src_Store.js.html#l83"><code>src&#x2F;Store.js:83</code></a>
         </p>
 
 
@@ -538,6 +542,84 @@ kpi.name
 
 
 </div>
+<div id="method_build" class="method item">
+    <h3 class="name"><code>build</code></h3>
+
+        <div class="args">
+            <span class="paren">(</span><ul class="args-list inline commas">
+                <li class="arg">
+                        <code>type</code>
+                </li>
+                <li class="arg">
+                        <code>attributes</code>
+                </li>
+            </ul><span class="paren">)</span>
+        </div>
+
+        <span class="returns-inline">
+            <span class="type">Object</span>
+        </span>
+
+
+
+
+
+
+
+    <div class="meta">
+                <p>
+                Defined in
+        <a href="../files/src_Store.js.html#l56"><code>src&#x2F;Store.js:56</code></a>
+        </p>
+
+
+
+    </div>
+
+    <div class="description">
+        
+    </div>
+
+        <div class="params">
+            <h4>Parameters:</h4>
+
+            <ul class="params-list">
+                <li class="param">
+                        <code class="param-name">type</code>
+                        <span class="type">String</span>
+
+
+                    <div class="param-description">
+                         
+                    </div>
+
+                </li>
+                <li class="param">
+                        <code class="param-name">attributes</code>
+                        <span class="type">Object</span>
+
+
+                    <div class="param-description">
+                        <p>json api attributes</p>
+
+                    </div>
+
+                </li>
+            </ul>
+        </div>
+
+        <div class="returns">
+            <h4>Returns:</h4>
+
+            <div class="returns-description">
+                        <span class="type">Object</span>:
+                    <p>Artemis Data record</p>
+
+            </div>
+        </div>
+
+
+</div>
 <div id="method_constructor" class="method item">
     <h3 class="name"><code>constructor</code></h3>
 
@@ -553,7 +635,7 @@ kpi.name
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l24"><code>src&#x2F;Store.js:24</code></a>
+        <a href="../files/src_Store.js.html#l26"><code>src&#x2F;Store.js:26</code></a>
         </p>
 
 
@@ -599,7 +681,7 @@ kpi.name
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l604"><code>src&#x2F;Store.js:604</code></a>
+        <a href="../files/src_Store.js.html#l617"><code>src&#x2F;Store.js:617</code></a>
         </p>
 
 
@@ -681,7 +763,7 @@ kpi.name
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l587"><code>src&#x2F;Store.js:587</code></a>
+        <a href="../files/src_Store.js.html#l600"><code>src&#x2F;Store.js:600</code></a>
         </p>
 
 
@@ -734,7 +816,7 @@ kpi.name
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l551"><code>src&#x2F;Store.js:551</code></a>
+        <a href="../files/src_Store.js.html#l564"><code>src&#x2F;Store.js:564</code></a>
         </p>
 
 
@@ -790,7 +872,7 @@ kpi.name
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l365"><code>src&#x2F;Store.js:365</code></a>
+        <a href="../files/src_Store.js.html#l378"><code>src&#x2F;Store.js:378</code></a>
         </p>
 
 
@@ -856,7 +938,7 @@ kpi.name
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l639"><code>src&#x2F;Store.js:639</code></a>
+        <a href="../files/src_Store.js.html#l652"><code>src&#x2F;Store.js:652</code></a>
         </p>
 
 
@@ -924,7 +1006,7 @@ kpi.name
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l673"><code>src&#x2F;Store.js:673</code></a>
+        <a href="../files/src_Store.js.html#l686"><code>src&#x2F;Store.js:686</code></a>
         </p>
 
 
@@ -991,7 +1073,7 @@ kpi.name
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l625"><code>src&#x2F;Store.js:625</code></a>
+        <a href="../files/src_Store.js.html#l638"><code>src&#x2F;Store.js:638</code></a>
         </p>
 
 
@@ -1058,7 +1140,7 @@ kpi.name
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l161"><code>src&#x2F;Store.js:161</code></a>
+        <a href="../files/src_Store.js.html#l173"><code>src&#x2F;Store.js:173</code></a>
         </p>
 
 
@@ -1163,7 +1245,7 @@ end_time: '2020-06-02T00:00:00.000Z'
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l225"><code>src&#x2F;Store.js:225</code></a>
+        <a href="../files/src_Store.js.html#l237"><code>src&#x2F;Store.js:237</code></a>
         </p>
 
 
@@ -1239,7 +1321,7 @@ end_time: '2020-06-02T00:00:00.000Z'
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l95"><code>src&#x2F;Store.js:95</code></a>
+        <a href="../files/src_Store.js.html#l107"><code>src&#x2F;Store.js:107</code></a>
         </p>
 
 
@@ -1333,7 +1415,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l259"><code>src&#x2F;Store.js:259</code></a>
+        <a href="../files/src_Store.js.html#l271"><code>src&#x2F;Store.js:271</code></a>
         </p>
 
 
@@ -1404,7 +1486,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l139"><code>src&#x2F;Store.js:139</code></a>
+        <a href="../files/src_Store.js.html#l151"><code>src&#x2F;Store.js:151</code></a>
         </p>
 
 
@@ -1485,7 +1567,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l496"><code>src&#x2F;Store.js:496</code></a>
+        <a href="../files/src_Store.js.html#l509"><code>src&#x2F;Store.js:509</code></a>
         </p>
 
 
@@ -1563,7 +1645,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l481"><code>src&#x2F;Store.js:481</code></a>
+        <a href="../files/src_Store.js.html#l494"><code>src&#x2F;Store.js:494</code></a>
         </p>
 
 
@@ -1644,7 +1726,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l449"><code>src&#x2F;Store.js:449</code></a>
+        <a href="../files/src_Store.js.html#l462"><code>src&#x2F;Store.js:462</code></a>
         </p>
 
 
@@ -1732,7 +1814,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l464"><code>src&#x2F;Store.js:464</code></a>
+        <a href="../files/src_Store.js.html#l477"><code>src&#x2F;Store.js:477</code></a>
         </p>
 
 
@@ -1807,7 +1889,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l540"><code>src&#x2F;Store.js:540</code></a>
+        <a href="../files/src_Store.js.html#l553"><code>src&#x2F;Store.js:553</code></a>
         </p>
 
 
@@ -1878,7 +1960,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l391"><code>src&#x2F;Store.js:391</code></a>
+        <a href="../files/src_Store.js.html#l404"><code>src&#x2F;Store.js:404</code></a>
         </p>
 
 
@@ -1967,7 +2049,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l523"><code>src&#x2F;Store.js:523</code></a>
+        <a href="../files/src_Store.js.html#l536"><code>src&#x2F;Store.js:536</code></a>
         </p>
 
 
@@ -2046,7 +2128,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l409"><code>src&#x2F;Store.js:409</code></a>
+        <a href="../files/src_Store.js.html#l422"><code>src&#x2F;Store.js:422</code></a>
         </p>
 
 
@@ -2121,7 +2203,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l429"><code>src&#x2F;Store.js:429</code></a>
+        <a href="../files/src_Store.js.html#l442"><code>src&#x2F;Store.js:442</code></a>
         </p>
 
 
@@ -2189,7 +2271,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l508"><code>src&#x2F;Store.js:508</code></a>
+        <a href="../files/src_Store.js.html#l521"><code>src&#x2F;Store.js:521</code></a>
         </p>
 
 
@@ -2264,7 +2346,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l380"><code>src&#x2F;Store.js:380</code></a>
+        <a href="../files/src_Store.js.html#l393"><code>src&#x2F;Store.js:393</code></a>
         </p>
 
 
@@ -2326,7 +2408,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l307"><code>src&#x2F;Store.js:307</code></a>
+        <a href="../files/src_Store.js.html#l319"><code>src&#x2F;Store.js:319</code></a>
         </p>
 
 
@@ -2380,7 +2462,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l330"><code>src&#x2F;Store.js:330</code></a>
+        <a href="../files/src_Store.js.html#l342"><code>src&#x2F;Store.js:342</code></a>
         </p>
 
 
@@ -2434,7 +2516,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l319"><code>src&#x2F;Store.js:319</code></a>
+        <a href="../files/src_Store.js.html#l331"><code>src&#x2F;Store.js:331</code></a>
         </p>
 
 
@@ -2482,7 +2564,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l344"><code>src&#x2F;Store.js:344</code></a>
+        <a href="../files/src_Store.js.html#l357"><code>src&#x2F;Store.js:357</code></a>
         </p>
 
 
@@ -2524,7 +2606,7 @@ as the primary key</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l81"><code>src&#x2F;Store.js:81</code></a>
+        <a href="../files/src_Store.js.html#l93"><code>src&#x2F;Store.js:93</code></a>
         </p>
 
 
@@ -2584,7 +2666,7 @@ in mobx.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l284"><code>src&#x2F;Store.js:284</code></a>
+        <a href="../files/src_Store.js.html#l296"><code>src&#x2F;Store.js:296</code></a>
         </p>
 
 
@@ -2620,7 +2702,7 @@ store.reset()
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l12"><code>src&#x2F;Store.js:12</code></a>
+        <a href="../files/src_Store.js.html#l14"><code>src&#x2F;Store.js:14</code></a>
         </p>
 
 

--- a/docs/data.json
+++ b/docs/data.json
@@ -3,7 +3,7 @@
         "name": "mobx-async-store",
         "description": "Asyc Data Store for mobx",
         "url": "https://github.com/artemis-ag/mobx-async-store",
-        "version": "1.2.0"
+        "version": "1.3.0"
     },
     "files": {
         "src/decorators/attributes.js": {
@@ -325,6 +325,39 @@
         {
             "file": "src/Model.js",
             "line": 85,
+            "itemtype": "method",
+            "name": "fetchOne",
+            "params": [
+                {
+                    "name": "id",
+                    "description": "",
+                    "type": "String"
+                },
+                {
+                    "name": "params",
+                    "description": "",
+                    "type": "Object"
+                }
+            ],
+            "class": "Model"
+        },
+        {
+            "file": "src/Model.js",
+            "line": 94,
+            "itemtype": "method",
+            "name": "fetchAll",
+            "params": [
+                {
+                    "name": "params",
+                    "description": "",
+                    "type": "Object"
+                }
+            ],
+            "class": "Model"
+        },
+        {
+            "file": "src/Model.js",
+            "line": 102,
             "description": "Initializer for model",
             "itemtype": "method",
             "name": "constructor",
@@ -332,7 +365,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 95,
+            "line": 112,
             "description": "The type of the model. Defined on the class. Defaults to the underscored version of the class name\n(eg 'calendar_events').",
             "itemtype": "property",
             "name": "type",
@@ -341,7 +374,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 103,
+            "line": 120,
             "description": "The canonical path to the resource on the server. Defined on the class.\nDefaults to the underscored version of the class name",
             "itemtype": "property",
             "name": "endpoint",
@@ -350,7 +383,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 110,
+            "line": 127,
             "description": "has this object been destroyed?",
             "itemtype": "property",
             "name": "_disposed",
@@ -360,7 +393,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 118,
+            "line": 135,
             "description": "set of relationships which have changed since last snapshot",
             "itemtype": "property",
             "name": "_dirtyRelationships",
@@ -369,7 +402,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 125,
+            "line": 142,
             "description": "set of attributes which have changed since last snapshot",
             "itemtype": "property",
             "name": "_dirtyAttributes",
@@ -378,7 +411,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 132,
+            "line": 149,
             "description": "True if the instance has been modified from its persisted state\n\nNOTE that isDirty does _NOT_ track changes to the related objects\nbut it _does_ track changes to the relationships themselves.\n\nFor example, adding or removing a related object will mark this record as dirty,\nbut changing a related object's properties will not mark this record as dirty.\n\nThe caller is reponsible for asking related objects about their\nown dirty state.\n\n```\nkpi = store.add('kpis', { name: 'A good thing to measure' })\nkpi.isDirty\n=> true\nkpi.name\n=> \"A good thing to measure\"\nawait kpi.save()\nkpi.isDirty\n=> false\nkpi.name = \"Another good thing to measure\"\nkpi.isDirty\n=> true\nawait kpi.save()\nkpi.isDirty\n=> false\n```",
             "itemtype": "property",
             "name": "isDirty",
@@ -387,7 +420,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 167,
+            "line": 184,
             "description": "have any changes been made since this record was last persisted?",
             "itemtype": "property",
             "name": "hasUnpersistedChanges",
@@ -396,7 +429,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 176,
+            "line": 193,
             "description": "True if the model has not been sent to the store",
             "itemtype": "property",
             "name": "isNew",
@@ -405,7 +438,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 188,
+            "line": 205,
             "description": "True if the instance is coming from / going to the server\n```\nkpi = store.find('kpis', 5)\n// fetch started\nkpi.isInFlight\n=> true\n// fetch finished\nkpi.isInFlight\n=> false\n```",
             "itemtype": "property",
             "name": "isInFlight",
@@ -415,7 +448,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 205,
+            "line": 222,
             "description": "A hash of errors from the server\n```\nkpi = store.find('kpis', 5)\nkpi.errors\n=> { authorization: \"You do not have access to this resource\" }\n```",
             "itemtype": "property",
             "name": "errors",
@@ -425,7 +458,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 218,
+            "line": 235,
             "description": "a list of snapshots that have been taken since the record was either last persisted or since it was instantiated",
             "itemtype": "property",
             "name": "snapshots",
@@ -435,7 +468,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 227,
+            "line": 244,
             "description": "restores data to its last snapshot state\n```\nkpi = store.find('kpis', 5)\nkpi.name\n=> \"A good thing to measure\"\nkpi.name = \"Another good thing to measure\"\nkpi.rollback()\nkpi.name\n=> \"A good thing to measure\"\n```",
             "itemtype": "method",
             "name": "rollback",
@@ -443,7 +476,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 244,
+            "line": 261,
             "description": "restores data to its last persisted state or the oldest snapshot\nstate if the model was never persisted",
             "itemtype": "method",
             "name": "rollbackToPersisted",
@@ -451,7 +484,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 254,
+            "line": 271,
             "description": "creates or updates a record.",
             "itemtype": "method",
             "name": "save",
@@ -470,7 +503,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 307,
+            "line": 324,
             "description": "Checks all validations, adding errors where necessary and returning `false` if any are not valid\nDefault is to check all validations, but they can be selectively run via options:\n - attributes - an array of names of attributes to validate\n - relationships - an array of names of relationships to validate",
             "itemtype": "method",
             "name": "validate",
@@ -489,7 +522,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 331,
+            "line": 348,
             "description": "deletes a record from the store and server",
             "itemtype": "method",
             "name": "destroy",
@@ -501,7 +534,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 400,
+            "line": 417,
             "description": "Magic method that makes changes to records\nobservable",
             "itemtype": "method",
             "name": "_makeObservable",
@@ -509,7 +542,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 417,
+            "line": 434,
             "description": "sets up a reaction for each top-level attribute so we can compare\nvalues after each mutation and keep track of dirty attr states\nif an attr is different than the last snapshot, add it to the\n_dirtyAttributes set\nif it's the same as the last snapshot, make sure it's _not_ in the\n_dirtyAttributes set",
             "itemtype": "method",
             "name": "_listenForChanges",
@@ -517,7 +550,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 450,
+            "line": 467,
             "description": "call this when destroying an object to make sure that we clean up\nany event listeners and don't leak memory",
             "itemtype": "method",
             "name": "dispose",
@@ -525,7 +558,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 460,
+            "line": 477,
             "description": "The current state of defined attributes and relationships of the instance\nReally just an alias for attributes\n```\ntodo = store.find('todos', 5)\ntodo.title\n=> \"Buy the eggs\"\nsnapshot = todo.snapshot\ntodo.title = \"Buy the eggs and bacon\"\nsnapshot.title\n=> \"Buy the eggs and bacon\"\n```",
             "itemtype": "method",
             "name": "snapshot",
@@ -537,7 +570,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 482,
+            "line": 499,
             "description": "Sets previous snapshot to current snapshot",
             "itemtype": "method",
             "name": "setPreviousSnapshot",
@@ -545,7 +578,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 491,
+            "line": 508,
             "description": "the latest snapshot",
             "itemtype": "method",
             "name": "previousSnapshot",
@@ -553,7 +586,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 502,
+            "line": 519,
             "description": "the latest persisted snapshot or the first snapshot if the model was never persisted",
             "itemtype": "method",
             "name": "previousSnapshot",
@@ -561,7 +594,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 511,
+            "line": 528,
             "description": "take a snapshot of the current model state.\nif persisted, clear the stack and push this snapshot to the top\nif not persisted, push this snapshot to the top of the stack",
             "itemtype": "method",
             "name": "_takeSnapshot",
@@ -576,7 +609,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 534,
+            "line": 551,
             "description": "set the current attributes and relationships to the attributes\nand relationships of the snapshot to be applied. also reset errors",
             "itemtype": "method",
             "name": "_applySnapshot",
@@ -591,7 +624,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 551,
+            "line": 568,
             "description": "a list of any property paths which have been changed since the previous\nsnapshot\n```\nconst todo = new Todo({ title: 'Buy Milk' })\ntodo.dirtyAttributes\n=> []\ntodo.title = 'Buy Cheese'\ntodo.dirtyAttributes\n=> ['title']\n```",
             "itemtype": "method",
             "name": "dirtyAttributes",
@@ -603,7 +636,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 572,
+            "line": 589,
             "description": "shortcut to get the static",
             "itemtype": "method",
             "name": "type",
@@ -615,7 +648,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 582,
+            "line": 599,
             "description": "current attributes of record",
             "itemtype": "method",
             "name": "attributes",
@@ -627,7 +660,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 600,
+            "line": 617,
             "description": "Getter find the attribute definition for the model type.",
             "itemtype": "method",
             "name": "attributeDefinitions",
@@ -639,7 +672,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 611,
+            "line": 628,
             "description": "Getter find the relationship definitions for the model type.",
             "itemtype": "method",
             "name": "relationshipDefinitions",
@@ -651,7 +684,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 622,
+            "line": 639,
             "description": "Getter to check if the record has errors.",
             "itemtype": "method",
             "name": "hasErrors",
@@ -663,7 +696,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 632,
+            "line": 649,
             "description": "Getter to check if the record has errors.",
             "itemtype": "method",
             "name": "hasErrors",
@@ -675,7 +708,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 642,
+            "line": 659,
             "description": "Getter to just get the names of a records attributes.",
             "itemtype": "method",
             "name": "attributeNames",
@@ -687,7 +720,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 652,
+            "line": 669,
             "description": "Getter to just get the names of a records relationships.",
             "itemtype": "method",
             "name": "relationshipNames",
@@ -699,7 +732,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 662,
+            "line": 679,
             "description": "getter method to get the default attributes",
             "itemtype": "method",
             "name": "defaultAttributes",
@@ -711,7 +744,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 679,
+            "line": 696,
             "description": "getter method to get data in api compliance format\nTODO: Figure out how to handle unpersisted ids",
             "itemtype": "method",
             "name": "jsonapi",
@@ -723,7 +756,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 760,
+            "line": 777,
             "description": "clone this object, deeply copy attrs and relationships (related\nobjects are not cloned, but the relationships themselves are)",
             "itemtype": "method",
             "name": "clone",
@@ -735,7 +768,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 773,
+            "line": 790,
             "description": "Comparison by value\nreturns `true` if this object has the same attrs and relationships\nas the \"other\" object, ignores differences in internal state like\nattribute \"dirtyness\" or errors",
             "itemtype": "method",
             "name": "isEqual",
@@ -754,7 +787,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 788,
+            "line": 805,
             "description": "Comparison by identity\nreturns `true` if this object has the same type and id as the\n\"other\" object, ignores differences in attrs and relationships",
             "itemtype": "method",
             "name": "isSame",
@@ -773,7 +806,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 12,
+            "line": 14,
             "description": "Observable property used to store data and\nhandle changes to state",
             "itemtype": "property",
             "name": "data",
@@ -783,7 +816,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 24,
+            "line": 26,
             "description": "Initializer for Store class",
             "itemtype": "method",
             "name": "constructor",
@@ -791,7 +824,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 33,
+            "line": 35,
             "description": "Adds an instance or an array of instances to the store.\n```\nkpiHash = { name: \"A good thing to measure\" }\nkpi = store.add('kpis', kpiHash)\nkpi.name\n=> \"A good thing to measure\"\n```",
             "itemtype": "method",
             "name": "add",
@@ -802,7 +835,7 @@
                     "type": "String"
                 },
                 {
-                    "name": "properties",
+                    "name": "attributes",
                     "description": "the properties to use",
                     "type": "Object"
                 }
@@ -815,7 +848,30 @@
         },
         {
             "file": "src/Store.js",
-            "line": 54,
+            "line": 56,
+            "itemtype": "method",
+            "name": "build",
+            "params": [
+                {
+                    "name": "type",
+                    "description": "",
+                    "type": "String"
+                },
+                {
+                    "name": "attributes",
+                    "description": "json api attributes",
+                    "type": "Object"
+                }
+            ],
+            "return": {
+                "description": "Artemis Data record",
+                "type": "Object"
+            },
+            "class": "Store"
+        },
+        {
+            "file": "src/Store.js",
+            "line": 67,
             "itemtype": "method",
             "name": "addModel",
             "params": [
@@ -838,7 +894,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 71,
+            "line": 83,
             "itemtype": "method",
             "name": "addModels",
             "params": [
@@ -861,7 +917,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 81,
+            "line": 93,
             "description": "Adds a record from the store. We can't simply remove the record\nby deleting the records property/key via delete due to a bug\nin mobx.",
             "itemtype": "method",
             "name": "remove",
@@ -881,7 +937,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 95,
+            "line": 107,
             "description": "finds an instance by `id`. If available in the store, returns that instance. Otherwise, triggers a fetch.\n\n  store.findOne('todos', 5)\n  // fetch triggered\n  => event1\n  store.findOne('todos', 5)\n  // no fetch triggered\n  => event1\n\nPassing `fromServer` as an option will always trigger a fetch if `true` and never trigger a fetch if `false`.\nOtherwise, it will trigger the default behavior\n\n  store.findOne('todos', 5, { fromServer: false })\n  // no fetch triggered\n  => undefined\n\n  store.findOne('todos', 5)\n  // fetch triggered\n  => event1\n\n  store.findOne('todos', 5, { fromServer: true })\n  // fetch triggered\n  => event1",
             "itemtype": "method",
             "name": "findOne",
@@ -905,7 +961,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 139,
+            "line": 151,
             "description": "returns cache if exists, returns promise if not",
             "itemtype": "method",
             "name": "findOrFetchOne",
@@ -929,7 +985,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 161,
+            "line": 173,
             "description": "finds all of the instances of a given type. If there are instances available in the store,\nit will return those, otherwise it will trigger a fetch\n\n  store.findAll('todos')\n  // fetch triggered\n  => [event1, event2, event3]\n  store.findAll('todos')\n  // no fetch triggered\n  => [event1, event2, event3]\n\npassing `fromServer` as an option will always trigger a\nfetch if `true` and never trigger a fetch if `false`.\nOtherwise, it will trigger the default behavior\n\n  store.findAll('todos', { fromServer: false })\n  // no fetch triggered\n  => []\n\n  store.findAll('todos')\n  // fetch triggered\n  => [event1, event2, event3]\n\n  // async stuff happens on the server\n  store.findAll('todos')\n  // no fetch triggered\n  => [event1, event2, event3]\n\n  store.findAll('todos', { fromServer: true })\n  // fetch triggered\n  => [event1, event2, event3, event4]\n\nQuery params can be passed as part of the options hash.\nThe response will be cached, so the next time `findAll`\nis called with identical params and values, the store will\nfirst look for the local result (unless `fromServer` is `true`)\n\n  store.findAll('todos', {\n    queryParams: {\n      filter: {\n        start_time: '2020-06-01T00:00:00.000Z',\n        end_time: '2020-06-02T00:00:00.000Z'\n      }\n    }\n  })",
             "itemtype": "method",
             "name": "findAll",
@@ -949,7 +1005,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 225,
+            "line": 237,
             "itemtype": "method",
             "name": "findAndFetchAll",
             "params": [
@@ -972,7 +1028,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 259,
+            "line": 271,
             "description": "returns cache if exists, returns promise if not",
             "itemtype": "method",
             "name": "findOrFetchAll",
@@ -992,7 +1048,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 284,
+            "line": 296,
             "description": "Clears the store of a given type, or clears all if no type given\n\n  store.reset('todos')\n  // removes all todos from store\n  store.reset()\n  // clears store",
             "itemtype": "method",
             "name": "reset",
@@ -1000,7 +1056,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 307,
+            "line": 319,
             "description": "Entry point for configuring the store",
             "itemtype": "method",
             "name": "init",
@@ -1015,7 +1071,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 319,
+            "line": 331,
             "description": "Entry point for configuring the store",
             "itemtype": "method",
             "name": "initializeNetworkConfiguration",
@@ -1030,7 +1086,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 330,
+            "line": 342,
             "description": "Entry point for configuring the store",
             "itemtype": "method",
             "name": "initializeNetworkConfiguration",
@@ -1045,7 +1101,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 344,
+            "line": 357,
             "description": "Creates an obserable index with model types\nas the primary key\n\nObservable({ todos: {} })",
             "itemtype": "method",
             "name": "initializeObservableDataProperty",
@@ -1053,7 +1109,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 365,
+            "line": 378,
             "description": "Wrapper around fetch applies user defined fetch options",
             "itemtype": "method",
             "name": "fetch",
@@ -1073,7 +1129,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 380,
+            "line": 393,
             "description": "Gets type of collection from data observable",
             "itemtype": "method",
             "name": "getType",
@@ -1092,7 +1148,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 391,
+            "line": 404,
             "description": "Get single all record\nbased on query params",
             "itemtype": "method",
             "name": "getMatchingRecord",
@@ -1120,7 +1176,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 409,
+            "line": 422,
             "description": "Gets individual record from store",
             "itemtype": "method",
             "name": "getRecord",
@@ -1144,7 +1200,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 429,
+            "line": 442,
             "description": "Gets records for type of collection from observable",
             "itemtype": "method",
             "name": "getRecords",
@@ -1163,7 +1219,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 449,
+            "line": 462,
             "description": "Gets single from store based on cached query",
             "itemtype": "method",
             "name": "getCachedRecord",
@@ -1191,7 +1247,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 464,
+            "line": 477,
             "description": "Gets records from store based on cached query",
             "itemtype": "method",
             "name": "getCachedRecords",
@@ -1215,7 +1271,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 481,
+            "line": 494,
             "description": "Gets records from store based on cached query",
             "itemtype": "method",
             "name": "getCachedIds",
@@ -1239,7 +1295,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 496,
+            "line": 509,
             "description": "Gets records from store based on cached query",
             "itemtype": "method",
             "name": "getCachedId",
@@ -1263,7 +1319,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 508,
+            "line": 521,
             "description": "Get multiple records by id",
             "itemtype": "method",
             "name": "getRecordsById",
@@ -1287,7 +1343,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 523,
+            "line": 536,
             "description": "Gets records all records or records\nbased on query params",
             "itemtype": "method",
             "name": "getMatchingRecords",
@@ -1311,7 +1367,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 540,
+            "line": 553,
             "description": "Helper to look up model class for type.",
             "itemtype": "method",
             "name": "getKlass",
@@ -1330,7 +1386,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 551,
+            "line": 564,
             "description": "Creates or updates a model",
             "itemtype": "method",
             "name": "createOrUpdateModel",
@@ -1345,7 +1401,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 587,
+            "line": 600,
             "description": "Create multiple models from an array of data",
             "itemtype": "method",
             "name": "createModelsFromData",
@@ -1360,7 +1416,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 604,
+            "line": 617,
             "description": "Helper to create a new model",
             "itemtype": "method",
             "name": "createModel",
@@ -1389,7 +1445,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 625,
+            "line": 638,
             "description": "Builds fetch url based",
             "itemtype": "method",
             "name": "fetchUrl",
@@ -1409,7 +1465,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 639,
+            "line": 652,
             "description": "finds an instance by `id`. If available in the store, returns that instance. Otherwise, triggers a fetch.",
             "itemtype": "method",
             "name": "fetchAll",
@@ -1429,7 +1485,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 673,
+            "line": 686,
             "description": "fetches record by `id`.",
             "async": 1,
             "itemtype": "method",

--- a/docs/files/src_Model.js.html
+++ b/docs/files/src_Model.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.2.0</em>
+            <em>API Docs for: 1.3.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -167,6 +167,23 @@ function stringifyIds (object) {
  @class Model
  */
 class Model {
+  /**
+   * @method fetchOne
+   * @param {String} id
+   * @param {Object} params
+   */
+  static fetchOne (id, params = {}) {
+    return this.store.fetchOne(this.type, id, params)
+  }
+
+  /**
+   * @method fetchAll
+   * @param {Object} params
+   */
+  static fetchAll (params = {}) {
+    return this.store.fetchAll(this.type, params)
+  }
+
   /**
    * Initializer for model
    *

--- a/docs/files/src_Store.js.html
+++ b/docs/files/src_Store.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.2.0</em>
+            <em>API Docs for: 1.3.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -94,6 +94,8 @@ import { dbOrNewId, requestUrl, uniqueBy, combineRacedRequests } from &#x27;./ut
  * @constructor
  */
 class Store {
+  static types = []
+
   /**
    * Observable property used to store data and
    * handle changes to state
@@ -125,15 +127,26 @@ class Store {
    * &#x60;&#x60;&#x60;
    * @method add
    * @param {String} type
-   * @param {Object} properties the properties to use
+   * @param {Object} attributes the properties to use
    * @return {Object} the new record
    */
-  add = (type, data) =&gt; {
-    if (data.constructor.name === &#x27;Array&#x27;) {
-      return this.addModels(type, data)
+  add = (type, attributes) =&gt; {
+    if (attributes.constructor.name === &#x27;Array&#x27;) {
+      return this.addModels(type, attributes)
     } else {
-      return this.addModel(type, toJS(data))
+      return this.addModel(type, toJS(attributes))
     }
+  }
+
+  /**
+   * @method build
+   * @param {String} type
+   * @param {Object} attributes json api attributes
+   * @return {Object} Artemis Data record
+   */
+  build = (type, attributes) =&gt; {
+    const id = dbOrNewId(attributes)
+    return this.createModel(type, id, { attributes })
   }
 
   /**
@@ -144,11 +157,10 @@ class Store {
    */
   @action
   addModel = (type, attributes) =&gt; {
-    const id = dbOrNewId(attributes)
-    const model = this.createModel(type, id, { attributes })
+    const model = this.build(type, attributes)
 
     // Add the model to the type records index
-    this.data[type].records.set(String(id), model)
+    this.data[type].records.set(String(model.id), model)
 
     return model
   }
@@ -421,6 +433,7 @@ class Store {
   initializeModelTypeIndex () {
     const { types } = this.constructor
     this.modelTypeIndex = types.reduce((modelTypeIndex, modelKlass) =&gt; {
+      modelKlass.store = this
       modelTypeIndex[modelKlass.type] = modelKlass
       return modelTypeIndex
     }, {})

--- a/docs/files/src_decorators_attributes.js.html
+++ b/docs/files/src_decorators_attributes.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.2.0</em>
+            <em>API Docs for: 1.3.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_relationships.js.html
+++ b/docs/files/src_decorators_relationships.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.2.0</em>
+            <em>API Docs for: 1.3.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_schema.js.html
+++ b/docs/files/src_schema.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.2.0</em>
+            <em>API Docs for: 1.3.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_utils.js.html
+++ b/docs/files/src_utils.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.2.0</em>
+            <em>API Docs for: 1.3.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
                 <h1><img src="./assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.2.0</em>
+            <em>API Docs for: 1.3.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -1139,4 +1139,33 @@ describe('Model', () => {
       expect(todo.isDirty).toBe(false)
     })
   })
+
+  describe('Model.fetchAll', () => {
+    it('finds all via the store', async () => {
+      const todo = store.add('organizations', { id: 1, title: 'Buy Milk' })
+      store.fetchAll = jest.fn(() => Promise.resolve([todo]))
+      const found = await Organization.fetchAll({ title: 'foo' })
+      expect(found.length).toBe(1)
+      expect(found[0].id).toBe(todo.id)
+      const { calls } = store.fetchAll.mock
+      expect(calls.length).toBe(1)
+      const [type, options] = calls[0]
+      expect(type).toEqual('organizations')
+      expect(options.title).toEqual('foo')
+    })
+  })
+
+  describe('Model.fetchOne', () => {
+    it('finds one via the store', async () => {
+      const todo = store.add('organizations', { id: 1, title: 'Buy Milk' })
+      store.fetchOne = jest.fn(() => Promise.resolve(todo))
+      const found = await Organization.fetchOne(1)
+      expect(found.id).toBe(todo.id)
+      const { calls } = store.fetchOne.mock
+      expect(calls.length).toBe(1)
+      const [type, id] = calls[0]
+      expect(type).toEqual('organizations')
+      expect(id).toEqual(1)
+    })
+  })
 })

--- a/src/Model.js
+++ b/src/Model.js
@@ -99,6 +99,14 @@ class Model {
     return this.store.fetchAll(this.type, params)
   }
 
+  static findOne (id, options = {}) {
+    return this.store.findOne(this.type, id, options)
+  }
+
+  static findAll (options = {}) {
+    return this.store.findAll(this.type, options)
+  }
+
   /**
    * Initializer for model
    *

--- a/src/Model.js
+++ b/src/Model.js
@@ -83,6 +83,23 @@ function stringifyIds (object) {
  */
 class Model {
   /**
+   * @method fetchOne
+   * @param {String} id
+   * @param {Object} params
+   */
+  static fetchOne (id, params = {}) {
+    return this.store.fetchOne(this.type, id, params)
+  }
+
+  /**
+   * @method fetchAll
+   * @param {Object} params
+   */
+  static fetchAll (params = {}) {
+    return this.store.fetchAll(this.type, params)
+  }
+
+  /**
    * Initializer for model
    *
    * @method constructor


### PR DESCRIPTION
We have too many "utils" scattered around our code base which encode different ways of fetching a particular model. I think it's time that we introduce static "fetcher" methods:

* `Model.fetchAll(params)`
* `Model.fetchOne(id, params)`

These methods each delegate to the corresponding fetch methods in the store.

This means that:
* we don't need a reference to the `dataStore` to do a fetch. We can do it from the model class, which we can import in whichever module we happen to be in

    ```javascript
    CropBatch.fetchAll(queryParams)
    ```

* we could move fetch utils into `ArtemisStore` where they can be part of the Model api and can be tested as such.
    ```javascript
    CropBatch.fetchBetween(startDate, endDate)
    ```

I only added `fetch` variants and avoided `find` variants because we currently don't support filtering records which have already been loaded by query params. I'd like to add support for that as well since that could enable a more sophisticated caching model, partial fetching, and UIs where cached date can be rendered before new data is returned, but that will be more work. This is more to demonstrate a path forward towards those ends than to be an all-encompassing solution.