### PR TITLE
fix reference by _id

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -259,7 +259,7 @@ function diff() {
 function parseErrorPointer() {
   var error = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
-  var regex = _wrapRegExp(/\/data\/([0-9]+)?\/?attributes\/(.*)$/, {
+  var regex = /*#__PURE__*/_wrapRegExp(/\/data\/([0-9]+)?\/?attributes\/(.*)$/, {
     index: 1,
     key: 2
   });
@@ -338,9 +338,7 @@ function ObjectPromiseProxy(promise, target) {
  *
  * @class Schema
  */
-var Schema =
-/*#__PURE__*/
-function () {
+var Schema = /*#__PURE__*/function () {
   function Schema() {
     _classCallCheck(this, Schema);
 
@@ -468,9 +466,7 @@ function stringifyIds(object) {
  */
 
 
-var Model = (_class = (_temp =
-/*#__PURE__*/
-function () {
+var Model = (_class = (_temp = /*#__PURE__*/function () {
   /**
    * Initializer for model
    *
@@ -676,12 +672,8 @@ function () {
       var _this = this;
 
       _this.errors = {};
-      return promise.then(
-      /*#__PURE__*/
-      function () {
-        var _ref = _asyncToGenerator(
-        /*#__PURE__*/
-        _regeneratorRuntime.mark(function _callee(response) {
+      return promise.then( /*#__PURE__*/function () {
+        var _ref = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee(response) {
           var json;
           return _regeneratorRuntime.wrap(function _callee$(_context) {
             while (1) {
@@ -767,7 +759,7 @@ function () {
     key: "_makeObservable",
     value: function _makeObservable(initialAttributes) {
       var defaultAttributes = this.defaultAttributes;
-      mobx.extendObservable(this, _objectSpread$1({}, defaultAttributes, {}, initialAttributes));
+      mobx.extendObservable(this, _objectSpread$1(_objectSpread$1({}, defaultAttributes), initialAttributes));
 
       this._listenForChanges();
     }
@@ -1400,9 +1392,7 @@ function _objectSpread$2(target) { for (var i = 1; i < arguments.length; i++) { 
  * @constructor
  */
 
-var Store = (_class$1 = (_temp$1 =
-/*#__PURE__*/
-function () {
+var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
   /**
    * Observable property used to store data and
    * handle changes to state
@@ -1454,12 +1444,8 @@ function () {
       });
     };
 
-    this.bulkSave =
-    /*#__PURE__*/
-    function () {
-      var _ref = _asyncToGenerator(
-      /*#__PURE__*/
-      _regeneratorRuntime.mark(function _callee(type, records) {
+    this.bulkSave = /*#__PURE__*/function () {
+      var _ref = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee(type, records) {
         var options,
             queryParams,
             url,
@@ -1485,7 +1471,7 @@ function () {
                 }); // send request
 
                 response = _this.fetch(url, {
-                  headers: _objectSpread$2({}, _this.defaultFetchOptions.headers, {
+                  headers: _objectSpread$2(_objectSpread$2({}, _this.defaultFetchOptions.headers), {}, {
                     'Content-Type': 'application/vnd.api+json; ext="bulk"'
                   }),
                   method: 'POST',
@@ -1790,14 +1776,14 @@ function () {
       var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
       var defaultFetchOptions = this.defaultFetchOptions;
 
-      var fetchOptions = _objectSpread$2({}, defaultFetchOptions, {}, options);
+      var fetchOptions = _objectSpread$2(_objectSpread$2({}, defaultFetchOptions), options);
 
       var key = JSON.stringify({
         url: url,
         fetchOptions: fetchOptions
       });
       return combineRacedRequests(key, function () {
-        return fetch(url, _objectSpread$2({}, defaultFetchOptions, {}, options));
+        return fetch(url, _objectSpread$2(_objectSpread$2({}, defaultFetchOptions), options));
       });
     })
     /**
@@ -2026,7 +2012,7 @@ function () {
             // Don't try to create relationship if meta included false
             if (!relationships[key].meta) {
               // defensive against existingRecord.relationships being undefined
-              mobx.set(record, 'relationships', _objectSpread$2({}, record.relationships, _defineProperty({}, key, relationships[key])));
+              mobx.set(record, 'relationships', _objectSpread$2(_objectSpread$2({}, record.relationships), {}, _defineProperty({}, key, relationships[key])));
             }
           });
         }
@@ -2126,9 +2112,7 @@ function () {
   }, {
     key: "fetchAll",
     value: function () {
-      var _fetchAll = _asyncToGenerator(
-      /*#__PURE__*/
-      _regeneratorRuntime.mark(function _callee2(type, queryParams) {
+      var _fetchAll = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee2(type, queryParams) {
         var _this5 = this;
 
         var store, url, response, json;
@@ -2214,9 +2198,7 @@ function () {
   }, {
     key: "fetchOne",
     value: function () {
-      var _fetchOne = _asyncToGenerator(
-      /*#__PURE__*/
-      _regeneratorRuntime.mark(function _callee3(type, id, queryParams) {
+      var _fetchOne = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee3(type, id, queryParams) {
         var url, response, json, data, included, record;
         return _regeneratorRuntime.wrap(function _callee3$(_context3) {
           while (1) {
@@ -2289,12 +2271,8 @@ function () {
       recordsArray.forEach(function (record) {
         record.isInFlight = true;
       });
-      return promise.then(
-      /*#__PURE__*/
-      function () {
-        var _ref3 = _asyncToGenerator(
-        /*#__PURE__*/
-        _regeneratorRuntime.mark(function _callee4(response) {
+      return promise.then( /*#__PURE__*/function () {
+        var _ref3 = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee4(response) {
           var status, json, data, included, _json, errorString;
 
           return _regeneratorRuntime.wrap(function _callee4$(_context4) {
@@ -2562,6 +2540,10 @@ function validates(target, property) {
 }
 
 var _Symbol$species;
+
+function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 /*
  * Defines a one-to-many relationship. Defaults to the class with camelized singular name of the property
  * An optional argument specifies the data model, if different from the property name
@@ -2676,10 +2658,17 @@ function getRelatedRecords(record, property) {
   } else {
     var foreignId = "".concat(singularizeType(record.type), "_id");
 
-    if (record.store.getRecords(relationType)) {
-      relatedRecords = record.store.getRecords(relationType).filter(function (rel) {
-        return String(rel[foreignId]) === String(record.id);
-      });
+    if (record.store.getType(relationType)) {
+      var _allRecords$;
+
+      var allRecords = record.store.getRecords(relationType);
+
+      if (allRecords === null || allRecords === void 0 ? void 0 : (_allRecords$ = allRecords[0]) === null || _allRecords$ === void 0 ? void 0 : _allRecords$[foreignId]) {
+        console.warn("Support for including non-canonical jsonapi references will be removed in future versions. Record type: ".concat(record.type, ". Reference: ").concat(foreignId));
+        relatedRecords = allRecords.filter(function (rel) {
+          return String(rel[foreignId]) === String(record.id);
+        });
+      }
     }
   }
 
@@ -2774,19 +2763,17 @@ function setRelatedRecord(record, relatedRecord, property) {
  */
 
 _Symbol$species = Symbol.species;
-var RelatedRecordsArray =
-/*#__PURE__*/
-function (_Array) {
+var RelatedRecordsArray = /*#__PURE__*/function (_Array) {
   _inherits(RelatedRecordsArray, _Array);
 
-  function RelatedRecordsArray(_array, _record, _property) {
-    var _getPrototypeOf2;
+  var _super = _createSuper(RelatedRecordsArray);
 
+  function RelatedRecordsArray(_array, _record, _property) {
     var _this;
 
     _classCallCheck(this, RelatedRecordsArray);
 
-    _this = _possibleConstructorReturn(this, (_getPrototypeOf2 = _getPrototypeOf(RelatedRecordsArray)).call.apply(_getPrototypeOf2, [this].concat(_toConsumableArray(_array))));
+    _this = _super.call.apply(_super, [this].concat(_toConsumableArray(_array)));
 
     _this.add = function (relatedRecord) {
       var _assertThisInitialize = _assertThisInitialized(_this),
@@ -2926,7 +2913,7 @@ function (_Array) {
   }]);
 
   return RelatedRecordsArray;
-}(_wrapNativeSuper(Array));
+}( /*#__PURE__*/_wrapNativeSuper(Array));
 
 exports.Model = Model;
 exports.ObjectPromiseProxy = ObjectPromiseProxy;

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -253,7 +253,7 @@ function diff() {
 function parseErrorPointer() {
   var error = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
-  var regex = _wrapRegExp(/\/data\/([0-9]+)?\/?attributes\/(.*)$/, {
+  var regex = /*#__PURE__*/_wrapRegExp(/\/data\/([0-9]+)?\/?attributes\/(.*)$/, {
     index: 1,
     key: 2
   });
@@ -332,9 +332,7 @@ function ObjectPromiseProxy(promise, target) {
  *
  * @class Schema
  */
-var Schema =
-/*#__PURE__*/
-function () {
+var Schema = /*#__PURE__*/function () {
   function Schema() {
     _classCallCheck(this, Schema);
 
@@ -462,9 +460,7 @@ function stringifyIds(object) {
  */
 
 
-var Model = (_class = (_temp =
-/*#__PURE__*/
-function () {
+var Model = (_class = (_temp = /*#__PURE__*/function () {
   /**
    * Initializer for model
    *
@@ -670,12 +666,8 @@ function () {
       var _this = this;
 
       _this.errors = {};
-      return promise.then(
-      /*#__PURE__*/
-      function () {
-        var _ref = _asyncToGenerator(
-        /*#__PURE__*/
-        _regeneratorRuntime.mark(function _callee(response) {
+      return promise.then( /*#__PURE__*/function () {
+        var _ref = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee(response) {
           var json;
           return _regeneratorRuntime.wrap(function _callee$(_context) {
             while (1) {
@@ -761,7 +753,7 @@ function () {
     key: "_makeObservable",
     value: function _makeObservable(initialAttributes) {
       var defaultAttributes = this.defaultAttributes;
-      extendObservable(this, _objectSpread$1({}, defaultAttributes, {}, initialAttributes));
+      extendObservable(this, _objectSpread$1(_objectSpread$1({}, defaultAttributes), initialAttributes));
 
       this._listenForChanges();
     }
@@ -1394,9 +1386,7 @@ function _objectSpread$2(target) { for (var i = 1; i < arguments.length; i++) { 
  * @constructor
  */
 
-var Store = (_class$1 = (_temp$1 =
-/*#__PURE__*/
-function () {
+var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
   /**
    * Observable property used to store data and
    * handle changes to state
@@ -1448,12 +1438,8 @@ function () {
       });
     };
 
-    this.bulkSave =
-    /*#__PURE__*/
-    function () {
-      var _ref = _asyncToGenerator(
-      /*#__PURE__*/
-      _regeneratorRuntime.mark(function _callee(type, records) {
+    this.bulkSave = /*#__PURE__*/function () {
+      var _ref = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee(type, records) {
         var options,
             queryParams,
             url,
@@ -1479,7 +1465,7 @@ function () {
                 }); // send request
 
                 response = _this.fetch(url, {
-                  headers: _objectSpread$2({}, _this.defaultFetchOptions.headers, {
+                  headers: _objectSpread$2(_objectSpread$2({}, _this.defaultFetchOptions.headers), {}, {
                     'Content-Type': 'application/vnd.api+json; ext="bulk"'
                   }),
                   method: 'POST',
@@ -1784,14 +1770,14 @@ function () {
       var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
       var defaultFetchOptions = this.defaultFetchOptions;
 
-      var fetchOptions = _objectSpread$2({}, defaultFetchOptions, {}, options);
+      var fetchOptions = _objectSpread$2(_objectSpread$2({}, defaultFetchOptions), options);
 
       var key = JSON.stringify({
         url: url,
         fetchOptions: fetchOptions
       });
       return combineRacedRequests(key, function () {
-        return fetch(url, _objectSpread$2({}, defaultFetchOptions, {}, options));
+        return fetch(url, _objectSpread$2(_objectSpread$2({}, defaultFetchOptions), options));
       });
     })
     /**
@@ -2020,7 +2006,7 @@ function () {
             // Don't try to create relationship if meta included false
             if (!relationships[key].meta) {
               // defensive against existingRecord.relationships being undefined
-              set(record, 'relationships', _objectSpread$2({}, record.relationships, _defineProperty({}, key, relationships[key])));
+              set(record, 'relationships', _objectSpread$2(_objectSpread$2({}, record.relationships), {}, _defineProperty({}, key, relationships[key])));
             }
           });
         }
@@ -2120,9 +2106,7 @@ function () {
   }, {
     key: "fetchAll",
     value: function () {
-      var _fetchAll = _asyncToGenerator(
-      /*#__PURE__*/
-      _regeneratorRuntime.mark(function _callee2(type, queryParams) {
+      var _fetchAll = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee2(type, queryParams) {
         var _this5 = this;
 
         var store, url, response, json;
@@ -2208,9 +2192,7 @@ function () {
   }, {
     key: "fetchOne",
     value: function () {
-      var _fetchOne = _asyncToGenerator(
-      /*#__PURE__*/
-      _regeneratorRuntime.mark(function _callee3(type, id, queryParams) {
+      var _fetchOne = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee3(type, id, queryParams) {
         var url, response, json, data, included, record;
         return _regeneratorRuntime.wrap(function _callee3$(_context3) {
           while (1) {
@@ -2283,12 +2265,8 @@ function () {
       recordsArray.forEach(function (record) {
         record.isInFlight = true;
       });
-      return promise.then(
-      /*#__PURE__*/
-      function () {
-        var _ref3 = _asyncToGenerator(
-        /*#__PURE__*/
-        _regeneratorRuntime.mark(function _callee4(response) {
+      return promise.then( /*#__PURE__*/function () {
+        var _ref3 = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee4(response) {
           var status, json, data, included, _json, errorString;
 
           return _regeneratorRuntime.wrap(function _callee4$(_context4) {
@@ -2556,6 +2534,10 @@ function validates(target, property) {
 }
 
 var _Symbol$species;
+
+function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 /*
  * Defines a one-to-many relationship. Defaults to the class with camelized singular name of the property
  * An optional argument specifies the data model, if different from the property name
@@ -2670,10 +2652,17 @@ function getRelatedRecords(record, property) {
   } else {
     var foreignId = "".concat(singularizeType(record.type), "_id");
 
-    if (record.store.getRecords(relationType)) {
-      relatedRecords = record.store.getRecords(relationType).filter(function (rel) {
-        return String(rel[foreignId]) === String(record.id);
-      });
+    if (record.store.getType(relationType)) {
+      var _allRecords$;
+
+      var allRecords = record.store.getRecords(relationType);
+
+      if (allRecords === null || allRecords === void 0 ? void 0 : (_allRecords$ = allRecords[0]) === null || _allRecords$ === void 0 ? void 0 : _allRecords$[foreignId]) {
+        console.warn("Support for including non-canonical jsonapi references will be removed in future versions. Record type: ".concat(record.type, ". Reference: ").concat(foreignId));
+        relatedRecords = allRecords.filter(function (rel) {
+          return String(rel[foreignId]) === String(record.id);
+        });
+      }
     }
   }
 
@@ -2768,19 +2757,17 @@ function setRelatedRecord(record, relatedRecord, property) {
  */
 
 _Symbol$species = Symbol.species;
-var RelatedRecordsArray =
-/*#__PURE__*/
-function (_Array) {
+var RelatedRecordsArray = /*#__PURE__*/function (_Array) {
   _inherits(RelatedRecordsArray, _Array);
 
-  function RelatedRecordsArray(_array, _record, _property) {
-    var _getPrototypeOf2;
+  var _super = _createSuper(RelatedRecordsArray);
 
+  function RelatedRecordsArray(_array, _record, _property) {
     var _this;
 
     _classCallCheck(this, RelatedRecordsArray);
 
-    _this = _possibleConstructorReturn(this, (_getPrototypeOf2 = _getPrototypeOf(RelatedRecordsArray)).call.apply(_getPrototypeOf2, [this].concat(_toConsumableArray(_array))));
+    _this = _super.call.apply(_super, [this].concat(_toConsumableArray(_array)));
 
     _this.add = function (relatedRecord) {
       var _assertThisInitialize = _assertThisInitialized(_this),
@@ -2920,6 +2907,6 @@ function (_Array) {
   }]);
 
   return RelatedRecordsArray;
-}(_wrapNativeSuper(Array));
+}( /*#__PURE__*/_wrapNativeSuper(Array));
 
 export { Model, ObjectPromiseProxy, QueryString, Store, attribute, relatedToMany, relatedToOne, validates };

--- a/docs/classes/Model.html
+++ b/docs/classes/Model.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.0.0</em>
+            <em>API Docs for: 3.0.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -1062,7 +1062,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l502"><code>src&#x2F;Model.js:502</code></a>
+        <a href="../files/src_Model.js.html#l491"><code>src&#x2F;Model.js:491</code></a>
         </p>
 
 
@@ -1070,7 +1070,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     </div>
 
     <div class="description">
-        <p>the latest persisted snapshot or the first snapshot if the model was never persisted</p>
+        <p>the latest snapshot</p>
 
     </div>
 
@@ -1093,7 +1093,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l491"><code>src&#x2F;Model.js:491</code></a>
+        <a href="../files/src_Model.js.html#l502"><code>src&#x2F;Model.js:502</code></a>
         </p>
 
 
@@ -1101,7 +1101,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     </div>
 
     <div class="description">
-        <p>the latest snapshot</p>
+        <p>the latest persisted snapshot or the first snapshot if the model was never persisted</p>
 
     </div>
 

--- a/docs/classes/RelatedRecordsArray.html
+++ b/docs/classes/RelatedRecordsArray.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.0.0</em>
+            <em>API Docs for: 3.0.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -84,7 +84,7 @@
 
 
         <div class="foundat">
-            Defined in: <a href="../files/src_decorators_relationships.js.html#l202"><code>src&#x2F;decorators&#x2F;relationships.js:202</code></a>
+            Defined in: <a href="../files/src_decorators_relationships.js.html#l206"><code>src&#x2F;decorators&#x2F;relationships.js:206</code></a>
         </div>
 
 
@@ -125,7 +125,7 @@
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_decorators_relationships.js.html#l202"><code>src&#x2F;decorators&#x2F;relationships.js:202</code></a>
+        <a href="../files/src_decorators_relationships.js.html#l206"><code>src&#x2F;decorators&#x2F;relationships.js:206</code></a>
         </p>
 
 
@@ -274,7 +274,7 @@
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_decorators_relationships.js.html#l233"><code>src&#x2F;decorators&#x2F;relationships.js:233</code></a>
+        <a href="../files/src_decorators_relationships.js.html#l237"><code>src&#x2F;decorators&#x2F;relationships.js:237</code></a>
         </p>
 
 
@@ -396,7 +396,7 @@ Attributes can be defined with a default.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_decorators_relationships.js.html#l130"><code>src&#x2F;decorators&#x2F;relationships.js:130</code></a>
+        <a href="../files/src_decorators_relationships.js.html#l134"><code>src&#x2F;decorators&#x2F;relationships.js:134</code></a>
         </p>
 
 
@@ -614,7 +614,7 @@ everything the same except it only returns a single record.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_decorators_relationships.js.html#l275"><code>src&#x2F;decorators&#x2F;relationships.js:275</code></a>
+        <a href="../files/src_decorators_relationships.js.html#l279"><code>src&#x2F;decorators&#x2F;relationships.js:279</code></a>
         </p>
 
 
@@ -686,7 +686,7 @@ everything the same except it only returns a single record.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_decorators_relationships.js.html#l155"><code>src&#x2F;decorators&#x2F;relationships.js:155</code></a>
+        <a href="../files/src_decorators_relationships.js.html#l159"><code>src&#x2F;decorators&#x2F;relationships.js:159</code></a>
         </p>
 
 

--- a/docs/classes/Schema.html
+++ b/docs/classes/Schema.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.0.0</em>
+            <em>API Docs for: 3.0.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Store.html
+++ b/docs/classes/Store.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.0.0</em>
+            <em>API Docs for: 3.0.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -2652,7 +2652,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l475"><code>src&#x2F;Store.js:475</code></a>
+        <a href="../files/src_Store.js.html#l464"><code>src&#x2F;Store.js:464</code></a>
         </p>
 
 
@@ -2706,7 +2706,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l464"><code>src&#x2F;Store.js:464</code></a>
+        <a href="../files/src_Store.js.html#l475"><code>src&#x2F;Store.js:475</code></a>
         </p>
 
 

--- a/docs/data.json
+++ b/docs/data.json
@@ -3,7 +3,7 @@
         "name": "mobx-async-store",
         "description": "Asyc Data Store for mobx",
         "url": "https://github.com/artemis-ag/mobx-async-store",
-        "version": "3.0.0"
+        "version": "3.0.1"
     },
     "files": {
         "src/decorators/attributes.js": {
@@ -68,7 +68,7 @@
             "plugin_for": [],
             "extension_for": [],
             "file": "src/decorators/relationships.js",
-            "line": 202,
+            "line": 206,
             "description": "An array that allows for updating store references and relationships",
             "is_constructor": 1,
             "params": [
@@ -219,7 +219,7 @@
         },
         {
             "file": "src/decorators/relationships.js",
-            "line": 130,
+            "line": 134,
             "description": "Handles getting polymorphic has_one/belong_to.",
             "itemtype": "method",
             "name": "getRelatedRecord",
@@ -227,7 +227,7 @@
         },
         {
             "file": "src/decorators/relationships.js",
-            "line": 155,
+            "line": 159,
             "description": "Handles setting polymorphic has_one/belong_to.\n- Validates the related record to make sure it inherits from `Model` class\n- Sets the relationship\n- Attempts to find an inverse relationship, and if successful adds it as well",
             "itemtype": "method",
             "name": "setRelatedRecord",
@@ -257,7 +257,7 @@
         },
         {
             "file": "src/decorators/relationships.js",
-            "line": 233,
+            "line": 237,
             "description": "Adds a record to the array, and updates references in the store, as well as inverse references",
             "itemtype": "method",
             "name": "add",
@@ -276,7 +276,7 @@
         },
         {
             "file": "src/decorators/relationships.js",
-            "line": 275,
+            "line": 279,
             "description": "Removes a record from the array, and updates references in the store, as well as inverse references",
             "itemtype": "method",
             "name": "remove",

--- a/docs/files/src_Model.js.html
+++ b/docs/files/src_Model.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.0.0</em>
+            <em>API Docs for: 3.0.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_Store.js.html
+++ b/docs/files/src_Store.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.0.0</em>
+            <em>API Docs for: 3.0.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_attributes.js.html
+++ b/docs/files/src_decorators_attributes.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.0.0</em>
+            <em>API Docs for: 3.0.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_relationships.js.html
+++ b/docs/files/src_decorators_relationships.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.0.0</em>
+            <em>API Docs for: 3.0.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -203,9 +203,13 @@ export function getRelatedRecords (record, property, modelType = null) {
     })
   } else {
     const foreignId = &#x60;${singularizeType(record.type)}_id&#x60;
+
     if (record.store.getRecords(relationType)) {
-      relatedRecords = record.store.getRecords(relationType)
-                                   .filter(rel =&gt; String(rel[foreignId]) === String(record.id))
+      const allRecords = record.store.getType(relationType) &amp;&amp; record.store.getRecords(relationType)
+      if (allRecords?.[0]?.[foreignId]) {
+        console.warn(&#x60;Support for including non-canonical jsonapi references will be removed in future versions. Record type: ${record.type}. Reference: ${foreignId}&#x60;)
+        relatedRecords = allRecords.filter(rel =&gt; String(rel[foreignId]) === String(record.id))
+      }
     }
   }
 

--- a/docs/files/src_schema.js.html
+++ b/docs/files/src_schema.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.0.0</em>
+            <em>API Docs for: 3.0.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_utils.js.html
+++ b/docs/files/src_utils.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.0.0</em>
+            <em>API Docs for: 3.0.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
                 <h1><img src="./assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.0.0</em>
+            <em>API Docs for: 3.0.1</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -14,7 +14,8 @@ import {
   exampleRelatedToManyResponse,
   exampleRelatedToManyWithNoiseResponse,
   exampleRelatedToManyIncludedResponse,
-  exampleRelatedToManyIncludedWithNoiseResponse
+  exampleRelatedToManyIncludedWithNoiseResponse,
+  exampleRelatedToOneUnmatchedTypeResponse
 } from './fixtures/exampleRelationalResponses'
 
 const timestamp = new Date(Date.now())
@@ -102,6 +103,7 @@ class Organization extends Model {
 
   @validates(validatesArrayPresence)
   @relatedToMany notes
+  @relatedToMany awesome_notes
 
   @relatedToOne user
 }
@@ -295,6 +297,17 @@ describe('Model', () => {
       expect(todo.title).toEqual('Do laundry')
       expect(todo.notes).toHaveLength(1)
       expect(todo.notes[0].description).toEqual('Use fabric softener')
+    })
+
+    it('builds relatedToMany relationship without included data', async () => {
+      fetch.mockResponse(exampleRelatedToOneUnmatchedTypeResponse)
+      const organization = await store.findOne('organizations', 1)
+
+      expect(organization.name).toEqual('Do laundry')
+      expect(organization.awesome_notes).toHaveLength(0)
+      expect(organization.awesome_notes).toBeInstanceOf(Array)
+      expect(organization.meeting_notes).toHaveLength(0)
+      expect(organization.meeting_notes).toBeInstanceOf(Array)
     })
 
     it('builds aliased relatedToMany relationship', async () => {

--- a/spec/fixtures/exampleRelationalResponses.js
+++ b/spec/fixtures/exampleRelationalResponses.js
@@ -159,3 +159,29 @@ export const exampleRelatedToOneIncludedResponse = JSON.stringify({
     version: '1.0'
   }
 })
+
+export const exampleRelatedToOneUnmatchedTypeResponse = JSON.stringify({
+  data: {
+    id: '1',
+    type: 'organizations',
+    attributes: {
+      id: 1,
+      name: 'Do laundry'
+    },
+    relationships: {
+      meeting_notes: {
+        meta: {
+          included: false
+        }
+      },
+      awesome_notes: {
+        meta: {
+          included: false
+        }
+      }
+    }
+  },
+  jsonapi: {
+    version: '1.0'
+  }
+})

--- a/src/decorators/relationships.js
+++ b/src/decorators/relationships.js
@@ -118,9 +118,13 @@ export function getRelatedRecords (record, property, modelType = null) {
     })
   } else {
     const foreignId = `${singularizeType(record.type)}_id`
-    if (record.store.getRecords(relationType)) {
-      relatedRecords = record.store.getRecords(relationType)
-                                   .filter(rel => String(rel[foreignId]) === String(record.id))
+
+    if (record.store.getType(relationType)) {
+      const allRecords = record.store.getRecords(relationType)
+      if (allRecords?.[0]?.[foreignId]) {
+        console.warn(`Support for including non-canonical jsonapi references will be removed in future versions. Record type: ${record.type}. Reference: ${foreignId}`)
+        relatedRecords = allRecords.filter(rel => String(rel[foreignId]) === String(record.id))
+      }
     }
   }
 


### PR DESCRIPTION
There's a "back door" in mobx-async-store that allows for reciprocal references to be inferred by `_id`. This is idiomatic Ruby on Rails, NOT jsonapi, and should not be supported in mobx-async-store.

It can cause issues if the relationship type doesn't match a model name, if the server returns `meta: { included: false }`.

```js
{
  id: "1",
  type: "users",
  attributes:
    { name: "Jon" }
  relationships: {
    todos: {
      meta: { included: false }
    },
    awesome_todos: {
      meta: { included: false }
    }
  }
}

// works
user.todos

// breaks
user.awesome_todos
```

https://github.com/artemis-ag/mobx-async-store/pull/69/commits/6979d788d51dfe740e75a1173f7cd90280655639