### PR TITLE
add findMany method to store

### DIFF
--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -39,6 +39,7 @@ var QueryString = {
 
 var pending = {};
 var counter = {};
+var URL_MAX_LENGTH = 1024;
 
 var incrementor = function incrementor(key) {
   return function () {
@@ -237,6 +238,37 @@ function diff() {
 
 function parseApiErrors(errors, defaultMessage) {
   return errors[0].detail.length === 0 ? defaultMessage : errors[0].detail[0];
+}
+/**
+ * Splits an array of ids into a series of strings that can be used to form
+ * queries that conform to a max length of URL_MAX_LENGTH. This is to prevent 414 errors.
+ * @method deriveIdQueryStrings
+ * @param {Array} ids an array of ids that will be used in the string
+ * @param {String} restOfUrl the additional text URL that will be passed to the server
+ */
+
+function deriveIdQueryStrings(ids) {
+  var restOfUrl = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '';
+  var idLength = Math.max.apply(Math, _toConsumableArray(ids.map(function (id) {
+    return String(id).length;
+  })));
+  var maxLength = URL_MAX_LENGTH - restOfUrl.length - encodeURIComponent('filter[ids]=,,').length;
+  var encodedIds = encodeURIComponent(ids.join(','));
+
+  if (encodedIds.length <= maxLength) {
+    return [ids.join(',')];
+  }
+
+  var minLength = maxLength - idLength;
+  var regexp = new RegExp(".{".concat(minLength, ",").concat(maxLength, "}%2C"), 'g'); // the matches
+
+  var matched = encodedIds.match(regexp); // everything that doesn't match, ie the last of the ids
+
+  var tail = encodedIds.replace(regexp, ''); // we manually strip the ',' at the end because javascript's non-capturing regex groups are hard to manage
+
+  return [].concat(_toConsumableArray(matched), [tail]).map(decodeURIComponent).map(function (string) {
+    return string.replace(/,$/, '');
+  });
 }
 
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
@@ -1470,6 +1502,57 @@ function () {
       }
     };
 
+    this.findMany = function (type, ids) {
+      var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+      var fromServer = options.fromServer;
+      var idsToQuery = ids.slice().map(String);
+
+      if (fromServer === false) {
+        // If fromServer is false never fetch the data and return
+        return _this.getRecords(type).filter(function (record) {
+          return idsToQuery.includes(record.id);
+        });
+      }
+
+      var recordsInStore = [];
+
+      if (fromServer !== true) {
+        recordsInStore = _this.getRecords(type).filter(function (record) {
+          return idsToQuery.includes(record.id);
+        });
+
+        if (recordsInStore.length === idsToQuery.length) {
+          // if fromServer is not false or true, but all the records are in store, wrap it in a promise
+          return Promise.resolve(recordsInStore);
+        }
+
+        var recordIdsInStore = recordsInStore.map(function (_ref2) {
+          var id = _ref2.id;
+          return String(id);
+        }); // If fromServer is not true, we will only query records that are not already in the store
+
+        idsToQuery = idsToQuery.filter(function (id) {
+          return !recordIdsInStore.includes(id);
+        });
+      }
+
+      var queryParams = options.queryParams || {};
+      queryParams.filter = queryParams.filter || {};
+
+      var baseUrl = _this.fetchUrl(type, queryParams);
+
+      var idQueries = deriveIdQueryStrings(idsToQuery, baseUrl);
+      var query = Promise.all(idQueries.map(function (queryIds) {
+        queryParams.filter.ids = queryIds;
+        return _this.fetchAll(type, queryParams);
+      }));
+      return query.then(function (recordsFromServer) {
+        var _recordsInStore;
+
+        return (_recordsInStore = recordsInStore).concat.apply(_recordsInStore, _toConsumableArray(recordsFromServer));
+      });
+    };
+
     this.findAll = function (type) {
       var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
       var fromServer = options.fromServer,
@@ -2172,7 +2255,7 @@ function () {
       return promise.then(
       /*#__PURE__*/
       function () {
-        var _ref2 = _asyncToGenerator(
+        var _ref3 = _asyncToGenerator(
         /*#__PURE__*/
         _regeneratorRuntime.mark(function _callee4(response) {
           var status, json, data, included, message, _json, errorString;
@@ -2258,7 +2341,7 @@ function () {
         }));
 
         return function (_x9) {
-          return _ref2.apply(this, arguments);
+          return _ref3.apply(this, arguments);
         };
       }(), function (error) {
         // TODO: Handle error states correctly, including handling errors for multiple targets

--- a/docs/classes/Model.html
+++ b/docs/classes/Model.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.4.0</em>
+            <em>API Docs for: 1.5.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/RelatedRecordsArray.html
+++ b/docs/classes/RelatedRecordsArray.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.4.0</em>
+            <em>API Docs for: 1.5.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Schema.html
+++ b/docs/classes/Schema.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.4.0</em>
+            <em>API Docs for: 1.5.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Store.html
+++ b/docs/classes/Store.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.4.0</em>
+            <em>API Docs for: 1.5.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -204,6 +204,10 @@
                             </li>
                             <li class="index-item method">
                                 <a href="#method_findAndFetchAll">findAndFetchAll</a>
+
+                            </li>
+                            <li class="index-item method">
+                                <a href="#method_findMany">findMany</a>
 
                             </li>
                             <li class="index-item method">
@@ -762,7 +766,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l655"><code>src&#x2F;Store.js:655</code></a>
+        <a href="../files/src_Store.js.html#l749"><code>src&#x2F;Store.js:749</code></a>
         </p>
 
 
@@ -844,7 +848,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l638"><code>src&#x2F;Store.js:638</code></a>
+        <a href="../files/src_Store.js.html#l732"><code>src&#x2F;Store.js:732</code></a>
         </p>
 
 
@@ -897,7 +901,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l602"><code>src&#x2F;Store.js:602</code></a>
+        <a href="../files/src_Store.js.html#l696"><code>src&#x2F;Store.js:696</code></a>
         </p>
 
 
@@ -953,7 +957,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l416"><code>src&#x2F;Store.js:416</code></a>
+        <a href="../files/src_Store.js.html#l510"><code>src&#x2F;Store.js:510</code></a>
         </p>
 
 
@@ -1019,7 +1023,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l690"><code>src&#x2F;Store.js:690</code></a>
+        <a href="../files/src_Store.js.html#l784"><code>src&#x2F;Store.js:784</code></a>
         </p>
 
 
@@ -1087,7 +1091,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l724"><code>src&#x2F;Store.js:724</code></a>
+        <a href="../files/src_Store.js.html#l818"><code>src&#x2F;Store.js:818</code></a>
         </p>
 
 
@@ -1154,7 +1158,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l676"><code>src&#x2F;Store.js:676</code></a>
+        <a href="../files/src_Store.js.html#l770"><code>src&#x2F;Store.js:770</code></a>
         </p>
 
 
@@ -1221,7 +1225,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l212"><code>src&#x2F;Store.js:212</code></a>
+        <a href="../files/src_Store.js.html#l306"><code>src&#x2F;Store.js:306</code></a>
         </p>
 
 
@@ -1326,7 +1330,7 @@ end_time: '2020-06-02T00:00:00.000Z'
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l276"><code>src&#x2F;Store.js:276</code></a>
+        <a href="../files/src_Store.js.html#l370"><code>src&#x2F;Store.js:370</code></a>
         </p>
 
 
@@ -1372,6 +1376,111 @@ end_time: '2020-06-02T00:00:00.000Z'
                         <span class="type">Array</span>:
             </div>
         </div>
+
+
+</div>
+<div id="method_findMany" class="method item">
+    <h3 class="name"><code>findMany</code></h3>
+
+        <div class="args">
+            <span class="paren">(</span><ul class="args-list inline commas">
+                <li class="arg">
+                        <code>type</code>
+                </li>
+                <li class="arg">
+                        <code>options</code>
+                </li>
+            </ul><span class="paren">)</span>
+        </div>
+
+
+
+
+
+
+
+
+    <div class="meta">
+                <p>
+                Defined in
+        <a href="../files/src_Store.js.html#l212"><code>src&#x2F;Store.js:212</code></a>
+        </p>
+
+
+
+    </div>
+
+    <div class="description">
+        <p>Like 'findOne', but with an array ids. If there are instances available in the store,
+it will return those, otherwise it will trigger a fetch</p>
+<p>store.findMany('todos', [1, 2, 3])
+// fetch triggered
+=&gt; [event1, event2, event3]
+store.findMany('todos', [3, 2, 1])
+// no fetch triggered
+=&gt; [event1, event2, event3]</p>
+<p>passing <code>fromServer</code> as an option will always trigger a
+fetch if <code>true</code> and never trigger a fetch if <code>false</code>.
+Otherwise, it will trigger the default behavior</p>
+<p>store.findMany('todos', [1, 2])
+// fetch triggered
+=&gt; [event1, event2]</p>
+<p>store.findMany('todos', [1, 2, 3], { fromServer: false })
+// no fetch triggered, only returns the records already in the store
+=&gt; [event1, event2]</p>
+<p>store.findMany('todos')
+// fetch triggered
+=&gt; [event1, event2, event3]</p>
+<p>// async stuff happens on the server
+store.findMany('todos', [1, 2, 3])
+// no fetch triggered
+=&gt; [event1, event2, event3]</p>
+<p>store.findMany('todos', [1, 2, 3], { fromServer: true })
+// fetch triggered
+=&gt; [event1, event2, event3]</p>
+<p>Query params can be passed as part of the options hash.
+The response will be cached, so the next time <code>findMany</code>
+is called with identical params and values, the store will
+first look for the local result (unless <code>fromServer</code> is <code>true</code>)</p>
+<p>store.findMany('todos', [1, 2, 3], {
+queryParams: {
+filter: {
+start_time: '2020-06-01T00:00:00.000Z',
+end_time: '2020-06-02T00:00:00.000Z'
+}
+}
+})</p>
+
+    </div>
+
+        <div class="params">
+            <h4>Parameters:</h4>
+
+            <ul class="params-list">
+                <li class="param">
+                        <code class="param-name">type</code>
+                        <span class="type">String</span>
+
+
+                    <div class="param-description">
+                        <p>the type to find</p>
+
+                    </div>
+
+                </li>
+                <li class="param">
+                        <code class="param-name">options</code>
+                        <span class="type">Object</span>
+
+
+                    <div class="param-description">
+                         
+                    </div>
+
+                </li>
+            </ul>
+        </div>
+
 
 
 </div>
@@ -1496,7 +1605,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l310"><code>src&#x2F;Store.js:310</code></a>
+        <a href="../files/src_Store.js.html#l404"><code>src&#x2F;Store.js:404</code></a>
         </p>
 
 
@@ -1648,7 +1757,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l547"><code>src&#x2F;Store.js:547</code></a>
+        <a href="../files/src_Store.js.html#l641"><code>src&#x2F;Store.js:641</code></a>
         </p>
 
 
@@ -1726,7 +1835,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l532"><code>src&#x2F;Store.js:532</code></a>
+        <a href="../files/src_Store.js.html#l626"><code>src&#x2F;Store.js:626</code></a>
         </p>
 
 
@@ -1807,7 +1916,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l500"><code>src&#x2F;Store.js:500</code></a>
+        <a href="../files/src_Store.js.html#l594"><code>src&#x2F;Store.js:594</code></a>
         </p>
 
 
@@ -1895,7 +2004,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l515"><code>src&#x2F;Store.js:515</code></a>
+        <a href="../files/src_Store.js.html#l609"><code>src&#x2F;Store.js:609</code></a>
         </p>
 
 
@@ -1970,7 +2079,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l591"><code>src&#x2F;Store.js:591</code></a>
+        <a href="../files/src_Store.js.html#l685"><code>src&#x2F;Store.js:685</code></a>
         </p>
 
 
@@ -2041,7 +2150,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l442"><code>src&#x2F;Store.js:442</code></a>
+        <a href="../files/src_Store.js.html#l536"><code>src&#x2F;Store.js:536</code></a>
         </p>
 
 
@@ -2130,7 +2239,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l574"><code>src&#x2F;Store.js:574</code></a>
+        <a href="../files/src_Store.js.html#l668"><code>src&#x2F;Store.js:668</code></a>
         </p>
 
 
@@ -2209,7 +2318,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l460"><code>src&#x2F;Store.js:460</code></a>
+        <a href="../files/src_Store.js.html#l554"><code>src&#x2F;Store.js:554</code></a>
         </p>
 
 
@@ -2284,7 +2393,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l480"><code>src&#x2F;Store.js:480</code></a>
+        <a href="../files/src_Store.js.html#l574"><code>src&#x2F;Store.js:574</code></a>
         </p>
 
 
@@ -2352,7 +2461,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l559"><code>src&#x2F;Store.js:559</code></a>
+        <a href="../files/src_Store.js.html#l653"><code>src&#x2F;Store.js:653</code></a>
         </p>
 
 
@@ -2427,7 +2536,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l431"><code>src&#x2F;Store.js:431</code></a>
+        <a href="../files/src_Store.js.html#l525"><code>src&#x2F;Store.js:525</code></a>
         </p>
 
 
@@ -2489,7 +2598,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l358"><code>src&#x2F;Store.js:358</code></a>
+        <a href="../files/src_Store.js.html#l452"><code>src&#x2F;Store.js:452</code></a>
         </p>
 
 
@@ -2543,7 +2652,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l381"><code>src&#x2F;Store.js:381</code></a>
+        <a href="../files/src_Store.js.html#l475"><code>src&#x2F;Store.js:475</code></a>
         </p>
 
 
@@ -2597,7 +2706,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l370"><code>src&#x2F;Store.js:370</code></a>
+        <a href="../files/src_Store.js.html#l464"><code>src&#x2F;Store.js:464</code></a>
         </p>
 
 
@@ -2645,7 +2754,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l395"><code>src&#x2F;Store.js:395</code></a>
+        <a href="../files/src_Store.js.html#l489"><code>src&#x2F;Store.js:489</code></a>
         </p>
 
 
@@ -2747,7 +2856,7 @@ in mobx.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l335"><code>src&#x2F;Store.js:335</code></a>
+        <a href="../files/src_Store.js.html#l429"><code>src&#x2F;Store.js:429</code></a>
         </p>
 
 
@@ -2791,7 +2900,7 @@ store.reset()
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l757"><code>src&#x2F;Store.js:757</code></a>
+        <a href="../files/src_Store.js.html#l851"><code>src&#x2F;Store.js:851</code></a>
         </p>
 
 

--- a/docs/data.json
+++ b/docs/data.json
@@ -3,7 +3,7 @@
         "name": "mobx-async-store",
         "description": "Asyc Data Store for mobx",
         "url": "https://github.com/artemis-ag/mobx-async-store",
-        "version": "1.4.0"
+        "version": "1.5.0"
     },
     "files": {
         "src/decorators/attributes.js": {
@@ -962,6 +962,26 @@
         {
             "file": "src/Store.js",
             "line": 212,
+            "description": "Like 'findOne', but with an array ids. If there are instances available in the store,\nit will return those, otherwise it will trigger a fetch\n\n  store.findMany('todos', [1, 2, 3])\n  // fetch triggered\n  => [event1, event2, event3]\n  store.findMany('todos', [3, 2, 1])\n  // no fetch triggered\n  => [event1, event2, event3]\n\npassing `fromServer` as an option will always trigger a\nfetch if `true` and never trigger a fetch if `false`.\nOtherwise, it will trigger the default behavior\n\n  store.findMany('todos', [1, 2])\n  // fetch triggered\n  => [event1, event2]\n\n  store.findMany('todos', [1, 2, 3], { fromServer: false })\n  // no fetch triggered, only returns the records already in the store\n  => [event1, event2]\n\n  store.findMany('todos')\n  // fetch triggered\n  => [event1, event2, event3]\n\n  // async stuff happens on the server\n  store.findMany('todos', [1, 2, 3])\n  // no fetch triggered\n  => [event1, event2, event3]\n\n  store.findMany('todos', [1, 2, 3], { fromServer: true })\n  // fetch triggered\n  => [event1, event2, event3]\n\nQuery params can be passed as part of the options hash.\nThe response will be cached, so the next time `findMany`\nis called with identical params and values, the store will\nfirst look for the local result (unless `fromServer` is `true`)\n\n  store.findMany('todos', [1, 2, 3], {\n    queryParams: {\n      filter: {\n        start_time: '2020-06-01T00:00:00.000Z',\n        end_time: '2020-06-02T00:00:00.000Z'\n      }\n    }\n  })",
+            "itemtype": "method",
+            "name": "findMany",
+            "params": [
+                {
+                    "name": "type",
+                    "description": "the type to find",
+                    "type": "String"
+                },
+                {
+                    "name": "options",
+                    "description": "",
+                    "type": "Object"
+                }
+            ],
+            "class": "Store"
+        },
+        {
+            "file": "src/Store.js",
+            "line": 306,
             "description": "finds all of the instances of a given type. If there are instances available in the store,\nit will return those, otherwise it will trigger a fetch\n\n  store.findAll('todos')\n  // fetch triggered\n  => [event1, event2, event3]\n  store.findAll('todos')\n  // no fetch triggered\n  => [event1, event2, event3]\n\npassing `fromServer` as an option will always trigger a\nfetch if `true` and never trigger a fetch if `false`.\nOtherwise, it will trigger the default behavior\n\n  store.findAll('todos', { fromServer: false })\n  // no fetch triggered\n  => []\n\n  store.findAll('todos')\n  // fetch triggered\n  => [event1, event2, event3]\n\n  // async stuff happens on the server\n  store.findAll('todos')\n  // no fetch triggered\n  => [event1, event2, event3]\n\n  store.findAll('todos', { fromServer: true })\n  // fetch triggered\n  => [event1, event2, event3, event4]\n\nQuery params can be passed as part of the options hash.\nThe response will be cached, so the next time `findAll`\nis called with identical params and values, the store will\nfirst look for the local result (unless `fromServer` is `true`)\n\n  store.findAll('todos', {\n    queryParams: {\n      filter: {\n        start_time: '2020-06-01T00:00:00.000Z',\n        end_time: '2020-06-02T00:00:00.000Z'\n      }\n    }\n  })",
             "itemtype": "method",
             "name": "findAll",
@@ -981,7 +1001,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 276,
+            "line": 370,
             "itemtype": "method",
             "name": "findAndFetchAll",
             "params": [
@@ -1004,7 +1024,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 310,
+            "line": 404,
             "description": "returns cache if exists, returns promise if not",
             "itemtype": "method",
             "name": "findOrFetchAll",
@@ -1024,7 +1044,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 335,
+            "line": 429,
             "description": "Clears the store of a given type, or clears all if no type given\n\n  store.reset('todos')\n  // removes all todos from store\n  store.reset()\n  // clears store",
             "itemtype": "method",
             "name": "reset",
@@ -1032,7 +1052,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 358,
+            "line": 452,
             "description": "Entry point for configuring the store",
             "itemtype": "method",
             "name": "init",
@@ -1047,7 +1067,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 370,
+            "line": 464,
             "description": "Entry point for configuring the store",
             "itemtype": "method",
             "name": "initializeNetworkConfiguration",
@@ -1062,7 +1082,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 381,
+            "line": 475,
             "description": "Entry point for configuring the store",
             "itemtype": "method",
             "name": "initializeNetworkConfiguration",
@@ -1077,7 +1097,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 395,
+            "line": 489,
             "description": "Creates an obserable index with model types\nas the primary key\n\nObservable({ todos: {} })",
             "itemtype": "method",
             "name": "initializeObservableDataProperty",
@@ -1085,7 +1105,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 416,
+            "line": 510,
             "description": "Wrapper around fetch applies user defined fetch options",
             "itemtype": "method",
             "name": "fetch",
@@ -1105,7 +1125,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 431,
+            "line": 525,
             "description": "Gets type of collection from data observable",
             "itemtype": "method",
             "name": "getType",
@@ -1124,7 +1144,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 442,
+            "line": 536,
             "description": "Get single all record\nbased on query params",
             "itemtype": "method",
             "name": "getMatchingRecord",
@@ -1152,7 +1172,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 460,
+            "line": 554,
             "description": "Gets individual record from store",
             "itemtype": "method",
             "name": "getRecord",
@@ -1176,7 +1196,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 480,
+            "line": 574,
             "description": "Gets records for type of collection from observable",
             "itemtype": "method",
             "name": "getRecords",
@@ -1195,7 +1215,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 500,
+            "line": 594,
             "description": "Gets single from store based on cached query",
             "itemtype": "method",
             "name": "getCachedRecord",
@@ -1223,7 +1243,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 515,
+            "line": 609,
             "description": "Gets records from store based on cached query",
             "itemtype": "method",
             "name": "getCachedRecords",
@@ -1247,7 +1267,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 532,
+            "line": 626,
             "description": "Gets records from store based on cached query",
             "itemtype": "method",
             "name": "getCachedIds",
@@ -1271,7 +1291,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 547,
+            "line": 641,
             "description": "Gets records from store based on cached query",
             "itemtype": "method",
             "name": "getCachedId",
@@ -1295,7 +1315,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 559,
+            "line": 653,
             "description": "Get multiple records by id",
             "itemtype": "method",
             "name": "getRecordsById",
@@ -1319,7 +1339,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 574,
+            "line": 668,
             "description": "Gets records all records or records\nbased on query params",
             "itemtype": "method",
             "name": "getMatchingRecords",
@@ -1343,7 +1363,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 591,
+            "line": 685,
             "description": "Helper to look up model class for type.",
             "itemtype": "method",
             "name": "getKlass",
@@ -1362,7 +1382,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 602,
+            "line": 696,
             "description": "Creates or updates a model",
             "itemtype": "method",
             "name": "createOrUpdateModel",
@@ -1377,7 +1397,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 638,
+            "line": 732,
             "description": "Create multiple models from an array of data",
             "itemtype": "method",
             "name": "createModelsFromData",
@@ -1392,7 +1412,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 655,
+            "line": 749,
             "description": "Helper to create a new model",
             "itemtype": "method",
             "name": "createModel",
@@ -1421,7 +1441,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 676,
+            "line": 770,
             "description": "Builds fetch url based",
             "itemtype": "method",
             "name": "fetchUrl",
@@ -1441,7 +1461,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 690,
+            "line": 784,
             "description": "finds an instance by `id`. If available in the store, returns that instance. Otherwise, triggers a fetch.",
             "itemtype": "method",
             "name": "fetchAll",
@@ -1461,7 +1481,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 724,
+            "line": 818,
             "description": "fetches record by `id`.",
             "async": 1,
             "itemtype": "method",
@@ -1482,7 +1502,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 757,
+            "line": 851,
             "description": "Defines a resolution for an API call that will update a record or\nset of records with the data returned from the API",
             "itemtype": "method",
             "name": "updateRecords",
@@ -1517,7 +1537,7 @@
         },
         {
             "file": "src/utils.js",
-            "line": 22,
+            "line": 23,
             "description": "Singularizes record type",
             "itemtype": "method",
             "name": "singularizeType",
@@ -1536,7 +1556,7 @@
         },
         {
             "file": "src/utils.js",
-            "line": 38,
+            "line": 39,
             "description": "Build request url from base url, endpoint, query params, and ids.",
             "itemtype": "method",
             "name": "requestUrl",
@@ -1548,7 +1568,7 @@
         },
         {
             "file": "src/utils.js",
-            "line": 65,
+            "line": 66,
             "description": "Avoids making racing requests by blocking a request if an identical one is\nalready in-flight. Blocked requests will be resolved when the initial request\nresolves by cloning the response.",
             "itemtype": "method",
             "name": "combineRacedRequests",
@@ -1572,7 +1592,7 @@
         },
         {
             "file": "src/utils.js",
-            "line": 104,
+            "line": 105,
             "description": "Reducer function for filtering out duplicate records\nby a key provided. Returns a function that has a accumulator and\ncurrent record per Array.reduce.",
             "itemtype": "method",
             "name": "uniqueByReducer",
@@ -1591,7 +1611,7 @@
         },
         {
             "file": "src/utils.js",
-            "line": 121,
+            "line": 122,
             "description": "Returns objects unique by key provided",
             "itemtype": "method",
             "name": "uniqueBy",
@@ -1615,7 +1635,7 @@
         },
         {
             "file": "src/utils.js",
-            "line": 147,
+            "line": 148,
             "description": "convert a value into a date, pass Date or Moment instances thru\nuntouched",
             "itemtype": "method",
             "name": "makeDate",
@@ -1634,7 +1654,7 @@
         },
         {
             "file": "src/utils.js",
-            "line": 159,
+            "line": 160,
             "description": "recursively walk an object and call the `iteratee` function for\neach property. returns an array of results of calls to the iteratee.",
             "itemtype": "method",
             "name": "walk",
@@ -1662,7 +1682,7 @@
         },
         {
             "file": "src/utils.js",
-            "line": 177,
+            "line": 178,
             "description": "deeply compare objects a and b and return object paths for attributes\nwhich differ. it is important to note that this comparison is biased\ntoward object a. object a is walked and compared against values in\nobject b. if a property exists in object b, but not in object a, it\nwill not be counted as a difference.",
             "itemtype": "method",
             "name": "diff",
@@ -1685,7 +1705,7 @@
         },
         {
             "file": "src/utils.js",
-            "line": 195,
+            "line": 196,
             "description": "A naive way of extracting errors from the server.\nThis needs some real work. Please don't track down the original author\nof the code (it's DEFINITELY not the person writing this documentation).\nCurrently it only extracts the message from the first error, but not only\ncan multiple errors be returned, they will correspond to different records\nin the case of a bulk JSONAPI response.",
             "itemtype": "method",
             "name": "parseApiErrors",
@@ -1698,6 +1718,26 @@
                 {
                     "name": "default",
                     "description": "error message",
+                    "type": "String"
+                }
+            ],
+            "class": ""
+        },
+        {
+            "file": "src/utils.js",
+            "line": 212,
+            "description": "Splits an array of ids into a series of strings that can be used to form\nqueries that conform to a max length of URL_MAX_LENGTH. This is to prevent 414 errors.",
+            "itemtype": "method",
+            "name": "deriveIdQueryStrings",
+            "params": [
+                {
+                    "name": "ids",
+                    "description": "an array of ids that will be used in the string",
+                    "type": "Array"
+                },
+                {
+                    "name": "restOfUrl",
+                    "description": "the additional text URL that will be passed to the server",
                     "type": "String"
                 }
             ],

--- a/docs/files/src_Model.js.html
+++ b/docs/files/src_Model.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.4.0</em>
+            <em>API Docs for: 1.5.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_Store.js.html
+++ b/docs/files/src_Store.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.4.0</em>
+            <em>API Docs for: 1.5.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -85,7 +85,7 @@
     <pre class="code prettyprint linenums">
 /* global fetch */
 import { action, observable, transaction, set, toJS } from &#x27;mobx&#x27;
-import { dbOrNewId, parseApiErrors, requestUrl, uniqueBy, combineRacedRequests } from &#x27;./utils&#x27;
+import { dbOrNewId, parseApiErrors, requestUrl, uniqueBy, combineRacedRequests, deriveIdQueryStrings } from &#x27;./utils&#x27;
 
 /**
  * Defines the Artemis Data Store class.
@@ -292,6 +292,100 @@ class Store {
       // Otherwise fetch it from the server
       return this.fetchOne(type, id, queryParams)
     }
+  }
+
+  /**
+   * Like &#x27;findOne&#x27;, but with an array ids. If there are instances available in the store,
+   * it will return those, otherwise it will trigger a fetch
+   *
+   *   store.findMany(&#x27;todos&#x27;, [1, 2, 3])
+   *   // fetch triggered
+   *   =&gt; [event1, event2, event3]
+   *   store.findMany(&#x27;todos&#x27;, [3, 2, 1])
+   *   // no fetch triggered
+   *   =&gt; [event1, event2, event3]
+   *
+   * passing &#x60;fromServer&#x60; as an option will always trigger a
+   * fetch if &#x60;true&#x60; and never trigger a fetch if &#x60;false&#x60;.
+   * Otherwise, it will trigger the default behavior
+   *
+   *   store.findMany(&#x27;todos&#x27;, [1, 2])
+   *   // fetch triggered
+   *   =&gt; [event1, event2]
+   *
+   *   store.findMany(&#x27;todos&#x27;, [1, 2, 3], { fromServer: false })
+   *   // no fetch triggered, only returns the records already in the store
+   *   =&gt; [event1, event2]
+   *
+   *   store.findMany(&#x27;todos&#x27;)
+   *   // fetch triggered
+   *   =&gt; [event1, event2, event3]
+   *
+   *   // async stuff happens on the server
+   *   store.findMany(&#x27;todos&#x27;, [1, 2, 3])
+   *   // no fetch triggered
+   *   =&gt; [event1, event2, event3]
+   *
+   *   store.findMany(&#x27;todos&#x27;, [1, 2, 3], { fromServer: true })
+   *   // fetch triggered
+   *   =&gt; [event1, event2, event3]
+   *
+   * Query params can be passed as part of the options hash.
+   * The response will be cached, so the next time &#x60;findMany&#x60;
+   * is called with identical params and values, the store will
+   * first look for the local result (unless &#x60;fromServer&#x60; is &#x60;true&#x60;)
+   *
+   *   store.findMany(&#x27;todos&#x27;, [1, 2, 3], {
+   *     queryParams: {
+   *       filter: {
+   *         start_time: &#x27;2020-06-01T00:00:00.000Z&#x27;,
+   *         end_time: &#x27;2020-06-02T00:00:00.000Z&#x27;
+   *       }
+   *     }
+   *   })
+   *
+   * @method findMany
+   * @param {String} type the type to find
+   * @param {Object} options
+   */
+  findMany = (type, ids, options = {}) =&gt; {
+    const { fromServer } = options
+
+    let idsToQuery = ids.slice().map(String)
+
+    if (fromServer === false) {
+      // If fromServer is false never fetch the data and return
+      return this.getRecords(type).filter(record =&gt; idsToQuery.includes(record.id))
+    }
+
+    let recordsInStore = []
+
+    if (fromServer !== true) {
+      recordsInStore = this.getRecords(type).filter(record =&gt; idsToQuery.includes(record.id))
+
+      if (recordsInStore.length === idsToQuery.length) {
+        // if fromServer is not false or true, but all the records are in store, wrap it in a promise
+        return Promise.resolve(recordsInStore)
+      }
+
+      const recordIdsInStore = recordsInStore.map(({ id }) =&gt; String(id))
+      // If fromServer is not true, we will only query records that are not already in the store
+      idsToQuery = idsToQuery.filter(id =&gt; !recordIdsInStore.includes(id))
+    }
+
+    const queryParams = options.queryParams || {}
+    queryParams.filter = queryParams.filter || {}
+    const baseUrl = this.fetchUrl(type, queryParams)
+    const idQueries = deriveIdQueryStrings(idsToQuery, baseUrl)
+
+    const query = Promise.all(
+      idQueries.map((queryIds) =&gt; {
+        queryParams.filter.ids = queryIds
+        return this.fetchAll(type, queryParams)
+      })
+    )
+
+    return query.then(recordsFromServer =&gt; recordsInStore.concat(...recordsFromServer))
   }
 
   /**

--- a/docs/files/src_decorators_attributes.js.html
+++ b/docs/files/src_decorators_attributes.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.4.0</em>
+            <em>API Docs for: 1.5.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_relationships.js.html
+++ b/docs/files/src_decorators_relationships.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.4.0</em>
+            <em>API Docs for: 1.5.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_schema.js.html
+++ b/docs/files/src_schema.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.4.0</em>
+            <em>API Docs for: 1.5.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_utils.js.html
+++ b/docs/files/src_utils.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.4.0</em>
+            <em>API Docs for: 1.5.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -91,6 +91,7 @@ import flattenDeep from &#x27;lodash/flattenDeep&#x27;
 
 const pending = {}
 const counter = {}
+export const URL_MAX_LENGTH = 1024
 
 const incrementor = (key) =&gt; () =&gt; {
   const count = (counter[key] || 0) + 1
@@ -291,6 +292,35 @@ export function diff (a = {}, b = {}) {
  */
 export function parseApiErrors (errors, defaultMessage) {
   return (errors[0].detail.length === 0) ? defaultMessage : errors[0].detail[0]
+}
+
+/**
+ * Splits an array of ids into a series of strings that can be used to form
+ * queries that conform to a max length of URL_MAX_LENGTH. This is to prevent 414 errors.
+ * @method deriveIdQueryStrings
+ * @param {Array} ids an array of ids that will be used in the string
+ * @param {String} restOfUrl the additional text URL that will be passed to the server
+ */
+
+export function deriveIdQueryStrings (ids, restOfUrl = &#x27;&#x27;) {
+  const idLength = Math.max(...ids.map(id =&gt; String(id).length))
+  const maxLength = URL_MAX_LENGTH - restOfUrl.length - encodeURIComponent(&#x27;filter[ids]=,,&#x27;).length
+
+  const encodedIds = encodeURIComponent(ids.join(&#x27;,&#x27;))
+  if (encodedIds.length &lt;= maxLength) {
+    return [ids.join(&#x27;,&#x27;)]
+  }
+
+  const minLength = maxLength - idLength
+
+  const regexp = new RegExp(&#x60;.{${minLength},${maxLength}}%2C&#x60;, &#x27;g&#x27;)
+  // the matches
+  const matched = encodedIds.match(regexp)
+  // everything that doesn&#x27;t match, ie the last of the ids
+  const tail = encodedIds.replace(regexp, &#x27;&#x27;)
+
+  // we manually strip the &#x27;,&#x27; at the end because javascript&#x27;s non-capturing regex groups are hard to manage
+  return [...matched, tail].map(decodeURIComponent).map(string =&gt; string.replace(/,$/, &#x27;&#x27;))
 }
 
     </pre>

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
                 <h1><img src="./assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.4.0</em>
+            <em>API Docs for: 1.5.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/spec/Store.spec.js
+++ b/spec/Store.spec.js
@@ -690,99 +690,6 @@ describe('Store', () => {
     })
 
     describe('when "fromServer" is not explicitly set', () => {
-      it('fetches data from server', async () => {
-        expect.assertions(4)
-        fetch.mockResponse(createMockTodosResponse(5, '1000'))
-        const ids = createMockIds(5, '1000')
-        const todos = await store.findMany('todos', ids, { fromServer: true })
-        expect(todos).toHaveLength(5)
-        expect(todos[0].title).toEqual('Todo 1000')
-        expect(fetch.mock.calls).toHaveLength(1)
-        expect(fetch.mock.calls[0][0])
-          .toEqual('/example_api/todos?filter%5Bids%5D=1000%2C1001%2C1002%2C1003%2C1004')
-      })
-
-      it('uses multiple fetches for data from server', async () => {
-        expect.assertions(7)
-
-        fetch.mockResponseOnce(createMockTodosResponse(100, '1000'))
-        fetch.mockResponseOnce(createMockTodosResponse(100, '1100'))
-        fetch.mockResponseOnce(createMockTodosResponse(100, '1200'))
-
-        const ids = createMockIds(300, '1000')
-        const todos = await store.findMany('todos', ids, { fromServer: true })
-
-        expect(todos).toHaveLength(300)
-        expect(store.findAll('todos', { fromServer: false })).toHaveLength(300)
-
-        expect(fetch.mock.calls).toHaveLength(3)
-        const [firstCall] = fetch.mock.calls[0]
-        expect(decodeURIComponent(firstCall)).toMatch(/1139$/)
-
-        fetch.mock.calls.forEach(call => {
-          expect(call[0].length).toBeLessThan(URL_MAX_LENGTH)
-        })
-      })
-
-      it('fetches data with other params', async () => {
-        expect.assertions(8)
-
-        const ids = createMockIds(300, '1000')
-        fetch.mockResponse(mockTodosResponse)
-
-        await store.findMany('todos', ids, {
-          fromServer: true,
-          queryParams: {
-            filter: {
-              title: 'Do taxes',
-              overdue: true
-            }
-          }
-        })
-
-        expect(fetch.mock.calls).toHaveLength(3)
-        fetch.mock.calls.forEach(call => {
-          const [path] = call
-          expect(decodeURIComponent(path)).toMatch('/example_api/todos?filter[title]=Do taxes&filter[overdue]=true')
-          expect(call.length).toBeLessThan(URL_MAX_LENGTH)
-        })
-
-        const [firstPath] = fetch.mock.calls[0]
-        expect(decodeURIComponent(firstPath)).toMatch(/1132$/)
-      })
-
-      it('fetches data with named array filters', async () => {
-        expect.assertions(8)
-        fetch.mockResponse(mockTodosResponse)
-        const ids = createMockIds(300, '1000')
-        await store.findMany('todos', ids, {
-          fromServer: true,
-          queryParams: {
-            filter: {
-              category: 'important'
-            }
-          }
-        })
-
-        expect(fetch.mock.calls).toHaveLength(3)
-        fetch.mock.calls.forEach(call => {
-          const [path] = call
-          expect(decodeURIComponent(path)).toMatch('filter[category]=important')
-          expect(call.length).toBeLessThan(URL_MAX_LENGTH)
-        })
-
-        const [firstPath] = fetch.mock.calls[0]
-        expect(decodeURIComponent(firstPath)).toMatch(/1135$/)
-      })
-
-      it('caches list ids by request url', async () => {
-        expect.assertions(1)
-        fetch.mockResponse(mockTodosResponse)
-        await store.findMany('todos', ['1'], { fromServer: true })
-        const cache = toJS(store.data.todos.cache)
-        expect(cache['/example_api/todos?filter%5Bids%5D=1']).toEqual(['1'])
-      })
-
       describe('no records of the specified type exist', () => {
         it('uses multiple fetches to request all records from server', async () => {
           expect.assertions(7)
@@ -792,7 +699,7 @@ describe('Store', () => {
           fetch.mockResponseOnce(createMockTodosResponse(100, '1200'))
 
           const ids = createMockIds(300, '1000')
-          const todos = await store.findMany('todos', ids, { fromServer: true })
+          const todos = await store.findMany('todos', ids)
 
           expect(todos).toHaveLength(300)
           expect(store.findAll('todos', { fromServer: false })).toHaveLength(300)

--- a/spec/utils.spec.js
+++ b/spec/utils.spec.js
@@ -1,0 +1,22 @@
+import QueryString from '../src/QueryString'
+import { deriveIdQueryStrings, URL_MAX_LENGTH } from '../src/utils'
+
+describe('deriveIdQueryStrings', () => {
+  const shortIds = [1, 2, 3]
+  const longIds = Array.from({length: 1000}, (_, index) => 1000 + index)
+  const baseUrl = 'https://example.com/todos'
+
+  it('splits ids into an expected length', () => {
+    const idQueryStrings = deriveIdQueryStrings(longIds, baseUrl)
+    expect(idQueryStrings).toHaveLength(8)
+    idQueryStrings.forEach(ids => {
+      expect(baseUrl.length + QueryString.stringify({ filter: { ids } }).length).toBeLessThan(URL_MAX_LENGTH)
+    })
+  })
+
+  it("doesn't split short arrays", () => {
+    const idQueryStrings = deriveIdQueryStrings(shortIds, baseUrl)
+    expect(idQueryStrings).toHaveLength(1)
+    expect(idQueryStrings[0].length + baseUrl.length).toBeLessThan(URL_MAX_LENGTH)
+  })
+})


### PR DESCRIPTION
Querying for many identified records is difficult in `mobx-async-store`. You can use `findOne`, which will kick off a query for each record, or `findAll`, which can cause 414 errors with a long list of ids.

`findMany` treats the syntax like a `findOne` but queries like a `findAll` with `filter[ids]` params. It first looks in the store to find available records, then splits into multiple queries for the records it does not have, avoiding the query max length. It then concatenates the responses with the records from the store and returns all of the records.

This PR is really long, but the relevant changes are in [Store](https://github.com/artemis-ag/mobx-async-store/pull/61/files#diff-7a95c660669a260e384552aaa39be4bfR212-R305) and [utils](https://github.com/artemis-ag/mobx-async-store/pull/61/files#diff-2b4ca49d4bb0a774c4d4c1672d7aa781R211-R239)