### PR TITLE
Pass options to jsonapi() in bulkSave for relationships [Ref #173716895]

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -1446,7 +1446,7 @@ function () {
                 url = _this.fetchUrl(type, queryParams, null); // convert records to an appropriate jsonapi attribute/relationship format
 
                 recordAttributes = records.map(function (record) {
-                  return record.jsonapi();
+                  return record.jsonapi(options);
                 }); // build a data payload
 
                 body = JSON.stringify({

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -1440,7 +1440,7 @@ function () {
                 url = _this.fetchUrl(type, queryParams, null); // convert records to an appropriate jsonapi attribute/relationship format
 
                 recordAttributes = records.map(function (record) {
-                  return record.jsonapi();
+                  return record.jsonapi(options);
                 }); // build a data payload
 
                 body = JSON.stringify({

--- a/docs/classes/Model.html
+++ b/docs/classes/Model.html
@@ -1062,7 +1062,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l491"><code>src&#x2F;Model.js:491</code></a>
+        <a href="../files/src_Model.js.html#l502"><code>src&#x2F;Model.js:502</code></a>
         </p>
 
 
@@ -1070,7 +1070,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     </div>
 
     <div class="description">
-        <p>the latest snapshot</p>
+        <p>the latest persisted snapshot or the first snapshot if the model was never persisted</p>
 
     </div>
 
@@ -1093,7 +1093,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l502"><code>src&#x2F;Model.js:502</code></a>
+        <a href="../files/src_Model.js.html#l491"><code>src&#x2F;Model.js:491</code></a>
         </p>
 
 
@@ -1101,7 +1101,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     </div>
 
     <div class="description">
-        <p>the latest persisted snapshot or the first snapshot if the model was never persisted</p>
+        <p>the latest snapshot</p>
 
     </div>
 

--- a/docs/classes/Model.html
+++ b/docs/classes/Model.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.0.0</em>
+            <em>API Docs for: 2.0.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -1062,7 +1062,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l502"><code>src&#x2F;Model.js:502</code></a>
+        <a href="../files/src_Model.js.html#l491"><code>src&#x2F;Model.js:491</code></a>
         </p>
 
 
@@ -1070,7 +1070,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     </div>
 
     <div class="description">
-        <p>the latest persisted snapshot or the first snapshot if the model was never persisted</p>
+        <p>the latest snapshot</p>
 
     </div>
 
@@ -1093,7 +1093,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l491"><code>src&#x2F;Model.js:491</code></a>
+        <a href="../files/src_Model.js.html#l502"><code>src&#x2F;Model.js:502</code></a>
         </p>
 
 
@@ -1101,7 +1101,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     </div>
 
     <div class="description">
-        <p>the latest snapshot</p>
+        <p>the latest persisted snapshot or the first snapshot if the model was never persisted</p>
 
     </div>
 

--- a/docs/classes/RelatedRecordsArray.html
+++ b/docs/classes/RelatedRecordsArray.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.0.0</em>
+            <em>API Docs for: 2.0.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Schema.html
+++ b/docs/classes/Schema.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.0.0</em>
+            <em>API Docs for: 2.0.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Store.html
+++ b/docs/classes/Store.html
@@ -2652,7 +2652,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l464"><code>src&#x2F;Store.js:464</code></a>
+        <a href="../files/src_Store.js.html#l475"><code>src&#x2F;Store.js:475</code></a>
         </p>
 
 
@@ -2706,7 +2706,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l475"><code>src&#x2F;Store.js:475</code></a>
+        <a href="../files/src_Store.js.html#l464"><code>src&#x2F;Store.js:464</code></a>
         </p>
 
 

--- a/docs/classes/Store.html
+++ b/docs/classes/Store.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.0.0</em>
+            <em>API Docs for: 2.0.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -2652,7 +2652,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l475"><code>src&#x2F;Store.js:475</code></a>
+        <a href="../files/src_Store.js.html#l464"><code>src&#x2F;Store.js:464</code></a>
         </p>
 
 
@@ -2706,7 +2706,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l464"><code>src&#x2F;Store.js:464</code></a>
+        <a href="../files/src_Store.js.html#l475"><code>src&#x2F;Store.js:475</code></a>
         </p>
 
 

--- a/docs/data.json
+++ b/docs/data.json
@@ -3,7 +3,7 @@
         "name": "mobx-async-store",
         "description": "Asyc Data Store for mobx",
         "url": "https://github.com/artemis-ag/mobx-async-store",
-        "version": "2.0.0"
+        "version": "2.0.1"
     },
     "files": {
         "src/decorators/attributes.js": {

--- a/docs/files/src_Model.js.html
+++ b/docs/files/src_Model.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.0.0</em>
+            <em>API Docs for: 2.0.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_Store.js.html
+++ b/docs/files/src_Store.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.0.0</em>
+            <em>API Docs for: 2.0.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -198,7 +198,7 @@ class Store {
     const url = this.fetchUrl(type, queryParams, null)
 
     // convert records to an appropriate jsonapi attribute/relationship format
-    const recordAttributes = records.map((record) =&gt; record.jsonapi())
+    const recordAttributes = records.map((record) =&gt; record.jsonapi(options))
 
     // build a data payload
     const body = JSON.stringify({ data: recordAttributes })

--- a/docs/files/src_decorators_attributes.js.html
+++ b/docs/files/src_decorators_attributes.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.0.0</em>
+            <em>API Docs for: 2.0.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_relationships.js.html
+++ b/docs/files/src_decorators_relationships.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.0.0</em>
+            <em>API Docs for: 2.0.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_schema.js.html
+++ b/docs/files/src_schema.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.0.0</em>
+            <em>API Docs for: 2.0.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_utils.js.html
+++ b/docs/files/src_utils.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.0.0</em>
+            <em>API Docs for: 2.0.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
                 <h1><img src="./assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.0.0</em>
+            <em>API Docs for: 2.0.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/src/Store.js
+++ b/src/Store.js
@@ -113,7 +113,7 @@ class Store {
     const url = this.fetchUrl(type, queryParams, null)
 
     // convert records to an appropriate jsonapi attribute/relationship format
-    const recordAttributes = records.map((record) => record.jsonapi())
+    const recordAttributes = records.map((record) => record.jsonapi(options))
 
     // build a data payload
     const body = JSON.stringify({ data: recordAttributes })


### PR DESCRIPTION
Previously, we had been relying on most relationships during `bulkSave()` to be handled in the completion handlers, based on ids passed through the completions' options. Since we actually have to pass `uploaded_documents` through via relationships, we have to pass the relationships through via `options`, which we hadn't previously been using in `bulkSave()`. No test, because it would end up being more of a test of `jsonapi()`'s implementation, which is already tested.