### PR TITLE
return a promise for findAll unless fromServer is explicitly false

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -1618,7 +1618,7 @@ function () {
 
       if (records.length > 0) {
         // Return data
-        return records;
+        return Promise.resolve(records);
       } else {
         // Otherwise fetch it from the server
         return _this.fetchAll(type, queryParams);

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -1612,7 +1612,7 @@ function () {
 
       if (records.length > 0) {
         // Return data
-        return records;
+        return Promise.resolve(records);
       } else {
         // Otherwise fetch it from the server
         return _this.fetchAll(type, queryParams);

--- a/docs/classes/Model.html
+++ b/docs/classes/Model.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.5.1</em>
+            <em>API Docs for: 2.0.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Model.html
+++ b/docs/classes/Model.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.5.0</em>
+            <em>API Docs for: 1.5.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/RelatedRecordsArray.html
+++ b/docs/classes/RelatedRecordsArray.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.5.1</em>
+            <em>API Docs for: 2.0.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/RelatedRecordsArray.html
+++ b/docs/classes/RelatedRecordsArray.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.5.0</em>
+            <em>API Docs for: 1.5.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Schema.html
+++ b/docs/classes/Schema.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.5.1</em>
+            <em>API Docs for: 2.0.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Schema.html
+++ b/docs/classes/Schema.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.5.0</em>
+            <em>API Docs for: 1.5.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Store.html
+++ b/docs/classes/Store.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.5.1</em>
+            <em>API Docs for: 2.0.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Store.html
+++ b/docs/classes/Store.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.5.0</em>
+            <em>API Docs for: 1.5.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/data.json
+++ b/docs/data.json
@@ -3,7 +3,7 @@
         "name": "mobx-async-store",
         "description": "Asyc Data Store for mobx",
         "url": "https://github.com/artemis-ag/mobx-async-store",
-        "version": "1.5.1"
+        "version": "2.0.0"
     },
     "files": {
         "src/decorators/attributes.js": {

--- a/docs/data.json
+++ b/docs/data.json
@@ -3,7 +3,7 @@
         "name": "mobx-async-store",
         "description": "Asyc Data Store for mobx",
         "url": "https://github.com/artemis-ag/mobx-async-store",
-        "version": "1.5.0"
+        "version": "1.5.1"
     },
     "files": {
         "src/decorators/attributes.js": {

--- a/docs/files/src_Model.js.html
+++ b/docs/files/src_Model.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.5.1</em>
+            <em>API Docs for: 2.0.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_Model.js.html
+++ b/docs/files/src_Model.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.5.0</em>
+            <em>API Docs for: 1.5.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_Store.js.html
+++ b/docs/files/src_Store.js.html
@@ -504,7 +504,7 @@ class Store {
 
     if (records.length &gt; 0) {
       // Return data
-      return records
+      return Promise.resolve(records)
     } else {
       // Otherwise fetch it from the server
       return this.fetchAll(type, queryParams)

--- a/docs/files/src_Store.js.html
+++ b/docs/files/src_Store.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.5.1</em>
+            <em>API Docs for: 2.0.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_Store.js.html
+++ b/docs/files/src_Store.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.5.0</em>
+            <em>API Docs for: 1.5.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_attributes.js.html
+++ b/docs/files/src_decorators_attributes.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.5.1</em>
+            <em>API Docs for: 2.0.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_attributes.js.html
+++ b/docs/files/src_decorators_attributes.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.5.0</em>
+            <em>API Docs for: 1.5.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_relationships.js.html
+++ b/docs/files/src_decorators_relationships.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.5.1</em>
+            <em>API Docs for: 2.0.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_relationships.js.html
+++ b/docs/files/src_decorators_relationships.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.5.0</em>
+            <em>API Docs for: 1.5.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_schema.js.html
+++ b/docs/files/src_schema.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.5.1</em>
+            <em>API Docs for: 2.0.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_schema.js.html
+++ b/docs/files/src_schema.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.5.0</em>
+            <em>API Docs for: 1.5.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_utils.js.html
+++ b/docs/files/src_utils.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.5.1</em>
+            <em>API Docs for: 2.0.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_utils.js.html
+++ b/docs/files/src_utils.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.5.0</em>
+            <em>API Docs for: 1.5.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
                 <h1><img src="./assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.5.1</em>
+            <em>API Docs for: 2.0.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
                 <h1><img src="./assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 1.5.0</em>
+            <em>API Docs for: 1.5.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "1.5.1",
+  "version": "2.0.0",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/spec/Store.spec.js
+++ b/spec/Store.spec.js
@@ -511,7 +511,7 @@ describe('Store', () => {
       })
 
       describe('if a query is made with identical params', () => {
-        it.only('skips fetch and returns local data from the store', async () => {
+        it('skips fetch and returns local data from the store', async () => {
           expect.assertions(6)
           // Query params for both requests
           const queryParams = { filter: { overdue: true } }

--- a/spec/Store.spec.js
+++ b/spec/Store.spec.js
@@ -159,7 +159,7 @@ describe('Store', () => {
       const examples = store.add('todos', exampleData)
       expect(examples).toHaveLength(2)
 
-      const foundExamples = store.findAll('todos', exampleData, { fromServer: false })
+      const foundExamples = store.findAll('todos', { fromServer: false })
       expect(foundExamples).toHaveLength(2)
     })
   })
@@ -511,18 +511,22 @@ describe('Store', () => {
       })
 
       describe('if a query is made with identical params', () => {
-        it('skips fetch and returns local data from the store', async () => {
-          expect.assertions(4)
+        it.only('skips fetch and returns local data from the store', async () => {
+          expect.assertions(6)
           // Query params for both requests
           const queryParams = { filter: { overdue: true } }
           // Only need to mock response once :)
           fetch.mockResponse(mockTodosResponse)
           // Fetch todos
-          let todos = await store.findAll('todos', { queryParams })
+          let query = store.findAll('todos', { queryParams })
+          expect(query).toBeInstanceOf(Promise)
+          let todos = await query
           expect(todos).toHaveLength(1)
           expect(fetch.mock.calls).toHaveLength(1)
           // Find todos a second time
-          todos = await store.findAll('todos', { queryParams })
+          query = store.findAll('todos', { queryParams })
+          expect(query).toBeInstanceOf(Promise)
+          todos = await query
           // Not fetch should be kicked off
           expect(todos).toHaveLength(1)
           expect(fetch.mock.calls).toHaveLength(1)

--- a/src/Store.js
+++ b/src/Store.js
@@ -419,7 +419,7 @@ class Store {
 
     if (records.length > 0) {
       // Return data
-      return records
+      return Promise.resolve(records)
     } else {
       // Otherwise fetch it from the server
       return this.fetchAll(type, queryParams)


### PR DESCRIPTION
Right now, if you execute a query twice without a `fromServer` param, the second one returns an array rather than a promise.

```js
store.findAll('todos')
=> returns Promise
store.findAll('todos')
=> returns Array
```

This works with `async/await`, but is not thennable.

```js
store.findAll('todos').then(...) // works
store.findAll('todos').then(...) // blows up
```

This is a potentially breaking change:
- If someone has forgotten to use `fromServer: false` but is expecting an array, it would break.

```js
// with current code
let todos = await store.findAll('todos')
todos.map(() => {}) // works
todos = store.findAll('todos')
todos.map(() => {}) // works
```