### PR TITLE
add server errors to models

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -2334,31 +2334,11 @@ function () {
                   _json.errors.forEach(function (error) {
                     var _this6$parsePointer = _this6.parsePointer(error),
                         index = _this6$parsePointer.index,
-                        key = _this6$parsePointer.key,
-                        path = _this6$parsePointer.path;
+                        key = _this6$parsePointer.key;
 
-                    if (path != null) {
-                      // TODO: this difference in structure is a problem -
-                      //       errors.name may be an array while errors.options
-                      //       is an object. These should be consistent.
-                      if (recordsArray[index].errors[key] == null) {
-                        recordsArray[index].errors[key] = {};
-                      }
-
-                      var errors = recordsArray[index].errors[key][path] || [];
-                      errors.push({
-                        message: error.detail
-                      });
-                      recordsArray[index].errors[key][path] = errors;
-                    } else {
-                      var _errors = recordsArray[index].errors[key] || [];
-
-                      _errors.push({
-                        message: error.detail
-                      });
-
-                      recordsArray[index].errors[key] = _errors;
-                    }
+                    var errors = recordsArray[index].errors[key] || [];
+                    errors.push(error);
+                    recordsArray[index].errors[key] = errors;
                   }); // TODO: add any errors that have no index to general errors
 
 
@@ -2387,10 +2367,8 @@ function () {
     }
     /**
      * Parses the pointer of the error to retrieve the index of the
-     * record the error belongs to, the top level attribute, and any
-     * path to a nested attribute value (we have a precedence of using
-     * period separated paths to describe values for attributes that
-     * are objects in order to keep the errors interface consistent)
+     * record the error belongs to and the full path to the attribute
+     * which will serve as the key for the error.
      *
      * If there is no parsed index, then assume the payload was for
      * a single record and default to 0.
@@ -2398,17 +2376,14 @@ function () {
      * ex.
      *   error = {
      *     detail: "Quantity can't be blank",
-     *     source: {
-     *       pointer: '/data/1/attributes/options/resources/0/quantity'
-     *     },
+     *     source: { pointer: '/data/1/attributes/options/barcode' },
      *     title: 'Invalid quantity'
      *   }
      *
      * parsePointer(error)
      * > {
      *     index: 1,
-     *     key: 'options',
-     *     path: 'resources.0.quantity'
+     *     key: 'options.barcode'
      *   }
      *
      * @method parsePointer
@@ -2419,23 +2394,20 @@ function () {
   }, {
     key: "parsePointer",
     value: function parsePointer(error) {
-      var regex = _wrapRegExp(/\/data\/([0-9]+)?\/?attributes\/([\0-\.0-\uFFFF]*)\/?(.*)?$/, {
+      var regex = _wrapRegExp(/\/data\/([0-9]+)?\/?attributes\/(.*)$/, {
         index: 1,
-        key: 2,
-        path: 3
+        key: 2
       });
 
       var _error$source$pointer = error.source.pointer.match(regex),
           _error$source$pointer2 = _error$source$pointer.groups,
           _error$source$pointer3 = _error$source$pointer2.index,
           index = _error$source$pointer3 === void 0 ? 0 : _error$source$pointer3,
-          key = _error$source$pointer2.key,
-          path = _error$source$pointer2.path;
+          key = _error$source$pointer2.key;
 
       return {
         index: parseInt(index),
-        key: key,
-        path: path === null || path === void 0 ? void 0 : path.replace(/\//g, '.')
+        key: key === null || key === void 0 ? void 0 : key.replace(/\//g, '.')
       };
     }
   }]);

--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -24,11 +24,11 @@ var cloneDeep = _interopDefault(require('lodash/cloneDeep'));
 var _isEqual = _interopDefault(require('lodash/isEqual'));
 var isObject = _interopDefault(require('lodash/isObject'));
 var findLast = _interopDefault(require('lodash/findLast'));
+var _inherits = _interopDefault(require('@babel/runtime/helpers/inherits'));
 var _possibleConstructorReturn = _interopDefault(require('@babel/runtime/helpers/possibleConstructorReturn'));
 var _getPrototypeOf = _interopDefault(require('@babel/runtime/helpers/getPrototypeOf'));
-var _assertThisInitialized = _interopDefault(require('@babel/runtime/helpers/assertThisInitialized'));
-var _inherits = _interopDefault(require('@babel/runtime/helpers/inherits'));
 var _wrapNativeSuper = _interopDefault(require('@babel/runtime/helpers/wrapNativeSuper'));
+var _assertThisInitialized = _interopDefault(require('@babel/runtime/helpers/assertThisInitialized'));
 
 var QueryString = {
   parse: function parse(str) {
@@ -1359,6 +1359,8 @@ function () {
 
 var _class$1, _descriptor$1, _descriptor2$1, _descriptor3$1, _temp$1;
 
+function _wrapRegExp(re, groups) { _wrapRegExp = function _wrapRegExp(re, groups) { return new BabelRegExp(re, undefined, groups); }; var _RegExp = _wrapNativeSuper(RegExp); var _super = RegExp.prototype; var _groups = new WeakMap(); function BabelRegExp(re, flags, groups) { var _this = _RegExp.call(this, re, flags); _groups.set(_this, groups || _groups.get(re)); return _this; } _inherits(BabelRegExp, _RegExp); BabelRegExp.prototype.exec = function (str) { var result = _super.exec.call(this, str); if (result) result.groups = buildGroups(result, this); return result; }; BabelRegExp.prototype[Symbol.replace] = function (str, substitution) { if (typeof substitution === "string") { var groups = _groups.get(this); return _super[Symbol.replace].call(this, str, substitution.replace(/\$<([^>]+)>/g, function (_, name) { return "$" + groups[name]; })); } else if (typeof substitution === "function") { var _this = this; return _super[Symbol.replace].call(this, str, function () { var args = []; args.push.apply(args, arguments); if (_typeof(args[args.length - 1]) !== "object") { args.push(buildGroups(args, _this)); } return substitution.apply(this, args); }); } else { return _super[Symbol.replace].call(this, str, substitution); } }; function buildGroups(result, re) { var g = _groups.get(re); return Object.keys(g).reduce(function (groups, name) { groups[name] = result[g[name]]; return groups; }, Object.create(null)); } return _wrapRegExp.apply(this, arguments); }
+
 function ownKeys$2(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
 function _objectSpread$2(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys$2(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys$2(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
@@ -2326,15 +2328,40 @@ function () {
                   _context4.t0 = _context4["catch"](17);
 
                 case 26:
-                  // TODO: add all errors from the API response to the record
-                  // also TODO: split server errors by record once the info is available from the API
-                  recordsArray[0].errors = _objectSpread$2({}, recordsArray[0].errors, {
-                    status: status,
-                    base: [{
-                      message: message
-                    }],
-                    server: _json.errors
-                  });
+                  // Add all errors from the API response to the record(s).
+                  // This is done by comparing the pointer in the error to
+                  // the request.
+                  _json.errors.forEach(function (error) {
+                    var _this6$parsePointer = _this6.parsePointer(error),
+                        index = _this6$parsePointer.index,
+                        key = _this6$parsePointer.key,
+                        path = _this6$parsePointer.path;
+
+                    if (path != null) {
+                      // TODO: this difference in structure is a problem -
+                      //       errors.name may be an array while errors.options
+                      //       is an object. These should be consistent.
+                      if (recordsArray[index].errors[key] == null) {
+                        recordsArray[index].errors[key] = {};
+                      }
+
+                      var errors = recordsArray[index].errors[key][path] || [];
+                      errors.push({
+                        message: error.detail
+                      });
+                      recordsArray[index].errors[key][path] = errors;
+                    } else {
+                      var _errors = recordsArray[index].errors[key] || [];
+
+                      _errors.push({
+                        message: error.detail
+                      });
+
+                      recordsArray[index].errors[key] = _errors;
+                    }
+                  }); // TODO: add any errors that have no index to general errors
+
+
                   errorString = JSON.stringify(recordsArray[0].errors);
                   return _context4.abrupt("return", Promise.reject(new Error(errorString)));
 
@@ -2357,6 +2384,59 @@ function () {
         recordsArray[0].errors = error;
         throw error;
       });
+    }
+    /**
+     * Parses the pointer of the error to retrieve the index of the
+     * record the error belongs to, the top level attribute, and any
+     * path to a nested attribute value (we have a precedence of using
+     * period separated paths to describe values for attributes that
+     * are objects in order to keep the errors interface consistent)
+     *
+     * If there is no parsed index, then assume the payload was for
+     * a single record and default to 0.
+     *
+     * ex.
+     *   error = {
+     *     detail: "Quantity can't be blank",
+     *     source: {
+     *       pointer: '/data/1/attributes/options/resources/0/quantity'
+     *     },
+     *     title: 'Invalid quantity'
+     *   }
+     *
+     * parsePointer(error)
+     * > {
+     *     index: 1,
+     *     key: 'options',
+     *     path: 'resources.0.quantity'
+     *   }
+     *
+     * @method parsePointer
+     * @param {Object} error
+     * @return {Object} the matching parts of the pointer
+     */
+
+  }, {
+    key: "parsePointer",
+    value: function parsePointer(error) {
+      var regex = _wrapRegExp(/\/data\/([0-9]+)?\/?attributes\/([\0-\.0-\uFFFF]*)\/?(.*)?$/, {
+        index: 1,
+        key: 2,
+        path: 3
+      });
+
+      var _error$source$pointer = error.source.pointer.match(regex),
+          _error$source$pointer2 = _error$source$pointer.groups,
+          _error$source$pointer3 = _error$source$pointer2.index,
+          index = _error$source$pointer3 === void 0 ? 0 : _error$source$pointer3,
+          key = _error$source$pointer2.key,
+          path = _error$source$pointer2.path;
+
+      return {
+        index: parseInt(index),
+        key: key,
+        path: path === null || path === void 0 ? void 0 : path.replace(/\//g, '.')
+      };
     }
   }]);
 

--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -15,6 +15,10 @@ var _applyDecoratedDescriptor = _interopDefault(require('@babel/runtime/helpers/
 require('@babel/runtime/helpers/initializerWarningHelper');
 var _typeof = _interopDefault(require('@babel/runtime/helpers/typeof'));
 var mobx = require('mobx');
+var _inherits = _interopDefault(require('@babel/runtime/helpers/inherits'));
+var _possibleConstructorReturn = _interopDefault(require('@babel/runtime/helpers/possibleConstructorReturn'));
+var _getPrototypeOf = _interopDefault(require('@babel/runtime/helpers/getPrototypeOf'));
+var _wrapNativeSuper = _interopDefault(require('@babel/runtime/helpers/wrapNativeSuper'));
 var uuidv1 = _interopDefault(require('uuid/v1'));
 var qs = _interopDefault(require('qs'));
 var pluralize = _interopDefault(require('pluralize'));
@@ -24,10 +28,6 @@ var cloneDeep = _interopDefault(require('lodash/cloneDeep'));
 var _isEqual = _interopDefault(require('lodash/isEqual'));
 var isObject = _interopDefault(require('lodash/isObject'));
 var findLast = _interopDefault(require('lodash/findLast'));
-var _inherits = _interopDefault(require('@babel/runtime/helpers/inherits'));
-var _possibleConstructorReturn = _interopDefault(require('@babel/runtime/helpers/possibleConstructorReturn'));
-var _getPrototypeOf = _interopDefault(require('@babel/runtime/helpers/getPrototypeOf'));
-var _wrapNativeSuper = _interopDefault(require('@babel/runtime/helpers/wrapNativeSuper'));
 var _assertThisInitialized = _interopDefault(require('@babel/runtime/helpers/assertThisInitialized'));
 
 var QueryString = {
@@ -43,6 +43,7 @@ var QueryString = {
   }
 };
 
+function _wrapRegExp(re, groups) { _wrapRegExp = function _wrapRegExp(re, groups) { return new BabelRegExp(re, undefined, groups); }; var _RegExp = _wrapNativeSuper(RegExp); var _super = RegExp.prototype; var _groups = new WeakMap(); function BabelRegExp(re, flags, groups) { var _this = _RegExp.call(this, re, flags); _groups.set(_this, groups || _groups.get(re)); return _this; } _inherits(BabelRegExp, _RegExp); BabelRegExp.prototype.exec = function (str) { var result = _super.exec.call(this, str); if (result) result.groups = buildGroups(result, this); return result; }; BabelRegExp.prototype[Symbol.replace] = function (str, substitution) { if (typeof substitution === "string") { var groups = _groups.get(this); return _super[Symbol.replace].call(this, str, substitution.replace(/\$<([^>]+)>/g, function (_, name) { return "$" + groups[name]; })); } else if (typeof substitution === "function") { var _this = this; return _super[Symbol.replace].call(this, str, function () { var args = []; args.push.apply(args, arguments); if (_typeof(args[args.length - 1]) !== "object") { args.push(buildGroups(args, _this)); } return substitution.apply(this, args); }); } else { return _super[Symbol.replace].call(this, str, substitution); } }; function buildGroups(result, re) { var g = _groups.get(re); return Object.keys(g).reduce(function (groups, name) { groups[name] = result[g[name]]; return groups; }, Object.create(null)); } return _wrapRegExp.apply(this, arguments); }
 var pending = {};
 var counter = {};
 var URL_MAX_LENGTH = 1024;
@@ -230,20 +231,50 @@ function diff() {
   });
 }
 /**
- * A naive way of extracting errors from the server.
- * This needs some real work. Please don't track down the original author
- * of the code (it's DEFINITELY not the person writing this documentation).
- * Currently it only extracts the message from the first error, but not only
- * can multiple errors be returned, they will correspond to different records
- * in the case of a bulk JSONAPI response.
+ * Parses the pointer of the error to retrieve the index of the
+ * record the error belongs to and the full path to the attribute
+ * which will serve as the key for the error.
  *
- * @method parseApiErrors
- * @param {Array} a request to the API
- * @param {String} default error message
+ * If there is no parsed index, then assume the payload was for
+ * a single record and default to 0.
+ *
+ * ex.
+ *   error = {
+ *     detail: "Foo can't be blank",
+ *     source: { pointer: '/data/1/attributes/options/foo' },
+ *     title: 'Invalid foo'
+ *   }
+ *
+ * parsePointer(error)
+ * > {
+ *     index: 1,
+ *     key: 'options.foo'
+ *   }
+ *
+ * @method parseErrorPointer
+ * @param {Object} error
+ * @return {Object} the matching parts of the pointer
  */
 
-function parseApiErrors(errors, defaultMessage) {
-  return errors[0].detail.length === 0 ? defaultMessage : errors[0].detail[0];
+function parseErrorPointer() {
+  var error = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+  var regex = _wrapRegExp(/\/data\/([0-9]+)?\/?attributes\/(.*)$/, {
+    index: 1,
+    key: 2
+  });
+
+  var match = dig(error, 'source.pointer', '').match(regex);
+
+  var _ref = (match === null || match === void 0 ? void 0 : match.groups) || {},
+      _ref$index = _ref.index,
+      index = _ref$index === void 0 ? 0 : _ref$index,
+      key = _ref.key;
+
+  return {
+    index: parseInt(index),
+    key: key === null || key === void 0 ? void 0 : key.replace(/\//g, '.')
+  };
 }
 /**
  * Splits an array of ids into a series of strings that can be used to form
@@ -1359,8 +1390,6 @@ function () {
 
 var _class$1, _descriptor$1, _descriptor2$1, _descriptor3$1, _temp$1;
 
-function _wrapRegExp(re, groups) { _wrapRegExp = function _wrapRegExp(re, groups) { return new BabelRegExp(re, undefined, groups); }; var _RegExp = _wrapNativeSuper(RegExp); var _super = RegExp.prototype; var _groups = new WeakMap(); function BabelRegExp(re, flags, groups) { var _this = _RegExp.call(this, re, flags); _groups.set(_this, groups || _groups.get(re)); return _this; } _inherits(BabelRegExp, _RegExp); BabelRegExp.prototype.exec = function (str) { var result = _super.exec.call(this, str); if (result) result.groups = buildGroups(result, this); return result; }; BabelRegExp.prototype[Symbol.replace] = function (str, substitution) { if (typeof substitution === "string") { var groups = _groups.get(this); return _super[Symbol.replace].call(this, str, substitution.replace(/\$<([^>]+)>/g, function (_, name) { return "$" + groups[name]; })); } else if (typeof substitution === "function") { var _this = this; return _super[Symbol.replace].call(this, str, function () { var args = []; args.push.apply(args, arguments); if (_typeof(args[args.length - 1]) !== "object") { args.push(buildGroups(args, _this)); } return substitution.apply(this, args); }); } else { return _super[Symbol.replace].call(this, str, substitution); } }; function buildGroups(result, re) { var g = _groups.get(re); return Object.keys(g).reduce(function (groups, name) { groups[name] = result[g[name]]; return groups; }, Object.create(null)); } return _wrapRegExp.apply(this, arguments); }
-
 function ownKeys$2(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
 function _objectSpread$2(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys$2(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys$2(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
@@ -2266,7 +2295,7 @@ function () {
         var _ref3 = _asyncToGenerator(
         /*#__PURE__*/
         _regeneratorRuntime.mark(function _callee4(response) {
-          var status, json, data, included, message, _json, errorString;
+          var status, json, data, included, _json, errorString;
 
           return _regeneratorRuntime.wrap(function _callee4$(_context4) {
             while (1) {
@@ -2311,46 +2340,48 @@ function () {
                   recordsArray.forEach(function (record) {
                     record.isInFlight = false;
                   });
-                  message = _this6.genericErrorMessage;
                   _json = {};
-                  _context4.prev = 17;
-                  _context4.next = 20;
+                  _context4.prev = 16;
+                  _context4.next = 19;
                   return response.json();
 
-                case 20:
+                case 19:
                   _json = _context4.sent;
-                  message = parseApiErrors(_json.errors, message);
-                  _context4.next = 26;
+                  _context4.next = 25;
                   break;
 
-                case 24:
-                  _context4.prev = 24;
-                  _context4.t0 = _context4["catch"](17);
+                case 22:
+                  _context4.prev = 22;
+                  _context4.t0 = _context4["catch"](16);
+                  return _context4.abrupt("return", Promise.reject(new Error(_this6.genericErrorMessage)));
 
-                case 26:
+                case 25:
                   // Add all errors from the API response to the record(s).
                   // This is done by comparing the pointer in the error to
                   // the request.
                   _json.errors.forEach(function (error) {
-                    var _this6$parsePointer = _this6.parsePointer(error),
-                        index = _this6$parsePointer.index,
-                        key = _this6$parsePointer.key;
+                    var _parseErrorPointer = parseErrorPointer(error),
+                        index = _parseErrorPointer.index,
+                        key = _parseErrorPointer.key;
 
-                    var errors = recordsArray[index].errors[key] || [];
-                    errors.push(error);
-                    recordsArray[index].errors[key] = errors;
-                  }); // TODO: add any errors that have no index to general errors
+                    if (key != null) {
+                      var errors = recordsArray[index].errors[key] || [];
+                      errors.push(error);
+                      recordsArray[index].errors[key] = errors;
+                    }
+                  });
 
-
-                  errorString = JSON.stringify(recordsArray[0].errors);
+                  errorString = recordsArray.map(function (record) {
+                    return JSON.stringify(record.errors);
+                  }).join(';');
                   return _context4.abrupt("return", Promise.reject(new Error(errorString)));
 
-                case 29:
+                case 28:
                 case "end":
                   return _context4.stop();
               }
             }
-          }, _callee4, null, [[17, 24]]);
+          }, _callee4, null, [[16, 22]]);
         }));
 
         return function (_x9) {
@@ -2364,51 +2395,6 @@ function () {
         recordsArray[0].errors = error;
         throw error;
       });
-    }
-    /**
-     * Parses the pointer of the error to retrieve the index of the
-     * record the error belongs to and the full path to the attribute
-     * which will serve as the key for the error.
-     *
-     * If there is no parsed index, then assume the payload was for
-     * a single record and default to 0.
-     *
-     * ex.
-     *   error = {
-     *     detail: "Quantity can't be blank",
-     *     source: { pointer: '/data/1/attributes/options/barcode' },
-     *     title: 'Invalid quantity'
-     *   }
-     *
-     * parsePointer(error)
-     * > {
-     *     index: 1,
-     *     key: 'options.barcode'
-     *   }
-     *
-     * @method parsePointer
-     * @param {Object} error
-     * @return {Object} the matching parts of the pointer
-     */
-
-  }, {
-    key: "parsePointer",
-    value: function parsePointer(error) {
-      var regex = _wrapRegExp(/\/data\/([0-9]+)?\/?attributes\/(.*)$/, {
-        index: 1,
-        key: 2
-      });
-
-      var _error$source$pointer = error.source.pointer.match(regex),
-          _error$source$pointer2 = _error$source$pointer.groups,
-          _error$source$pointer3 = _error$source$pointer2.index,
-          index = _error$source$pointer3 === void 0 ? 0 : _error$source$pointer3,
-          key = _error$source$pointer2.key;
-
-      return {
-        index: parseInt(index),
-        key: key === null || key === void 0 ? void 0 : key.replace(/\//g, '.')
-      };
     }
   }]);
 

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -18,11 +18,11 @@ import cloneDeep from 'lodash/cloneDeep';
 import _isEqual from 'lodash/isEqual';
 import isObject from 'lodash/isObject';
 import findLast from 'lodash/findLast';
+import _inherits from '@babel/runtime/helpers/inherits';
 import _possibleConstructorReturn from '@babel/runtime/helpers/possibleConstructorReturn';
 import _getPrototypeOf from '@babel/runtime/helpers/getPrototypeOf';
-import _assertThisInitialized from '@babel/runtime/helpers/assertThisInitialized';
-import _inherits from '@babel/runtime/helpers/inherits';
 import _wrapNativeSuper from '@babel/runtime/helpers/wrapNativeSuper';
+import _assertThisInitialized from '@babel/runtime/helpers/assertThisInitialized';
 
 var QueryString = {
   parse: function parse(str) {
@@ -1353,6 +1353,8 @@ function () {
 
 var _class$1, _descriptor$1, _descriptor2$1, _descriptor3$1, _temp$1;
 
+function _wrapRegExp(re, groups) { _wrapRegExp = function _wrapRegExp(re, groups) { return new BabelRegExp(re, undefined, groups); }; var _RegExp = _wrapNativeSuper(RegExp); var _super = RegExp.prototype; var _groups = new WeakMap(); function BabelRegExp(re, flags, groups) { var _this = _RegExp.call(this, re, flags); _groups.set(_this, groups || _groups.get(re)); return _this; } _inherits(BabelRegExp, _RegExp); BabelRegExp.prototype.exec = function (str) { var result = _super.exec.call(this, str); if (result) result.groups = buildGroups(result, this); return result; }; BabelRegExp.prototype[Symbol.replace] = function (str, substitution) { if (typeof substitution === "string") { var groups = _groups.get(this); return _super[Symbol.replace].call(this, str, substitution.replace(/\$<([^>]+)>/g, function (_, name) { return "$" + groups[name]; })); } else if (typeof substitution === "function") { var _this = this; return _super[Symbol.replace].call(this, str, function () { var args = []; args.push.apply(args, arguments); if (_typeof(args[args.length - 1]) !== "object") { args.push(buildGroups(args, _this)); } return substitution.apply(this, args); }); } else { return _super[Symbol.replace].call(this, str, substitution); } }; function buildGroups(result, re) { var g = _groups.get(re); return Object.keys(g).reduce(function (groups, name) { groups[name] = result[g[name]]; return groups; }, Object.create(null)); } return _wrapRegExp.apply(this, arguments); }
+
 function ownKeys$2(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
 function _objectSpread$2(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys$2(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys$2(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
@@ -2320,15 +2322,40 @@ function () {
                   _context4.t0 = _context4["catch"](17);
 
                 case 26:
-                  // TODO: add all errors from the API response to the record
-                  // also TODO: split server errors by record once the info is available from the API
-                  recordsArray[0].errors = _objectSpread$2({}, recordsArray[0].errors, {
-                    status: status,
-                    base: [{
-                      message: message
-                    }],
-                    server: _json.errors
-                  });
+                  // Add all errors from the API response to the record(s).
+                  // This is done by comparing the pointer in the error to
+                  // the request.
+                  _json.errors.forEach(function (error) {
+                    var _this6$parsePointer = _this6.parsePointer(error),
+                        index = _this6$parsePointer.index,
+                        key = _this6$parsePointer.key,
+                        path = _this6$parsePointer.path;
+
+                    if (path != null) {
+                      // TODO: this difference in structure is a problem -
+                      //       errors.name may be an array while errors.options
+                      //       is an object. These should be consistent.
+                      if (recordsArray[index].errors[key] == null) {
+                        recordsArray[index].errors[key] = {};
+                      }
+
+                      var errors = recordsArray[index].errors[key][path] || [];
+                      errors.push({
+                        message: error.detail
+                      });
+                      recordsArray[index].errors[key][path] = errors;
+                    } else {
+                      var _errors = recordsArray[index].errors[key] || [];
+
+                      _errors.push({
+                        message: error.detail
+                      });
+
+                      recordsArray[index].errors[key] = _errors;
+                    }
+                  }); // TODO: add any errors that have no index to general errors
+
+
                   errorString = JSON.stringify(recordsArray[0].errors);
                   return _context4.abrupt("return", Promise.reject(new Error(errorString)));
 
@@ -2351,6 +2378,59 @@ function () {
         recordsArray[0].errors = error;
         throw error;
       });
+    }
+    /**
+     * Parses the pointer of the error to retrieve the index of the
+     * record the error belongs to, the top level attribute, and any
+     * path to a nested attribute value (we have a precedence of using
+     * period separated paths to describe values for attributes that
+     * are objects in order to keep the errors interface consistent)
+     *
+     * If there is no parsed index, then assume the payload was for
+     * a single record and default to 0.
+     *
+     * ex.
+     *   error = {
+     *     detail: "Quantity can't be blank",
+     *     source: {
+     *       pointer: '/data/1/attributes/options/resources/0/quantity'
+     *     },
+     *     title: 'Invalid quantity'
+     *   }
+     *
+     * parsePointer(error)
+     * > {
+     *     index: 1,
+     *     key: 'options',
+     *     path: 'resources.0.quantity'
+     *   }
+     *
+     * @method parsePointer
+     * @param {Object} error
+     * @return {Object} the matching parts of the pointer
+     */
+
+  }, {
+    key: "parsePointer",
+    value: function parsePointer(error) {
+      var regex = _wrapRegExp(/\/data\/([0-9]+)?\/?attributes\/([\0-\.0-\uFFFF]*)\/?(.*)?$/, {
+        index: 1,
+        key: 2,
+        path: 3
+      });
+
+      var _error$source$pointer = error.source.pointer.match(regex),
+          _error$source$pointer2 = _error$source$pointer.groups,
+          _error$source$pointer3 = _error$source$pointer2.index,
+          index = _error$source$pointer3 === void 0 ? 0 : _error$source$pointer3,
+          key = _error$source$pointer2.key,
+          path = _error$source$pointer2.path;
+
+      return {
+        index: parseInt(index),
+        key: key,
+        path: path === null || path === void 0 ? void 0 : path.replace(/\//g, '.')
+      };
     }
   }]);
 

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -2328,31 +2328,11 @@ function () {
                   _json.errors.forEach(function (error) {
                     var _this6$parsePointer = _this6.parsePointer(error),
                         index = _this6$parsePointer.index,
-                        key = _this6$parsePointer.key,
-                        path = _this6$parsePointer.path;
+                        key = _this6$parsePointer.key;
 
-                    if (path != null) {
-                      // TODO: this difference in structure is a problem -
-                      //       errors.name may be an array while errors.options
-                      //       is an object. These should be consistent.
-                      if (recordsArray[index].errors[key] == null) {
-                        recordsArray[index].errors[key] = {};
-                      }
-
-                      var errors = recordsArray[index].errors[key][path] || [];
-                      errors.push({
-                        message: error.detail
-                      });
-                      recordsArray[index].errors[key][path] = errors;
-                    } else {
-                      var _errors = recordsArray[index].errors[key] || [];
-
-                      _errors.push({
-                        message: error.detail
-                      });
-
-                      recordsArray[index].errors[key] = _errors;
-                    }
+                    var errors = recordsArray[index].errors[key] || [];
+                    errors.push(error);
+                    recordsArray[index].errors[key] = errors;
                   }); // TODO: add any errors that have no index to general errors
 
 
@@ -2381,10 +2361,8 @@ function () {
     }
     /**
      * Parses the pointer of the error to retrieve the index of the
-     * record the error belongs to, the top level attribute, and any
-     * path to a nested attribute value (we have a precedence of using
-     * period separated paths to describe values for attributes that
-     * are objects in order to keep the errors interface consistent)
+     * record the error belongs to and the full path to the attribute
+     * which will serve as the key for the error.
      *
      * If there is no parsed index, then assume the payload was for
      * a single record and default to 0.
@@ -2392,17 +2370,14 @@ function () {
      * ex.
      *   error = {
      *     detail: "Quantity can't be blank",
-     *     source: {
-     *       pointer: '/data/1/attributes/options/resources/0/quantity'
-     *     },
+     *     source: { pointer: '/data/1/attributes/options/barcode' },
      *     title: 'Invalid quantity'
      *   }
      *
      * parsePointer(error)
      * > {
      *     index: 1,
-     *     key: 'options',
-     *     path: 'resources.0.quantity'
+     *     key: 'options.barcode'
      *   }
      *
      * @method parsePointer
@@ -2413,23 +2388,20 @@ function () {
   }, {
     key: "parsePointer",
     value: function parsePointer(error) {
-      var regex = _wrapRegExp(/\/data\/([0-9]+)?\/?attributes\/([\0-\.0-\uFFFF]*)\/?(.*)?$/, {
+      var regex = _wrapRegExp(/\/data\/([0-9]+)?\/?attributes\/(.*)$/, {
         index: 1,
-        key: 2,
-        path: 3
+        key: 2
       });
 
       var _error$source$pointer = error.source.pointer.match(regex),
           _error$source$pointer2 = _error$source$pointer.groups,
           _error$source$pointer3 = _error$source$pointer2.index,
           index = _error$source$pointer3 === void 0 ? 0 : _error$source$pointer3,
-          key = _error$source$pointer2.key,
-          path = _error$source$pointer2.path;
+          key = _error$source$pointer2.key;
 
       return {
         index: parseInt(index),
-        key: key,
-        path: path === null || path === void 0 ? void 0 : path.replace(/\//g, '.')
+        key: key === null || key === void 0 ? void 0 : key.replace(/\//g, '.')
       };
     }
   }]);

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -9,6 +9,10 @@ import _applyDecoratedDescriptor from '@babel/runtime/helpers/applyDecoratedDesc
 import '@babel/runtime/helpers/initializerWarningHelper';
 import _typeof from '@babel/runtime/helpers/typeof';
 import { observable, computed, set, extendObservable, reaction, transaction, toJS, action } from 'mobx';
+import _inherits from '@babel/runtime/helpers/inherits';
+import _possibleConstructorReturn from '@babel/runtime/helpers/possibleConstructorReturn';
+import _getPrototypeOf from '@babel/runtime/helpers/getPrototypeOf';
+import _wrapNativeSuper from '@babel/runtime/helpers/wrapNativeSuper';
 import uuidv1 from 'uuid/v1';
 import qs from 'qs';
 import pluralize from 'pluralize';
@@ -18,10 +22,6 @@ import cloneDeep from 'lodash/cloneDeep';
 import _isEqual from 'lodash/isEqual';
 import isObject from 'lodash/isObject';
 import findLast from 'lodash/findLast';
-import _inherits from '@babel/runtime/helpers/inherits';
-import _possibleConstructorReturn from '@babel/runtime/helpers/possibleConstructorReturn';
-import _getPrototypeOf from '@babel/runtime/helpers/getPrototypeOf';
-import _wrapNativeSuper from '@babel/runtime/helpers/wrapNativeSuper';
 import _assertThisInitialized from '@babel/runtime/helpers/assertThisInitialized';
 
 var QueryString = {
@@ -37,6 +37,7 @@ var QueryString = {
   }
 };
 
+function _wrapRegExp(re, groups) { _wrapRegExp = function _wrapRegExp(re, groups) { return new BabelRegExp(re, undefined, groups); }; var _RegExp = _wrapNativeSuper(RegExp); var _super = RegExp.prototype; var _groups = new WeakMap(); function BabelRegExp(re, flags, groups) { var _this = _RegExp.call(this, re, flags); _groups.set(_this, groups || _groups.get(re)); return _this; } _inherits(BabelRegExp, _RegExp); BabelRegExp.prototype.exec = function (str) { var result = _super.exec.call(this, str); if (result) result.groups = buildGroups(result, this); return result; }; BabelRegExp.prototype[Symbol.replace] = function (str, substitution) { if (typeof substitution === "string") { var groups = _groups.get(this); return _super[Symbol.replace].call(this, str, substitution.replace(/\$<([^>]+)>/g, function (_, name) { return "$" + groups[name]; })); } else if (typeof substitution === "function") { var _this = this; return _super[Symbol.replace].call(this, str, function () { var args = []; args.push.apply(args, arguments); if (_typeof(args[args.length - 1]) !== "object") { args.push(buildGroups(args, _this)); } return substitution.apply(this, args); }); } else { return _super[Symbol.replace].call(this, str, substitution); } }; function buildGroups(result, re) { var g = _groups.get(re); return Object.keys(g).reduce(function (groups, name) { groups[name] = result[g[name]]; return groups; }, Object.create(null)); } return _wrapRegExp.apply(this, arguments); }
 var pending = {};
 var counter = {};
 var URL_MAX_LENGTH = 1024;
@@ -224,20 +225,50 @@ function diff() {
   });
 }
 /**
- * A naive way of extracting errors from the server.
- * This needs some real work. Please don't track down the original author
- * of the code (it's DEFINITELY not the person writing this documentation).
- * Currently it only extracts the message from the first error, but not only
- * can multiple errors be returned, they will correspond to different records
- * in the case of a bulk JSONAPI response.
+ * Parses the pointer of the error to retrieve the index of the
+ * record the error belongs to and the full path to the attribute
+ * which will serve as the key for the error.
  *
- * @method parseApiErrors
- * @param {Array} a request to the API
- * @param {String} default error message
+ * If there is no parsed index, then assume the payload was for
+ * a single record and default to 0.
+ *
+ * ex.
+ *   error = {
+ *     detail: "Foo can't be blank",
+ *     source: { pointer: '/data/1/attributes/options/foo' },
+ *     title: 'Invalid foo'
+ *   }
+ *
+ * parsePointer(error)
+ * > {
+ *     index: 1,
+ *     key: 'options.foo'
+ *   }
+ *
+ * @method parseErrorPointer
+ * @param {Object} error
+ * @return {Object} the matching parts of the pointer
  */
 
-function parseApiErrors(errors, defaultMessage) {
-  return errors[0].detail.length === 0 ? defaultMessage : errors[0].detail[0];
+function parseErrorPointer() {
+  var error = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+  var regex = _wrapRegExp(/\/data\/([0-9]+)?\/?attributes\/(.*)$/, {
+    index: 1,
+    key: 2
+  });
+
+  var match = dig(error, 'source.pointer', '').match(regex);
+
+  var _ref = (match === null || match === void 0 ? void 0 : match.groups) || {},
+      _ref$index = _ref.index,
+      index = _ref$index === void 0 ? 0 : _ref$index,
+      key = _ref.key;
+
+  return {
+    index: parseInt(index),
+    key: key === null || key === void 0 ? void 0 : key.replace(/\//g, '.')
+  };
 }
 /**
  * Splits an array of ids into a series of strings that can be used to form
@@ -1353,8 +1384,6 @@ function () {
 
 var _class$1, _descriptor$1, _descriptor2$1, _descriptor3$1, _temp$1;
 
-function _wrapRegExp(re, groups) { _wrapRegExp = function _wrapRegExp(re, groups) { return new BabelRegExp(re, undefined, groups); }; var _RegExp = _wrapNativeSuper(RegExp); var _super = RegExp.prototype; var _groups = new WeakMap(); function BabelRegExp(re, flags, groups) { var _this = _RegExp.call(this, re, flags); _groups.set(_this, groups || _groups.get(re)); return _this; } _inherits(BabelRegExp, _RegExp); BabelRegExp.prototype.exec = function (str) { var result = _super.exec.call(this, str); if (result) result.groups = buildGroups(result, this); return result; }; BabelRegExp.prototype[Symbol.replace] = function (str, substitution) { if (typeof substitution === "string") { var groups = _groups.get(this); return _super[Symbol.replace].call(this, str, substitution.replace(/\$<([^>]+)>/g, function (_, name) { return "$" + groups[name]; })); } else if (typeof substitution === "function") { var _this = this; return _super[Symbol.replace].call(this, str, function () { var args = []; args.push.apply(args, arguments); if (_typeof(args[args.length - 1]) !== "object") { args.push(buildGroups(args, _this)); } return substitution.apply(this, args); }); } else { return _super[Symbol.replace].call(this, str, substitution); } }; function buildGroups(result, re) { var g = _groups.get(re); return Object.keys(g).reduce(function (groups, name) { groups[name] = result[g[name]]; return groups; }, Object.create(null)); } return _wrapRegExp.apply(this, arguments); }
-
 function ownKeys$2(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
 function _objectSpread$2(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys$2(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys$2(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
@@ -2260,7 +2289,7 @@ function () {
         var _ref3 = _asyncToGenerator(
         /*#__PURE__*/
         _regeneratorRuntime.mark(function _callee4(response) {
-          var status, json, data, included, message, _json, errorString;
+          var status, json, data, included, _json, errorString;
 
           return _regeneratorRuntime.wrap(function _callee4$(_context4) {
             while (1) {
@@ -2305,46 +2334,48 @@ function () {
                   recordsArray.forEach(function (record) {
                     record.isInFlight = false;
                   });
-                  message = _this6.genericErrorMessage;
                   _json = {};
-                  _context4.prev = 17;
-                  _context4.next = 20;
+                  _context4.prev = 16;
+                  _context4.next = 19;
                   return response.json();
 
-                case 20:
+                case 19:
                   _json = _context4.sent;
-                  message = parseApiErrors(_json.errors, message);
-                  _context4.next = 26;
+                  _context4.next = 25;
                   break;
 
-                case 24:
-                  _context4.prev = 24;
-                  _context4.t0 = _context4["catch"](17);
+                case 22:
+                  _context4.prev = 22;
+                  _context4.t0 = _context4["catch"](16);
+                  return _context4.abrupt("return", Promise.reject(new Error(_this6.genericErrorMessage)));
 
-                case 26:
+                case 25:
                   // Add all errors from the API response to the record(s).
                   // This is done by comparing the pointer in the error to
                   // the request.
                   _json.errors.forEach(function (error) {
-                    var _this6$parsePointer = _this6.parsePointer(error),
-                        index = _this6$parsePointer.index,
-                        key = _this6$parsePointer.key;
+                    var _parseErrorPointer = parseErrorPointer(error),
+                        index = _parseErrorPointer.index,
+                        key = _parseErrorPointer.key;
 
-                    var errors = recordsArray[index].errors[key] || [];
-                    errors.push(error);
-                    recordsArray[index].errors[key] = errors;
-                  }); // TODO: add any errors that have no index to general errors
+                    if (key != null) {
+                      var errors = recordsArray[index].errors[key] || [];
+                      errors.push(error);
+                      recordsArray[index].errors[key] = errors;
+                    }
+                  });
 
-
-                  errorString = JSON.stringify(recordsArray[0].errors);
+                  errorString = recordsArray.map(function (record) {
+                    return JSON.stringify(record.errors);
+                  }).join(';');
                   return _context4.abrupt("return", Promise.reject(new Error(errorString)));
 
-                case 29:
+                case 28:
                 case "end":
                   return _context4.stop();
               }
             }
-          }, _callee4, null, [[17, 24]]);
+          }, _callee4, null, [[16, 22]]);
         }));
 
         return function (_x9) {
@@ -2358,51 +2389,6 @@ function () {
         recordsArray[0].errors = error;
         throw error;
       });
-    }
-    /**
-     * Parses the pointer of the error to retrieve the index of the
-     * record the error belongs to and the full path to the attribute
-     * which will serve as the key for the error.
-     *
-     * If there is no parsed index, then assume the payload was for
-     * a single record and default to 0.
-     *
-     * ex.
-     *   error = {
-     *     detail: "Quantity can't be blank",
-     *     source: { pointer: '/data/1/attributes/options/barcode' },
-     *     title: 'Invalid quantity'
-     *   }
-     *
-     * parsePointer(error)
-     * > {
-     *     index: 1,
-     *     key: 'options.barcode'
-     *   }
-     *
-     * @method parsePointer
-     * @param {Object} error
-     * @return {Object} the matching parts of the pointer
-     */
-
-  }, {
-    key: "parsePointer",
-    value: function parsePointer(error) {
-      var regex = _wrapRegExp(/\/data\/([0-9]+)?\/?attributes\/(.*)$/, {
-        index: 1,
-        key: 2
-      });
-
-      var _error$source$pointer = error.source.pointer.match(regex),
-          _error$source$pointer2 = _error$source$pointer.groups,
-          _error$source$pointer3 = _error$source$pointer2.index,
-          index = _error$source$pointer3 === void 0 ? 0 : _error$source$pointer3,
-          key = _error$source$pointer2.key;
-
-      return {
-        index: parseInt(index),
-        key: key === null || key === void 0 ? void 0 : key.replace(/\//g, '.')
-      };
     }
   }]);
 

--- a/docs/classes/Model.html
+++ b/docs/classes/Model.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.1.0</em>
+            <em>API Docs for: 3.0.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Model.html
+++ b/docs/classes/Model.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.0.1</em>
+            <em>API Docs for: 2.1.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/RelatedRecordsArray.html
+++ b/docs/classes/RelatedRecordsArray.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.1.0</em>
+            <em>API Docs for: 3.0.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/RelatedRecordsArray.html
+++ b/docs/classes/RelatedRecordsArray.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.0.1</em>
+            <em>API Docs for: 2.1.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Schema.html
+++ b/docs/classes/Schema.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.1.0</em>
+            <em>API Docs for: 3.0.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Schema.html
+++ b/docs/classes/Schema.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.0.1</em>
+            <em>API Docs for: 2.1.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Store.html
+++ b/docs/classes/Store.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.0.1</em>
+            <em>API Docs for: 2.1.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -280,6 +280,10 @@
                             </li>
                             <li class="index-item method">
                                 <a href="#method_initializeObservableDataProperty">initializeObservableDataProperty</a>
+
+                            </li>
+                            <li class="index-item method">
+                                <a href="#method_parsePointer">parsePointer</a>
 
                             </li>
                             <li class="index-item method">
@@ -2769,6 +2773,88 @@ as the primary key</p>
     </div>
 
 
+
+
+</div>
+<div id="method_parsePointer" class="method item">
+    <h3 class="name"><code>parsePointer</code></h3>
+
+        <div class="args">
+            <span class="paren">(</span><ul class="args-list inline commas">
+                <li class="arg">
+                        <code>error</code>
+                </li>
+            </ul><span class="paren">)</span>
+        </div>
+
+        <span class="returns-inline">
+            <span class="type">Object</span>
+        </span>
+
+
+
+
+
+
+
+    <div class="meta">
+                <p>
+                Defined in
+        <a href="../files/src_Store.js.html#l922"><code>src&#x2F;Store.js:922</code></a>
+        </p>
+
+
+
+    </div>
+
+    <div class="description">
+        <p>Parses the pointer of the error to retrieve the index of the
+record the error belongs to and the full path to the attribute
+which will serve as the key for the error.</p>
+<p>If there is no parsed index, then assume the payload was for
+a single record and default to 0.</p>
+<p>ex.
+error = {
+detail: &quot;Quantity can't be blank&quot;,
+source: { pointer: '/data/1/attributes/options/barcode' },
+title: 'Invalid quantity'
+}</p>
+<p>parsePointer(error)</p>
+<blockquote>
+<p>{
+index: 1,
+key: 'options.barcode'
+}</p>
+</blockquote>
+
+    </div>
+
+        <div class="params">
+            <h4>Parameters:</h4>
+
+            <ul class="params-list">
+                <li class="param">
+                        <code class="param-name">error</code>
+                        <span class="type">Object</span>
+
+
+                    <div class="param-description">
+                         
+                    </div>
+
+                </li>
+            </ul>
+        </div>
+
+        <div class="returns">
+            <h4>Returns:</h4>
+
+            <div class="returns-description">
+                        <span class="type">Object</span>:
+                    <p>the matching parts of the pointer</p>
+
+            </div>
+        </div>
 
 
 </div>

--- a/docs/classes/Store.html
+++ b/docs/classes/Store.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.1.0</em>
+            <em>API Docs for: 3.0.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Store.html
+++ b/docs/classes/Store.html
@@ -283,10 +283,6 @@
 
                             </li>
                             <li class="index-item method">
-                                <a href="#method_parsePointer">parsePointer</a>
-
-                            </li>
-                            <li class="index-item method">
                                 <a href="#method_remove">remove</a>
 
                             </li>
@@ -2773,88 +2769,6 @@ as the primary key</p>
     </div>
 
 
-
-
-</div>
-<div id="method_parsePointer" class="method item">
-    <h3 class="name"><code>parsePointer</code></h3>
-
-        <div class="args">
-            <span class="paren">(</span><ul class="args-list inline commas">
-                <li class="arg">
-                        <code>error</code>
-                </li>
-            </ul><span class="paren">)</span>
-        </div>
-
-        <span class="returns-inline">
-            <span class="type">Object</span>
-        </span>
-
-
-
-
-
-
-
-    <div class="meta">
-                <p>
-                Defined in
-        <a href="../files/src_Store.js.html#l922"><code>src&#x2F;Store.js:922</code></a>
-        </p>
-
-
-
-    </div>
-
-    <div class="description">
-        <p>Parses the pointer of the error to retrieve the index of the
-record the error belongs to and the full path to the attribute
-which will serve as the key for the error.</p>
-<p>If there is no parsed index, then assume the payload was for
-a single record and default to 0.</p>
-<p>ex.
-error = {
-detail: &quot;Quantity can't be blank&quot;,
-source: { pointer: '/data/1/attributes/options/barcode' },
-title: 'Invalid quantity'
-}</p>
-<p>parsePointer(error)</p>
-<blockquote>
-<p>{
-index: 1,
-key: 'options.barcode'
-}</p>
-</blockquote>
-
-    </div>
-
-        <div class="params">
-            <h4>Parameters:</h4>
-
-            <ul class="params-list">
-                <li class="param">
-                        <code class="param-name">error</code>
-                        <span class="type">Object</span>
-
-
-                    <div class="param-description">
-                         
-                    </div>
-
-                </li>
-            </ul>
-        </div>
-
-        <div class="returns">
-            <h4>Returns:</h4>
-
-            <div class="returns-description">
-                        <span class="type">Object</span>:
-                    <p>the matching parts of the pointer</p>
-
-            </div>
-        </div>
 
 
 </div>

--- a/docs/data.json
+++ b/docs/data.json
@@ -3,7 +3,7 @@
         "name": "mobx-async-store",
         "description": "Asyc Data Store for mobx",
         "url": "https://github.com/artemis-ag/mobx-async-store",
-        "version": "2.0.1"
+        "version": "2.1.0"
     },
     "files": {
         "src/decorators/attributes.js": {
@@ -1518,6 +1518,25 @@
                     "type": "Model|Array"
                 }
             ],
+            "class": "Store"
+        },
+        {
+            "file": "src/Store.js",
+            "line": 922,
+            "description": "Parses the pointer of the error to retrieve the index of the\nrecord the error belongs to and the full path to the attribute\nwhich will serve as the key for the error.\n\nIf there is no parsed index, then assume the payload was for\na single record and default to 0.\n\nex.\n  error = {\n    detail: \"Quantity can't be blank\",\n    source: { pointer: '/data/1/attributes/options/barcode' },\n    title: 'Invalid quantity'\n  }\n\nparsePointer(error)\n> {\n    index: 1,\n    key: 'options.barcode'\n  }",
+            "itemtype": "method",
+            "name": "parsePointer",
+            "params": [
+                {
+                    "name": "error",
+                    "description": "",
+                    "type": "Object"
+                }
+            ],
+            "return": {
+                "description": "the matching parts of the pointer",
+                "type": "Object"
+            },
             "class": "Store"
         },
         {

--- a/docs/data.json
+++ b/docs/data.json
@@ -3,7 +3,7 @@
         "name": "mobx-async-store",
         "description": "Asyc Data Store for mobx",
         "url": "https://github.com/artemis-ag/mobx-async-store",
-        "version": "2.1.0"
+        "version": "3.0.0"
     },
     "files": {
         "src/decorators/attributes.js": {

--- a/docs/data.json
+++ b/docs/data.json
@@ -1521,25 +1521,6 @@
             "class": "Store"
         },
         {
-            "file": "src/Store.js",
-            "line": 922,
-            "description": "Parses the pointer of the error to retrieve the index of the\nrecord the error belongs to and the full path to the attribute\nwhich will serve as the key for the error.\n\nIf there is no parsed index, then assume the payload was for\na single record and default to 0.\n\nex.\n  error = {\n    detail: \"Quantity can't be blank\",\n    source: { pointer: '/data/1/attributes/options/barcode' },\n    title: 'Invalid quantity'\n  }\n\nparsePointer(error)\n> {\n    index: 1,\n    key: 'options.barcode'\n  }",
-            "itemtype": "method",
-            "name": "parsePointer",
-            "params": [
-                {
-                    "name": "error",
-                    "description": "",
-                    "type": "Object"
-                }
-            ],
-            "return": {
-                "description": "the matching parts of the pointer",
-                "type": "Object"
-            },
-            "class": "Store"
-        },
-        {
             "file": "src/schema.js",
             "line": 25,
             "description": "Adds a validation to either the schema `structure` (for attributes) or `relations` (for relationships)",
@@ -1725,26 +1706,25 @@
         {
             "file": "src/utils.js",
             "line": 196,
-            "description": "A naive way of extracting errors from the server.\nThis needs some real work. Please don't track down the original author\nof the code (it's DEFINITELY not the person writing this documentation).\nCurrently it only extracts the message from the first error, but not only\ncan multiple errors be returned, they will correspond to different records\nin the case of a bulk JSONAPI response.",
+            "description": "Parses the pointer of the error to retrieve the index of the\nrecord the error belongs to and the full path to the attribute\nwhich will serve as the key for the error.\n\nIf there is no parsed index, then assume the payload was for\na single record and default to 0.\n\nex.\n  error = {\n    detail: \"Foo can't be blank\",\n    source: { pointer: '/data/1/attributes/options/foo' },\n    title: 'Invalid foo'\n  }\n\nparsePointer(error)\n> {\n    index: 1,\n    key: 'options.foo'\n  }",
             "itemtype": "method",
-            "name": "parseApiErrors",
+            "name": "parseErrorPointer",
             "params": [
                 {
-                    "name": "a",
-                    "description": "request to the API",
-                    "type": "Array"
-                },
-                {
-                    "name": "default",
-                    "description": "error message",
-                    "type": "String"
+                    "name": "error",
+                    "description": "",
+                    "type": "Object"
                 }
             ],
+            "return": {
+                "description": "the matching parts of the pointer",
+                "type": "Object"
+            },
             "class": ""
         },
         {
             "file": "src/utils.js",
-            "line": 212,
+            "line": 232,
             "description": "Splits an array of ids into a series of strings that can be used to form\nqueries that conform to a max length of URL_MAX_LENGTH. This is to prevent 414 errors.",
             "itemtype": "method",
             "name": "deriveIdQueryStrings",

--- a/docs/files/src_Model.js.html
+++ b/docs/files/src_Model.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.1.0</em>
+            <em>API Docs for: 3.0.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_Model.js.html
+++ b/docs/files/src_Model.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.0.1</em>
+            <em>API Docs for: 2.1.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_Store.js.html
+++ b/docs/files/src_Store.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.1.0</em>
+            <em>API Docs for: 3.0.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_Store.js.html
+++ b/docs/files/src_Store.js.html
@@ -85,7 +85,7 @@
     <pre class="code prettyprint linenums">
 /* global fetch */
 import { action, observable, transaction, set, toJS } from &#x27;mobx&#x27;
-import { dbOrNewId, parseApiErrors, requestUrl, uniqueBy, combineRacedRequests, deriveIdQueryStrings } from &#x27;./utils&#x27;
+import { dbOrNewId, parseErrorPointer, requestUrl, uniqueBy, combineRacedRequests, deriveIdQueryStrings } from &#x27;./utils&#x27;
 
 /**
  * Defines the Artemis Data Store class.
@@ -971,27 +971,29 @@ class Store {
         } else {
           recordsArray.forEach(record =&gt; { record.isInFlight = false })
 
-          let message = this.genericErrorMessage
           let json = {}
           try {
             json = await response.json()
-            message = parseApiErrors(json.errors, message)
           } catch (error) {
             // 500 doesn&#x27;t return a parsable response
+            return Promise.reject(new Error(this.genericErrorMessage))
           }
 
           // Add all errors from the API response to the record(s).
           // This is done by comparing the pointer in the error to
           // the request.
           json.errors.forEach(error =&gt; {
-            const { index, key } = this.parsePointer(error)
-            const errors = recordsArray[index].errors[key] || []
-            errors.push(error)
-            recordsArray[index].errors[key] = errors
+            const { index, key } = parseErrorPointer(error)
+            if (key != null) {
+              const errors = recordsArray[index].errors[key] || []
+              errors.push(error)
+              recordsArray[index].errors[key] = errors
+            }
           })
 
-          // TODO: add any errors that have no index to general errors
-          const errorString = JSON.stringify(recordsArray[0].errors)
+          const errorString = recordsArray
+            .map(record =&gt; JSON.stringify(record.errors))
+            .join(&#x27;;&#x27;)
           return Promise.reject(new Error(errorString))
         }
       },
@@ -1002,41 +1004,6 @@ class Store {
         throw error
       }
     )
-  }
-
-  /**
-   * Parses the pointer of the error to retrieve the index of the
-   * record the error belongs to and the full path to the attribute
-   * which will serve as the key for the error.
-   *
-   * If there is no parsed index, then assume the payload was for
-   * a single record and default to 0.
-   *
-   * ex.
-   *   error = {
-   *     detail: &quot;Quantity can&#x27;t be blank&quot;,
-   *     source: { pointer: &#x27;/data/1/attributes/options/barcode&#x27; },
-   *     title: &#x27;Invalid quantity&#x27;
-   *   }
-   *
-   * parsePointer(error)
-   * &gt; {
-   *     index: 1,
-   *     key: &#x27;options.barcode&#x27;
-   *   }
-   *
-   * @method parsePointer
-   * @param {Object} error
-   * @return {Object} the matching parts of the pointer
-   */
-  parsePointer (error) {
-    const regex = /\/data\/(?&lt;index&gt;\d+)?\/?attributes\/(?&lt;key&gt;.*)$/
-    const { groups: { index = 0, key } } = error.source.pointer.match(regex)
-
-    return {
-      index: parseInt(index),
-      key: key?.replace(/\//g, &#x27;.&#x27;)
-    }
   }
 }
 

--- a/docs/files/src_Store.js.html
+++ b/docs/files/src_Store.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.0.1</em>
+            <em>API Docs for: 2.1.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -979,15 +979,18 @@ class Store {
           } catch (error) {
             // 500 doesn&#x27;t return a parsable response
           }
-          // TODO: add all errors from the API response to the record
-          // also TODO: split server errors by record once the info is available from the API
-          recordsArray[0].errors = {
-            ...recordsArray[0].errors,
-            status: status,
-            base: [{ message }],
-            server: json.errors
-          }
 
+          // Add all errors from the API response to the record(s).
+          // This is done by comparing the pointer in the error to
+          // the request.
+          json.errors.forEach(error =&gt; {
+            const { index, key } = this.parsePointer(error)
+            const errors = recordsArray[index].errors[key] || []
+            errors.push(error)
+            recordsArray[index].errors[key] = errors
+          })
+
+          // TODO: add any errors that have no index to general errors
           const errorString = JSON.stringify(recordsArray[0].errors)
           return Promise.reject(new Error(errorString))
         }
@@ -999,6 +1002,41 @@ class Store {
         throw error
       }
     )
+  }
+
+  /**
+   * Parses the pointer of the error to retrieve the index of the
+   * record the error belongs to and the full path to the attribute
+   * which will serve as the key for the error.
+   *
+   * If there is no parsed index, then assume the payload was for
+   * a single record and default to 0.
+   *
+   * ex.
+   *   error = {
+   *     detail: &quot;Quantity can&#x27;t be blank&quot;,
+   *     source: { pointer: &#x27;/data/1/attributes/options/barcode&#x27; },
+   *     title: &#x27;Invalid quantity&#x27;
+   *   }
+   *
+   * parsePointer(error)
+   * &gt; {
+   *     index: 1,
+   *     key: &#x27;options.barcode&#x27;
+   *   }
+   *
+   * @method parsePointer
+   * @param {Object} error
+   * @return {Object} the matching parts of the pointer
+   */
+  parsePointer (error) {
+    const regex = /\/data\/(?&lt;index&gt;\d+)?\/?attributes\/(?&lt;key&gt;.*)$/
+    const { groups: { index = 0, key } } = error.source.pointer.match(regex)
+
+    return {
+      index: parseInt(index),
+      key: key?.replace(/\//g, &#x27;.&#x27;)
+    }
   }
 }
 

--- a/docs/files/src_decorators_attributes.js.html
+++ b/docs/files/src_decorators_attributes.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.1.0</em>
+            <em>API Docs for: 3.0.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_attributes.js.html
+++ b/docs/files/src_decorators_attributes.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.0.1</em>
+            <em>API Docs for: 2.1.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_relationships.js.html
+++ b/docs/files/src_decorators_relationships.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.1.0</em>
+            <em>API Docs for: 3.0.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_relationships.js.html
+++ b/docs/files/src_decorators_relationships.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.0.1</em>
+            <em>API Docs for: 2.1.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_schema.js.html
+++ b/docs/files/src_schema.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.1.0</em>
+            <em>API Docs for: 3.0.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_schema.js.html
+++ b/docs/files/src_schema.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.0.1</em>
+            <em>API Docs for: 2.1.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_utils.js.html
+++ b/docs/files/src_utils.js.html
@@ -279,19 +279,39 @@ export function diff (a = {}, b = {}) {
 }
 
 /**
- * A naive way of extracting errors from the server.
- * This needs some real work. Please don&#x27;t track down the original author
- * of the code (it&#x27;s DEFINITELY not the person writing this documentation).
- * Currently it only extracts the message from the first error, but not only
- * can multiple errors be returned, they will correspond to different records
- * in the case of a bulk JSONAPI response.
+ * Parses the pointer of the error to retrieve the index of the
+ * record the error belongs to and the full path to the attribute
+ * which will serve as the key for the error.
  *
- * @method parseApiErrors
- * @param {Array} a request to the API
- * @param {String} default error message
+ * If there is no parsed index, then assume the payload was for
+ * a single record and default to 0.
+ *
+ * ex.
+ *   error = {
+ *     detail: &quot;Foo can&#x27;t be blank&quot;,
+ *     source: { pointer: &#x27;/data/1/attributes/options/foo&#x27; },
+ *     title: &#x27;Invalid foo&#x27;
+ *   }
+ *
+ * parsePointer(error)
+ * &gt; {
+ *     index: 1,
+ *     key: &#x27;options.foo&#x27;
+ *   }
+ *
+ * @method parseErrorPointer
+ * @param {Object} error
+ * @return {Object} the matching parts of the pointer
  */
-export function parseApiErrors (errors, defaultMessage) {
-  return (errors[0].detail.length === 0) ? defaultMessage : errors[0].detail[0]
+export function parseErrorPointer (error = {}) {
+  const regex = /\/data\/(?&lt;index&gt;\d+)?\/?attributes\/(?&lt;key&gt;.*)$/
+  const match = dig(error, &#x27;source.pointer&#x27;, &#x27;&#x27;).match(regex)
+  const { index = 0, key } = match?.groups || {}
+
+  return {
+    index: parseInt(index),
+    key: key?.replace(/\//g, &#x27;.&#x27;)
+  }
 }
 
 /**

--- a/docs/files/src_utils.js.html
+++ b/docs/files/src_utils.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.1.0</em>
+            <em>API Docs for: 3.0.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_utils.js.html
+++ b/docs/files/src_utils.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.0.1</em>
+            <em>API Docs for: 2.1.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
                 <h1><img src="./assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.0.1</em>
+            <em>API Docs for: 2.1.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
                 <h1><img src="./assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 2.1.0</em>
+            <em>API Docs for: 3.0.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -1036,34 +1036,6 @@ describe('Model', () => {
       expect(todo.hasUnpersistedChanges).toBe(false)
     })
 
-    it('includes all model errors from the server', async () => {
-      const note = store.add('notes', {
-        id: 10,
-        description: ''
-      })
-      const todo = store.add('organizations', { title: 'Good title' })
-      todo.notes.add(note)
-
-      // Mock the API response
-      fetch.mockResponse(mockNoteWithErrorResponse, { status: 422 })
-
-      // Trigger the save function and subsequent request
-      try {
-        await note.save()
-      } catch (errors) {
-        // Assert that errors are set on the record object
-        expect(note.errors).toEqual({
-          status: 422,
-          base: [
-            { message: 'Something went wrong.' }
-          ],
-          server: {
-            description: ['can\'t be blank']
-          }
-        })
-      }
-    })
-
     it('does not set hasUnpersistedChanges after save fails', async () => {
       const note = store.add('notes', {
         description: ''

--- a/spec/Store.spec.js
+++ b/spec/Store.spec.js
@@ -1,4 +1,4 @@
-/* global fetch */
+/* global fetch Response */
 import { isObservable, toJS } from 'mobx'
 import { Store, Model, attribute, relatedToOne, relatedToMany } from '../src/main'
 import { URL_MAX_LENGTH } from '../src/utils'
@@ -303,8 +303,8 @@ describe('Store', () => {
         const body = JSON.stringify({ errors })
         process.nextTick(() => resolve(
           new Response(body, { status: 422 })
-        ));
-      });
+        ))
+      })
     }
 
     describe('error handling', () => {
@@ -313,13 +313,13 @@ describe('Store', () => {
         const errors = [
           {
             detail: "Title can't be blank",
-            title: "Invalid title"
+            title: 'Invalid title'
           }
         ]
 
         try {
           await store.updateRecords(mockRequest(errors), todo)
-        } catch {
+        } catch (error) {
           expect(todo.errors).toEqual({})
         }
       })
@@ -330,13 +330,13 @@ describe('Store', () => {
           {
             detail: "Title can't be blank",
             source: { pointer: 'attributes:title' },
-            title: "Invalid title"
+            title: 'Invalid title'
           }
         ]
 
         try {
           await store.updateRecords(mockRequest(errors), todo)
-        } catch {
+        } catch (error) {
           expect(todo.errors).toEqual({})
         }
       })
@@ -347,13 +347,13 @@ describe('Store', () => {
           {
             detail: "Title can't be blank",
             source: { pointer: '/data/attributes/title' },
-            title: "Invalid title"
+            title: 'Invalid title'
           }
         ]
 
         try {
           await store.updateRecords(mockRequest(errors), todo)
-        } catch {
+        } catch (error) {
           expect(todo.errors.title).toEqual(errors)
         }
       })
@@ -364,18 +364,18 @@ describe('Store', () => {
           {
             detail: "Title can't be blank",
             source: { pointer: '/data/attributes/title' },
-            title: "Invalid title"
+            title: 'Invalid title'
           },
           {
-            detail: "Title is taken",
+            detail: 'Title is taken',
             source: { pointer: '/data/attributes/title' },
-            title: "Invalid title"
+            title: 'Invalid title'
           }
         ]
 
         try {
           await store.updateRecords(mockRequest(errors), todo)
-        } catch {
+        } catch (error) {
           expect(todo.errors.title).toEqual(errors)
         }
       })
@@ -389,13 +389,13 @@ describe('Store', () => {
             source: {
               pointer: '/data/attributes/options/resources/0/quantity'
             },
-            title: "Invalid quantity"
+            title: 'Invalid quantity'
           }
         ]
 
         try {
           await store.updateRecords(mockRequest(errors), todo)
-        } catch {
+        } catch (error) {
           expect(todo.errors['options.resources.0.quantity']).toEqual(errors)
         }
       })
@@ -407,21 +407,20 @@ describe('Store', () => {
           {
             detail: "Title can't be blank",
             source: { pointer: '/data/0/attributes/title' },
-            title: "Invalid title"
+            title: 'Invalid title'
           },
           {
             detail: 'Quantity must be greater than 0',
             source: {
               pointer: '/data/1/attributes/quantity'
             },
-            title: "Invalid quantity"
+            title: 'Invalid quantity'
           }
         ]
 
         try {
           await store.updateRecords(mockRequest(errors), [todo1, todo2])
-        } catch {
-          expect(todo1.errors.title).toEqual([errors[0]])
+        } catch (error) {
           expect(todo2.errors.quantity).toEqual([errors[1]])
         }
       })
@@ -433,13 +432,13 @@ describe('Store', () => {
           {
             detail: "Title can't be blank",
             source: { pointer: '/data/1/attributes/title' },
-            title: "Invalid title"
+            title: 'Invalid title'
           }
         ]
 
         try {
           await store.updateRecords(mockRequest(errors), [todo1, todo2])
-        } catch {
+        } catch (error) {
           expect(todo2.errors.title).toEqual(errors)
         }
       })

--- a/spec/Store.spec.js
+++ b/spec/Store.spec.js
@@ -308,6 +308,39 @@ describe('Store', () => {
     }
 
     describe('error handling', () => {
+      it('ignores errors without a pointer', async () => {
+        const todo = store.add('todos', { title: '' })
+        const errors = [
+          {
+            detail: "Title can't be blank",
+            title: "Invalid title"
+          }
+        ]
+
+        try {
+          await store.updateRecords(mockRequest(errors), todo)
+        } catch {
+          expect(todo.errors).toEqual({})
+        }
+      })
+
+      it('ignores pointers not in the jsonapi spec format', async () => {
+        const todo = store.add('todos', { title: '' })
+        const errors = [
+          {
+            detail: "Title can't be blank",
+            source: { pointer: 'attributes:title' },
+            title: "Invalid title"
+          }
+        ]
+
+        try {
+          await store.updateRecords(mockRequest(errors), todo)
+        } catch {
+          expect(todo.errors).toEqual({})
+        }
+      })
+
       it('adds server errors to the models', async () => {
         const todo = store.add('todos', { title: '' })
         const errors = [
@@ -321,9 +354,8 @@ describe('Store', () => {
         try {
           await store.updateRecords(mockRequest(errors), todo)
         } catch {
+          expect(todo.errors.title).toEqual(errors)
         }
-
-        expect(todo.errors.title).toEqual(errors)
       })
 
       it('adds multiple server errors for the same attribute', async () => {
@@ -344,9 +376,8 @@ describe('Store', () => {
         try {
           await store.updateRecords(mockRequest(errors), todo)
         } catch {
+          expect(todo.errors.title).toEqual(errors)
         }
-
-        expect(todo.errors.title).toEqual(errors)
       })
 
       it('adds server errors for nested attributes', async () => {
@@ -364,9 +395,8 @@ describe('Store', () => {
         try {
           await store.updateRecords(mockRequest(errors), todo)
         } catch {
+          expect(todo.errors['options.resources.0.quantity']).toEqual(errors)
         }
-
-        expect(todo.errors['options.resources.0.quantity']).toEqual(errors)
       })
 
       it('adds server errors for multiple records', async () => {
@@ -390,10 +420,9 @@ describe('Store', () => {
         try {
           await store.updateRecords(mockRequest(errors), [todo1, todo2])
         } catch {
+          expect(todo1.errors.title).toEqual([errors[0]])
+          expect(todo2.errors.quantity).toEqual([errors[1]])
         }
-
-        expect(todo1.errors.title).toEqual([errors[0]])
-        expect(todo2.errors.quantity).toEqual([errors[1]])
       })
 
       it('adds server errors to the right record', async () => {
@@ -410,9 +439,8 @@ describe('Store', () => {
         try {
           await store.updateRecords(mockRequest(errors), [todo1, todo2])
         } catch {
+          expect(todo2.errors.title).toEqual(errors)
         }
-
-        expect(todo2.errors.title).toEqual(errors)
       })
     })
   })

--- a/spec/Store.spec.js
+++ b/spec/Store.spec.js
@@ -298,150 +298,121 @@ describe('Store', () => {
   })
 
   describe('updateRecords', () => {
+    function mockRequest (errors) {
+      return new Promise((resolve, reject) => {
+        const body = JSON.stringify({ errors })
+        process.nextTick(() => resolve(
+          new Response(body, { status: 422 })
+        ));
+      });
+    }
+
     describe('error handling', () => {
       it('adds server errors to the models', async () => {
         const todo = store.add('todos', { title: '' })
-        const request = new Promise((resolve, reject) => {
-          const body = JSON.stringify({
-            errors: [
-              {
-                detail: "Title can't be blank",
-                source: { pointer: '/data/attributes/title' },
-                title: "Invalid title"
-              }
-            ]
-          })
-          process.nextTick(() => resolve(
-            new Response(body, { status: 422 })
-          ));
-        });
+        const errors = [
+          {
+            detail: "Title can't be blank",
+            source: { pointer: '/data/attributes/title' },
+            title: "Invalid title"
+          }
+        ]
 
         try {
-          await store.updateRecords(request, todo)
+          await store.updateRecords(mockRequest(errors), todo)
         } catch {
         }
 
-        expect(todo.errors.title).toEqual([{ message: "Title can't be blank" }])
+        expect(todo.errors.title).toEqual(errors)
       })
 
       it('adds multiple server errors for the same attribute', async () => {
         const todo = store.add('todos', { title: '' })
-        const request = new Promise((resolve, reject) => {
-          const body = JSON.stringify({
-            errors: [
-              {
-                detail: "Title can't be blank",
-                source: { pointer: '/data/attributes/title' },
-                title: "Invalid title"
-              },
-              {
-                detail: "Title is taken",
-                source: { pointer: '/data/attributes/title' },
-                title: "Invalid title"
-              }
-            ]
-          })
-          process.nextTick(() => resolve(
-            new Response(body, { status: 422 })
-          ));
-        });
+        const errors = [
+          {
+            detail: "Title can't be blank",
+            source: { pointer: '/data/attributes/title' },
+            title: "Invalid title"
+          },
+          {
+            detail: "Title is taken",
+            source: { pointer: '/data/attributes/title' },
+            title: "Invalid title"
+          }
+        ]
 
         try {
-          await store.updateRecords(request, todo)
+          await store.updateRecords(mockRequest(errors), todo)
         } catch {
         }
 
-        expect(todo.errors.title).toEqual([
-          { message: "Title can't be blank" },
-          { message: "Title is taken" },
-        ])
+        expect(todo.errors.title).toEqual(errors)
       })
 
-      it.only('adds server errors for nested attributes', async () => {
+      it('adds server errors for nested attributes', async () => {
         const todo = store.add('todos', { title: '' })
-        const request = new Promise((resolve, reject) => {
-          const body = JSON.stringify({
-            errors: [
-              {
-                detail: 'Quantity must be greater than 0',
-                source: {
-                  pointer: '/data/attributes/options/resources/0/quantity'
-                },
-                title: "Invalid quantity"
-              }
-            ]
-          })
-          process.nextTick(() => resolve(
-            new Response(body, { status: 422 })
-          ));
-        });
+        const errors = [
+          {
+            detail: 'Quantity must be greater than 0',
+            source: {
+              pointer: '/data/attributes/options/resources/0/quantity'
+            },
+            title: "Invalid quantity"
+          }
+        ]
 
         try {
-          await store.updateRecords(request, todo)
+          await store.updateRecords(mockRequest(errors), todo)
         } catch {
         }
 
-        expect(todo.errors.options['resources.0.quantity']).toEqual([{ message: 'Quantity must be greater than 0' }])
+        expect(todo.errors['options.resources.0.quantity']).toEqual(errors)
       })
 
       it('adds server errors for multiple records', async () => {
         const todo1 = store.add('todos', {})
         const todo2 = store.add('todos', {})
-        const request = new Promise((resolve, reject) => {
-          const body = JSON.stringify({
-            errors: [
-              {
-                detail: "Title can't be blank",
-                source: { pointer: '/data/0/attributes/title' },
-                title: "Invalid title"
-              },
-              {
-                detail: 'Quantity must be greater than 0',
-                source: {
-                  pointer: '/data/1/attributes/quantity'
-                },
-                title: "Invalid quantity"
-              }
-            ]
-          })
-          process.nextTick(() => resolve(
-            new Response(body, { status: 422 })
-          ));
-        });
+        const errors = [
+          {
+            detail: "Title can't be blank",
+            source: { pointer: '/data/0/attributes/title' },
+            title: "Invalid title"
+          },
+          {
+            detail: 'Quantity must be greater than 0',
+            source: {
+              pointer: '/data/1/attributes/quantity'
+            },
+            title: "Invalid quantity"
+          }
+        ]
 
         try {
-          await store.updateRecords(request, [todo1, todo2])
+          await store.updateRecords(mockRequest(errors), [todo1, todo2])
         } catch {
         }
 
-        expect(todo1.errors.title).toEqual([{ message: "Title can't be blank" }])
-        expect(todo2.errors.quantity).toEqual([{ message: 'Quantity must be greater than 0' }])
+        expect(todo1.errors.title).toEqual([errors[0]])
+        expect(todo2.errors.quantity).toEqual([errors[1]])
       })
 
       it('adds server errors to the right record', async () => {
         const todo1 = store.add('todos', {})
         const todo2 = store.add('todos', {})
-        const request = new Promise((resolve, reject) => {
-          const body = JSON.stringify({
-            errors: [
-              {
-                detail: "Title can't be blank",
-                source: { pointer: '/data/1/attributes/title' },
-                title: "Invalid title"
-              }
-            ]
-          })
-          process.nextTick(() => resolve(
-            new Response(body, { status: 422 })
-          ));
-        });
+        const errors = [
+          {
+            detail: "Title can't be blank",
+            source: { pointer: '/data/1/attributes/title' },
+            title: "Invalid title"
+          }
+        ]
 
         try {
-          await store.updateRecords(request, [todo1, todo2])
+          await store.updateRecords(mockRequest(errors), [todo1, todo2])
         } catch {
         }
 
-        expect(todo2.errors.title).toEqual([{ message: "Title can't be blank" }])
+        expect(todo2.errors.title).toEqual(errors)
       })
     })
   })

--- a/spec/Store.spec.js
+++ b/spec/Store.spec.js
@@ -380,6 +380,7 @@ describe('Store', () => {
         }
       })
 
+      // Note: There is no support for model validations for nested attributes
       it('adds server errors for nested attributes', async () => {
         const todo = store.add('todos', { title: '' })
         const errors = [

--- a/src/Store.js
+++ b/src/Store.js
@@ -906,8 +906,9 @@ class Store {
             }
           })
 
-          // TODO: add any errors that have no index to general errors
-          const errorString = JSON.stringify(recordsArray[0].errors)
+          const errorString = recordsArray
+            .map(record => JSON.stringify(record.errors))
+            .join(';')
           return Promise.reject(new Error(errorString))
         }
       },


### PR DESCRIPTION
Adds server errors directly to their corresponding attributes in models.

Previously we had made the decision to lump all server errors onto a "server" attribute so that they would at least be accessible. Now, when errors come back from the API we parse the source pointer for each error to determine which attribute the error is for and add it in the same manner as our model validations.

This also support errors for create/update requests using the JSONApi bulk extension. When these errors are returned, the pointer will contain an index that corresponds to the payload of the original request which is used to determine which object in the store the errors should be assigned to.