### PR TITLE
Store#build

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,28 @@ const todos = store.add('todos', [
 ])
 ```
 
+### Building without adding to the store
+
+Records can be built without being added to the store with `Store#build`
+
+```JavaScript
+const todo = store.build('todos', { title: 'Buy Milk', category: 'chores' })
+```
+
+Newly created client records with have a temporary id by default.
+
+```JavaScript
+todo.id
+// => tmp-6b46fa20-db49-11e9-8256-1be9dad543b1
+```
+
+The newly built record will be ephemeral and will not be added to the store
+```JavaScript
+store.findOne('todos', todo.id)
+// => undefined
+```
+
+
 ### Persisting records with `Model#save`
 
 Records created on client side can be persisted via an AJAX request by calling the `save` method on the record.

--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -1371,6 +1371,16 @@ function () {
       }
     };
 
+    this.build = function (type, attributes) {
+      var id = dbOrNewId(attributes);
+
+      var model = _this.createModel(type, id, {
+        attributes: attributes
+      });
+
+      return model;
+    };
+
     _initializerDefineProperty(this, "addModel", _descriptor2$1, this);
 
     this.addModels = function (type, data) {

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -1365,6 +1365,16 @@ function () {
       }
     };
 
+    this.build = function (type, attributes) {
+      var id = dbOrNewId(attributes);
+
+      var model = _this.createModel(type, id, {
+        attributes: attributes
+      });
+
+      return model;
+    };
+
     _initializerDefineProperty(this, "addModel", _descriptor2$1, this);
 
     this.addModels = function (type, data) {

--- a/docs/classes/Model.html
+++ b/docs/classes/Model.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.3.0</em>
+            <em>API Docs for: 1.4.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/RelatedRecordsArray.html
+++ b/docs/classes/RelatedRecordsArray.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.3.0</em>
+            <em>API Docs for: 1.4.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Schema.html
+++ b/docs/classes/Schema.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.3.0</em>
+            <em>API Docs for: 1.4.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Store.html
+++ b/docs/classes/Store.html
@@ -151,15 +151,15 @@
 
                             </li>
                             <li class="index-item method">
-                                <a href="#method_add">add</a>
-
-                            </li>
-                            <li class="index-item method">
                                 <a href="#method_addModel">addModel</a>
 
                             </li>
                             <li class="index-item method">
                                 <a href="#method_addModels">addModels</a>
+
+                            </li>
+                            <li class="index-item method">
+                                <a href="#method_build">build</a>
 
                             </li>
                             <li class="index-item method">
@@ -394,90 +394,6 @@ kpi.name
 
 
 </div>
-<div id="method_add" class="method item">
-    <h3 class="name"><code>add</code></h3>
-
-        <div class="args">
-            <span class="paren">(</span><ul class="args-list inline commas">
-                <li class="arg">
-                        <code>type</code>
-                </li>
-                <li class="arg">
-                        <code>properties</code>
-                </li>
-            </ul><span class="paren">)</span>
-        </div>
-
-        <span class="returns-inline">
-            <span class="type">Object</span>
-        </span>
-
-
-
-
-
-
-
-    <div class="meta">
-                <p>
-                Defined in
-        <a href="../files/src_Store.js.html#l54"><code>src&#x2F;Store.js:54</code></a>
-        </p>
-
-
-
-    </div>
-
-    <div class="description">
-        <p>builds an instance of a model but does not add it to the store</p>
-<pre class="code prettyprint"><code>kpiHash = { name: &quot;A good thing to measure&quot; }
-kpi = store.build('kpis', kpiHash)
-kpi.name
-=&gt; &quot;A good thing to measure&quot;
-</code></pre>
-
-    </div>
-
-        <div class="params">
-            <h4>Parameters:</h4>
-
-            <ul class="params-list">
-                <li class="param">
-                        <code class="param-name">type</code>
-                        <span class="type">String</span>
-
-
-                    <div class="param-description">
-                         
-                    </div>
-
-                </li>
-                <li class="param">
-                        <code class="param-name">properties</code>
-                        <span class="type">Object</span>
-
-
-                    <div class="param-description">
-                        <p>the properties to use</p>
-
-                    </div>
-
-                </li>
-            </ul>
-        </div>
-
-        <div class="returns">
-            <h4>Returns:</h4>
-
-            <div class="returns-description">
-                        <span class="type">Object</span>:
-                    <p>the new record</p>
-
-            </div>
-        </div>
-
-
-</div>
 <div id="method_addModel" class="method item">
     <h3 class="name"><code>addModel</code></h3>
 
@@ -628,6 +544,90 @@ kpi.name
             <div class="returns-description">
                         <span class="type">Array</span>:
                     <p>array of ArtemisData records</p>
+
+            </div>
+        </div>
+
+
+</div>
+<div id="method_build" class="method item">
+    <h3 class="name"><code>build</code></h3>
+
+        <div class="args">
+            <span class="paren">(</span><ul class="args-list inline commas">
+                <li class="arg">
+                        <code>type</code>
+                </li>
+                <li class="arg">
+                        <code>properties</code>
+                </li>
+            </ul><span class="paren">)</span>
+        </div>
+
+        <span class="returns-inline">
+            <span class="type">Object</span>
+        </span>
+
+
+
+
+
+
+
+    <div class="meta">
+                <p>
+                Defined in
+        <a href="../files/src_Store.js.html#l54"><code>src&#x2F;Store.js:54</code></a>
+        </p>
+
+
+
+    </div>
+
+    <div class="description">
+        <p>Builds an instance of a model that includes either an automatically or manually created temporary ID, but does not add it to the store.</p>
+<pre class="code prettyprint"><code>kpiHash = { name: &quot;A good thing to measure&quot; }
+kpi = store.build('kpis', kpiHash)
+kpi.name
+=&gt; &quot;A good thing to measure&quot;
+</code></pre>
+
+    </div>
+
+        <div class="params">
+            <h4>Parameters:</h4>
+
+            <ul class="params-list">
+                <li class="param">
+                        <code class="param-name">type</code>
+                        <span class="type">String</span>
+
+
+                    <div class="param-description">
+                         
+                    </div>
+
+                </li>
+                <li class="param">
+                        <code class="param-name">properties</code>
+                        <span class="type">Object</span>
+
+
+                    <div class="param-description">
+                        <p>the properties to use</p>
+
+                    </div>
+
+                </li>
+            </ul>
+        </div>
+
+        <div class="returns">
+            <h4>Returns:</h4>
+
+            <div class="returns-description">
+                        <span class="type">Object</span>:
+                    <p>the new record</p>
 
             </div>
         </div>

--- a/docs/classes/Store.html
+++ b/docs/classes/Store.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.3.0</em>
+            <em>API Docs for: 1.4.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -146,6 +146,10 @@
                     <h3>Methods</h3>
 
                     <ul class="index-list methods">
+                            <li class="index-item method">
+                                <a href="#method_add">add</a>
+
+                            </li>
                             <li class="index-item method">
                                 <a href="#method_add">add</a>
 
@@ -390,6 +394,90 @@ kpi.name
 
 
 </div>
+<div id="method_add" class="method item">
+    <h3 class="name"><code>add</code></h3>
+
+        <div class="args">
+            <span class="paren">(</span><ul class="args-list inline commas">
+                <li class="arg">
+                        <code>type</code>
+                </li>
+                <li class="arg">
+                        <code>properties</code>
+                </li>
+            </ul><span class="paren">)</span>
+        </div>
+
+        <span class="returns-inline">
+            <span class="type">Object</span>
+        </span>
+
+
+
+
+
+
+
+    <div class="meta">
+                <p>
+                Defined in
+        <a href="../files/src_Store.js.html#l54"><code>src&#x2F;Store.js:54</code></a>
+        </p>
+
+
+
+    </div>
+
+    <div class="description">
+        <p>builds an instance of a model but does not add it to the store</p>
+<pre class="code prettyprint"><code>kpiHash = { name: &quot;A good thing to measure&quot; }
+kpi = store.build('kpis', kpiHash)
+kpi.name
+=&gt; &quot;A good thing to measure&quot;
+</code></pre>
+
+    </div>
+
+        <div class="params">
+            <h4>Parameters:</h4>
+
+            <ul class="params-list">
+                <li class="param">
+                        <code class="param-name">type</code>
+                        <span class="type">String</span>
+
+
+                    <div class="param-description">
+                         
+                    </div>
+
+                </li>
+                <li class="param">
+                        <code class="param-name">properties</code>
+                        <span class="type">Object</span>
+
+
+                    <div class="param-description">
+                        <p>the properties to use</p>
+
+                    </div>
+
+                </li>
+            </ul>
+        </div>
+
+        <div class="returns">
+            <h4>Returns:</h4>
+
+            <div class="returns-description">
+                        <span class="type">Object</span>:
+                    <p>the new record</p>
+
+            </div>
+        </div>
+
+
+</div>
 <div id="method_addModel" class="method item">
     <h3 class="name"><code>addModel</code></h3>
 
@@ -417,7 +505,7 @@ kpi.name
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l54"><code>src&#x2F;Store.js:54</code></a>
+        <a href="../files/src_Store.js.html#l74"><code>src&#x2F;Store.js:74</code></a>
         </p>
 
 
@@ -495,7 +583,7 @@ kpi.name
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l71"><code>src&#x2F;Store.js:71</code></a>
+        <a href="../files/src_Store.js.html#l91"><code>src&#x2F;Store.js:91</code></a>
         </p>
 
 
@@ -570,7 +658,7 @@ kpi.name
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l81"><code>src&#x2F;Store.js:81</code></a>
+        <a href="../files/src_Store.js.html#l101"><code>src&#x2F;Store.js:101</code></a>
         </p>
 
 
@@ -674,7 +762,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l635"><code>src&#x2F;Store.js:635</code></a>
+        <a href="../files/src_Store.js.html#l655"><code>src&#x2F;Store.js:655</code></a>
         </p>
 
 
@@ -756,7 +844,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l618"><code>src&#x2F;Store.js:618</code></a>
+        <a href="../files/src_Store.js.html#l638"><code>src&#x2F;Store.js:638</code></a>
         </p>
 
 
@@ -809,7 +897,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l582"><code>src&#x2F;Store.js:582</code></a>
+        <a href="../files/src_Store.js.html#l602"><code>src&#x2F;Store.js:602</code></a>
         </p>
 
 
@@ -865,7 +953,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l396"><code>src&#x2F;Store.js:396</code></a>
+        <a href="../files/src_Store.js.html#l416"><code>src&#x2F;Store.js:416</code></a>
         </p>
 
 
@@ -931,7 +1019,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l670"><code>src&#x2F;Store.js:670</code></a>
+        <a href="../files/src_Store.js.html#l690"><code>src&#x2F;Store.js:690</code></a>
         </p>
 
 
@@ -999,7 +1087,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l704"><code>src&#x2F;Store.js:704</code></a>
+        <a href="../files/src_Store.js.html#l724"><code>src&#x2F;Store.js:724</code></a>
         </p>
 
 
@@ -1066,7 +1154,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l656"><code>src&#x2F;Store.js:656</code></a>
+        <a href="../files/src_Store.js.html#l676"><code>src&#x2F;Store.js:676</code></a>
         </p>
 
 
@@ -1133,7 +1221,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l192"><code>src&#x2F;Store.js:192</code></a>
+        <a href="../files/src_Store.js.html#l212"><code>src&#x2F;Store.js:212</code></a>
         </p>
 
 
@@ -1238,7 +1326,7 @@ end_time: '2020-06-02T00:00:00.000Z'
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l256"><code>src&#x2F;Store.js:256</code></a>
+        <a href="../files/src_Store.js.html#l276"><code>src&#x2F;Store.js:276</code></a>
         </p>
 
 
@@ -1314,7 +1402,7 @@ end_time: '2020-06-02T00:00:00.000Z'
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l126"><code>src&#x2F;Store.js:126</code></a>
+        <a href="../files/src_Store.js.html#l146"><code>src&#x2F;Store.js:146</code></a>
         </p>
 
 
@@ -1408,7 +1496,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l290"><code>src&#x2F;Store.js:290</code></a>
+        <a href="../files/src_Store.js.html#l310"><code>src&#x2F;Store.js:310</code></a>
         </p>
 
 
@@ -1479,7 +1567,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l170"><code>src&#x2F;Store.js:170</code></a>
+        <a href="../files/src_Store.js.html#l190"><code>src&#x2F;Store.js:190</code></a>
         </p>
 
 
@@ -1560,7 +1648,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l527"><code>src&#x2F;Store.js:527</code></a>
+        <a href="../files/src_Store.js.html#l547"><code>src&#x2F;Store.js:547</code></a>
         </p>
 
 
@@ -1638,7 +1726,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l512"><code>src&#x2F;Store.js:512</code></a>
+        <a href="../files/src_Store.js.html#l532"><code>src&#x2F;Store.js:532</code></a>
         </p>
 
 
@@ -1719,7 +1807,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l480"><code>src&#x2F;Store.js:480</code></a>
+        <a href="../files/src_Store.js.html#l500"><code>src&#x2F;Store.js:500</code></a>
         </p>
 
 
@@ -1807,7 +1895,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l495"><code>src&#x2F;Store.js:495</code></a>
+        <a href="../files/src_Store.js.html#l515"><code>src&#x2F;Store.js:515</code></a>
         </p>
 
 
@@ -1882,7 +1970,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l571"><code>src&#x2F;Store.js:571</code></a>
+        <a href="../files/src_Store.js.html#l591"><code>src&#x2F;Store.js:591</code></a>
         </p>
 
 
@@ -1953,7 +2041,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l422"><code>src&#x2F;Store.js:422</code></a>
+        <a href="../files/src_Store.js.html#l442"><code>src&#x2F;Store.js:442</code></a>
         </p>
 
 
@@ -2042,7 +2130,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l554"><code>src&#x2F;Store.js:554</code></a>
+        <a href="../files/src_Store.js.html#l574"><code>src&#x2F;Store.js:574</code></a>
         </p>
 
 
@@ -2121,7 +2209,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l440"><code>src&#x2F;Store.js:440</code></a>
+        <a href="../files/src_Store.js.html#l460"><code>src&#x2F;Store.js:460</code></a>
         </p>
 
 
@@ -2196,7 +2284,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l460"><code>src&#x2F;Store.js:460</code></a>
+        <a href="../files/src_Store.js.html#l480"><code>src&#x2F;Store.js:480</code></a>
         </p>
 
 
@@ -2264,7 +2352,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l539"><code>src&#x2F;Store.js:539</code></a>
+        <a href="../files/src_Store.js.html#l559"><code>src&#x2F;Store.js:559</code></a>
         </p>
 
 
@@ -2339,7 +2427,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l411"><code>src&#x2F;Store.js:411</code></a>
+        <a href="../files/src_Store.js.html#l431"><code>src&#x2F;Store.js:431</code></a>
         </p>
 
 
@@ -2401,7 +2489,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l338"><code>src&#x2F;Store.js:338</code></a>
+        <a href="../files/src_Store.js.html#l358"><code>src&#x2F;Store.js:358</code></a>
         </p>
 
 
@@ -2455,7 +2543,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l361"><code>src&#x2F;Store.js:361</code></a>
+        <a href="../files/src_Store.js.html#l381"><code>src&#x2F;Store.js:381</code></a>
         </p>
 
 
@@ -2509,7 +2597,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l350"><code>src&#x2F;Store.js:350</code></a>
+        <a href="../files/src_Store.js.html#l370"><code>src&#x2F;Store.js:370</code></a>
         </p>
 
 
@@ -2557,7 +2645,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l375"><code>src&#x2F;Store.js:375</code></a>
+        <a href="../files/src_Store.js.html#l395"><code>src&#x2F;Store.js:395</code></a>
         </p>
 
 
@@ -2599,7 +2687,7 @@ as the primary key</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l112"><code>src&#x2F;Store.js:112</code></a>
+        <a href="../files/src_Store.js.html#l132"><code>src&#x2F;Store.js:132</code></a>
         </p>
 
 
@@ -2659,7 +2747,7 @@ in mobx.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l315"><code>src&#x2F;Store.js:315</code></a>
+        <a href="../files/src_Store.js.html#l335"><code>src&#x2F;Store.js:335</code></a>
         </p>
 
 
@@ -2703,7 +2791,7 @@ store.reset()
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l737"><code>src&#x2F;Store.js:737</code></a>
+        <a href="../files/src_Store.js.html#l757"><code>src&#x2F;Store.js:757</code></a>
         </p>
 
 

--- a/docs/data.json
+++ b/docs/data.json
@@ -3,7 +3,7 @@
         "name": "mobx-async-store",
         "description": "Asyc Data Store for mobx",
         "url": "https://github.com/artemis-ag/mobx-async-store",
-        "version": "1.3.0"
+        "version": "1.4.0"
     },
     "files": {
         "src/decorators/attributes.js": {
@@ -804,6 +804,30 @@
         {
             "file": "src/Store.js",
             "line": 54,
+            "description": "builds an instance of a model but does not add it to the store\n```\nkpiHash = { name: \"A good thing to measure\" }\nkpi = store.build('kpis', kpiHash)\nkpi.name\n=> \"A good thing to measure\"\n```",
+            "itemtype": "method",
+            "name": "add",
+            "params": [
+                {
+                    "name": "type",
+                    "description": "",
+                    "type": "String"
+                },
+                {
+                    "name": "properties",
+                    "description": "the properties to use",
+                    "type": "Object"
+                }
+            ],
+            "return": {
+                "description": "the new record",
+                "type": "Object"
+            },
+            "class": "Store"
+        },
+        {
+            "file": "src/Store.js",
+            "line": 74,
             "itemtype": "method",
             "name": "addModel",
             "params": [
@@ -826,7 +850,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 71,
+            "line": 91,
             "itemtype": "method",
             "name": "addModels",
             "params": [
@@ -849,7 +873,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 81,
+            "line": 101,
             "description": "Saves a collection of records via a bulk-supported JSONApi\nendpoint. All records need to be of the same type.",
             "itemtype": "method",
             "name": "bulkSave",
@@ -869,7 +893,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 112,
+            "line": 132,
             "description": "Adds a record from the store. We can't simply remove the record\nby deleting the records property/key via delete due to a bug\nin mobx.",
             "itemtype": "method",
             "name": "remove",
@@ -889,7 +913,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 126,
+            "line": 146,
             "description": "finds an instance by `id`. If available in the store, returns that instance. Otherwise, triggers a fetch.\n\n  store.findOne('todos', 5)\n  // fetch triggered\n  => event1\n  store.findOne('todos', 5)\n  // no fetch triggered\n  => event1\n\nPassing `fromServer` as an option will always trigger a fetch if `true` and never trigger a fetch if `false`.\nOtherwise, it will trigger the default behavior\n\n  store.findOne('todos', 5, { fromServer: false })\n  // no fetch triggered\n  => undefined\n\n  store.findOne('todos', 5)\n  // fetch triggered\n  => event1\n\n  store.findOne('todos', 5, { fromServer: true })\n  // fetch triggered\n  => event1",
             "itemtype": "method",
             "name": "findOne",
@@ -913,7 +937,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 170,
+            "line": 190,
             "description": "returns cache if exists, returns promise if not",
             "itemtype": "method",
             "name": "findOrFetchOne",
@@ -937,7 +961,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 192,
+            "line": 212,
             "description": "finds all of the instances of a given type. If there are instances available in the store,\nit will return those, otherwise it will trigger a fetch\n\n  store.findAll('todos')\n  // fetch triggered\n  => [event1, event2, event3]\n  store.findAll('todos')\n  // no fetch triggered\n  => [event1, event2, event3]\n\npassing `fromServer` as an option will always trigger a\nfetch if `true` and never trigger a fetch if `false`.\nOtherwise, it will trigger the default behavior\n\n  store.findAll('todos', { fromServer: false })\n  // no fetch triggered\n  => []\n\n  store.findAll('todos')\n  // fetch triggered\n  => [event1, event2, event3]\n\n  // async stuff happens on the server\n  store.findAll('todos')\n  // no fetch triggered\n  => [event1, event2, event3]\n\n  store.findAll('todos', { fromServer: true })\n  // fetch triggered\n  => [event1, event2, event3, event4]\n\nQuery params can be passed as part of the options hash.\nThe response will be cached, so the next time `findAll`\nis called with identical params and values, the store will\nfirst look for the local result (unless `fromServer` is `true`)\n\n  store.findAll('todos', {\n    queryParams: {\n      filter: {\n        start_time: '2020-06-01T00:00:00.000Z',\n        end_time: '2020-06-02T00:00:00.000Z'\n      }\n    }\n  })",
             "itemtype": "method",
             "name": "findAll",
@@ -957,7 +981,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 256,
+            "line": 276,
             "itemtype": "method",
             "name": "findAndFetchAll",
             "params": [
@@ -980,7 +1004,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 290,
+            "line": 310,
             "description": "returns cache if exists, returns promise if not",
             "itemtype": "method",
             "name": "findOrFetchAll",
@@ -1000,7 +1024,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 315,
+            "line": 335,
             "description": "Clears the store of a given type, or clears all if no type given\n\n  store.reset('todos')\n  // removes all todos from store\n  store.reset()\n  // clears store",
             "itemtype": "method",
             "name": "reset",
@@ -1008,7 +1032,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 338,
+            "line": 358,
             "description": "Entry point for configuring the store",
             "itemtype": "method",
             "name": "init",
@@ -1023,7 +1047,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 350,
+            "line": 370,
             "description": "Entry point for configuring the store",
             "itemtype": "method",
             "name": "initializeNetworkConfiguration",
@@ -1038,7 +1062,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 361,
+            "line": 381,
             "description": "Entry point for configuring the store",
             "itemtype": "method",
             "name": "initializeNetworkConfiguration",
@@ -1053,7 +1077,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 375,
+            "line": 395,
             "description": "Creates an obserable index with model types\nas the primary key\n\nObservable({ todos: {} })",
             "itemtype": "method",
             "name": "initializeObservableDataProperty",
@@ -1061,7 +1085,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 396,
+            "line": 416,
             "description": "Wrapper around fetch applies user defined fetch options",
             "itemtype": "method",
             "name": "fetch",
@@ -1081,7 +1105,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 411,
+            "line": 431,
             "description": "Gets type of collection from data observable",
             "itemtype": "method",
             "name": "getType",
@@ -1100,7 +1124,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 422,
+            "line": 442,
             "description": "Get single all record\nbased on query params",
             "itemtype": "method",
             "name": "getMatchingRecord",
@@ -1128,7 +1152,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 440,
+            "line": 460,
             "description": "Gets individual record from store",
             "itemtype": "method",
             "name": "getRecord",
@@ -1152,7 +1176,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 460,
+            "line": 480,
             "description": "Gets records for type of collection from observable",
             "itemtype": "method",
             "name": "getRecords",
@@ -1171,7 +1195,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 480,
+            "line": 500,
             "description": "Gets single from store based on cached query",
             "itemtype": "method",
             "name": "getCachedRecord",
@@ -1199,7 +1223,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 495,
+            "line": 515,
             "description": "Gets records from store based on cached query",
             "itemtype": "method",
             "name": "getCachedRecords",
@@ -1223,7 +1247,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 512,
+            "line": 532,
             "description": "Gets records from store based on cached query",
             "itemtype": "method",
             "name": "getCachedIds",
@@ -1247,7 +1271,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 527,
+            "line": 547,
             "description": "Gets records from store based on cached query",
             "itemtype": "method",
             "name": "getCachedId",
@@ -1271,7 +1295,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 539,
+            "line": 559,
             "description": "Get multiple records by id",
             "itemtype": "method",
             "name": "getRecordsById",
@@ -1295,7 +1319,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 554,
+            "line": 574,
             "description": "Gets records all records or records\nbased on query params",
             "itemtype": "method",
             "name": "getMatchingRecords",
@@ -1319,7 +1343,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 571,
+            "line": 591,
             "description": "Helper to look up model class for type.",
             "itemtype": "method",
             "name": "getKlass",
@@ -1338,7 +1362,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 582,
+            "line": 602,
             "description": "Creates or updates a model",
             "itemtype": "method",
             "name": "createOrUpdateModel",
@@ -1353,7 +1377,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 618,
+            "line": 638,
             "description": "Create multiple models from an array of data",
             "itemtype": "method",
             "name": "createModelsFromData",
@@ -1368,7 +1392,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 635,
+            "line": 655,
             "description": "Helper to create a new model",
             "itemtype": "method",
             "name": "createModel",
@@ -1397,7 +1421,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 656,
+            "line": 676,
             "description": "Builds fetch url based",
             "itemtype": "method",
             "name": "fetchUrl",
@@ -1417,7 +1441,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 670,
+            "line": 690,
             "description": "finds an instance by `id`. If available in the store, returns that instance. Otherwise, triggers a fetch.",
             "itemtype": "method",
             "name": "fetchAll",
@@ -1437,7 +1461,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 704,
+            "line": 724,
             "description": "fetches record by `id`.",
             "async": 1,
             "itemtype": "method",
@@ -1458,7 +1482,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 737,
+            "line": 757,
             "description": "Defines a resolution for an API call that will update a record or\nset of records with the data returned from the API",
             "itemtype": "method",
             "name": "updateRecords",

--- a/docs/data.json
+++ b/docs/data.json
@@ -804,9 +804,9 @@
         {
             "file": "src/Store.js",
             "line": 54,
-            "description": "builds an instance of a model but does not add it to the store\n```\nkpiHash = { name: \"A good thing to measure\" }\nkpi = store.build('kpis', kpiHash)\nkpi.name\n=> \"A good thing to measure\"\n```",
+            "description": "Builds an instance of a model that includes either an automatically or manually created temporary ID, but does not add it to the store.\n```\nkpiHash = { name: \"A good thing to measure\" }\nkpi = store.build('kpis', kpiHash)\nkpi.name\n=> \"A good thing to measure\"\n```",
             "itemtype": "method",
-            "name": "add",
+            "name": "build",
             "params": [
                 {
                     "name": "type",

--- a/docs/files/src_Model.js.html
+++ b/docs/files/src_Model.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.3.0</em>
+            <em>API Docs for: 1.4.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_Store.js.html
+++ b/docs/files/src_Store.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.3.0</em>
+            <em>API Docs for: 1.4.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -134,6 +134,26 @@ class Store {
     } else {
       return this.addModel(type, toJS(data))
     }
+  }
+
+  /**
+   * builds an instance of a model but does not add it to the store
+   * &#x60;&#x60;&#x60;
+   * kpiHash = { name: &quot;A good thing to measure&quot; }
+   * kpi = store.build(&#x27;kpis&#x27;, kpiHash)
+   * kpi.name
+   * =&gt; &quot;A good thing to measure&quot;
+   * &#x60;&#x60;&#x60;
+   * @method add
+   * @param {String} type
+   * @param {Object} properties the properties to use
+   * @return {Object} the new record
+   */
+  build = (type, attributes) =&gt; {
+    const id = dbOrNewId(attributes)
+    const model = this.createModel(type, id, { attributes })
+
+    return model
   }
 
   /**

--- a/docs/files/src_Store.js.html
+++ b/docs/files/src_Store.js.html
@@ -137,14 +137,14 @@ class Store {
   }
 
   /**
-   * builds an instance of a model but does not add it to the store
+   * Builds an instance of a model that includes either an automatically or manually created temporary ID, but does not add it to the store.
    * &#x60;&#x60;&#x60;
    * kpiHash = { name: &quot;A good thing to measure&quot; }
    * kpi = store.build(&#x27;kpis&#x27;, kpiHash)
    * kpi.name
    * =&gt; &quot;A good thing to measure&quot;
    * &#x60;&#x60;&#x60;
-   * @method add
+   * @method build
    * @param {String} type
    * @param {Object} properties the properties to use
    * @return {Object} the new record

--- a/docs/files/src_decorators_attributes.js.html
+++ b/docs/files/src_decorators_attributes.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.3.0</em>
+            <em>API Docs for: 1.4.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_relationships.js.html
+++ b/docs/files/src_decorators_relationships.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.3.0</em>
+            <em>API Docs for: 1.4.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_schema.js.html
+++ b/docs/files/src_schema.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.3.0</em>
+            <em>API Docs for: 1.4.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_utils.js.html
+++ b/docs/files/src_utils.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.3.0</em>
+            <em>API Docs for: 1.4.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
                 <h1><img src="./assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.3.0</em>
+            <em>API Docs for: 1.4.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/spec/Store.spec.js
+++ b/spec/Store.spec.js
@@ -135,6 +135,28 @@ describe('Store', () => {
     })
   })
 
+  describe('build', () => {
+    it('builds a model instance', () => {
+      const example = store.build('todos', { title: 'Buy Milk' })
+      expect(example.title).toEqual('Buy Milk')
+    })
+
+    it('does not add it to the store', () => {
+      const example = store.build('todos', { title: 'Buy Milk' })
+      expect(store.getRecord('todos', example.id)).toBeUndefined()
+    })
+
+    it('gives the record a temporary id', () => {
+      const example = store.build('todos', { title: 'Buy Milk' })
+      expect(example.id).toMatch(/^tmp-/)
+    })
+
+    it('unless an id is present in attributes', () => {
+      const example = store.build('todos', { id: 'foo', title: 'Buy Milk' })
+      expect(example.id).toBe('foo')
+    })
+  })
+
   describe('bulkSave', () => {
     it('raises an invariant error if we submit n records and don\'t receive data for n records', async () => {
       expect.assertions(1)

--- a/src/Store.js
+++ b/src/Store.js
@@ -52,6 +52,26 @@ class Store {
   }
 
   /**
+   * builds an instance of a model but does not add it to the store
+   * ```
+   * kpiHash = { name: "A good thing to measure" }
+   * kpi = store.build('kpis', kpiHash)
+   * kpi.name
+   * => "A good thing to measure"
+   * ```
+   * @method add
+   * @param {String} type
+   * @param {Object} properties the properties to use
+   * @return {Object} the new record
+   */
+  build = (type, attributes) => {
+    const id = dbOrNewId(attributes)
+    const model = this.createModel(type, id, { attributes })
+
+    return model
+  }
+
+  /**
    * @method addModel
    * @param {String} type
    * @param {Object} attributes json api attributes

--- a/src/Store.js
+++ b/src/Store.js
@@ -52,7 +52,7 @@ class Store {
   }
 
   /**
-   * Builds an instance of a model that includes either an automatically or manually created temporary ID, but does not add it to the store. 
+   * Builds an instance of a model that includes either an automatically or manually created temporary ID, but does not add it to the store.
    * ```
    * kpiHash = { name: "A good thing to measure" }
    * kpi = store.build('kpis', kpiHash)

--- a/src/Store.js
+++ b/src/Store.js
@@ -59,7 +59,7 @@ class Store {
    * kpi.name
    * => "A good thing to measure"
    * ```
-   * @method add
+   * @method build
    * @param {String} type
    * @param {Object} properties the properties to use
    * @return {Object} the new record

--- a/src/Store.js
+++ b/src/Store.js
@@ -52,7 +52,7 @@ class Store {
   }
 
   /**
-   * builds an instance of a model but does not add it to the store
+   * Builds an instance of a model that includes either an automatically or manually created temporary ID, but does not add it to the store. 
    * ```
    * kpiHash = { name: "A good thing to measure" }
    * kpi = store.build('kpis', kpiHash)


### PR DESCRIPTION
* define `Store#build` to build a model instance w/o adding it to the store

sometimes we want to be able to create an ephemeral model instance w/o adding it to the store (building a model instance from form data for example) this instance may or may not get added to the store later, but it's nice to not have to explicitly remove the record from the store if, for example, the form is abandoned.