### PR TITLE
Remove our version of isEqual, it is not used [Ref #176874011]

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -25,7 +25,7 @@ var pluralize = _interopDefault(require('pluralize'));
 var dig = _interopDefault(require('lodash/get'));
 var flattenDeep = _interopDefault(require('lodash/flattenDeep'));
 var cloneDeep = _interopDefault(require('lodash/cloneDeep'));
-var _isEqual = _interopDefault(require('lodash/isEqual'));
+var isEqual = _interopDefault(require('lodash/isEqual'));
 var isObject = _interopDefault(require('lodash/isObject'));
 var findLast = _interopDefault(require('lodash/findLast'));
 var pick = _interopDefault(require('lodash/pick'));
@@ -1004,23 +1004,6 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
       });
     }
     /**
-     * Comparison by value
-     * returns `true` if this object has the same attrs and relationships
-     * as the "other" object, ignores differences in internal state like
-     * attribute "dirtyness" or errors
-     *
-     * @method isEqual
-     * @param {Object} other
-     * @return {Object}
-     */
-
-  }, {
-    key: "isEqual",
-    value: function isEqual(other) {
-      if (!other) return false;
-      return _isEqual(this.attributes, other.attributes) && _isEqual(this.relationships, other.relationships);
-    }
-    /**
      * Comparison by identity
      * returns `true` if this object has the same type and id as the
      * "other" object, ignores differences in attrs and relationships
@@ -1071,7 +1054,7 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
           diff(currentValue, previousValue).forEach(function (property) {
             dirtyAccumulator.add("".concat(attr, ".").concat(property));
           });
-        } else if (!_isEqual(previousValue, currentValue)) {
+        } else if (!isEqual(previousValue, currentValue)) {
           dirtyAccumulator.add(attr);
         }
 
@@ -1117,7 +1100,7 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
           return [value.id, value.type];
         }).sort() : [previousValues.id, previousValues.type];
 
-        if (!_isEqual(currentIds, previousIds)) {
+        if (!isEqual(currentIds, previousIds)) {
           dirtyAccumulator.add(name);
         }
 

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -19,7 +19,7 @@ import pluralize from 'pluralize';
 import dig from 'lodash/get';
 import flattenDeep from 'lodash/flattenDeep';
 import cloneDeep from 'lodash/cloneDeep';
-import _isEqual from 'lodash/isEqual';
+import isEqual from 'lodash/isEqual';
 import isObject from 'lodash/isObject';
 import findLast from 'lodash/findLast';
 import pick from 'lodash/pick';
@@ -998,23 +998,6 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
       });
     }
     /**
-     * Comparison by value
-     * returns `true` if this object has the same attrs and relationships
-     * as the "other" object, ignores differences in internal state like
-     * attribute "dirtyness" or errors
-     *
-     * @method isEqual
-     * @param {Object} other
-     * @return {Object}
-     */
-
-  }, {
-    key: "isEqual",
-    value: function isEqual(other) {
-      if (!other) return false;
-      return _isEqual(this.attributes, other.attributes) && _isEqual(this.relationships, other.relationships);
-    }
-    /**
      * Comparison by identity
      * returns `true` if this object has the same type and id as the
      * "other" object, ignores differences in attrs and relationships
@@ -1065,7 +1048,7 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
           diff(currentValue, previousValue).forEach(function (property) {
             dirtyAccumulator.add("".concat(attr, ".").concat(property));
           });
-        } else if (!_isEqual(previousValue, currentValue)) {
+        } else if (!isEqual(previousValue, currentValue)) {
           dirtyAccumulator.add(attr);
         }
 
@@ -1111,7 +1094,7 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
           return [value.id, value.type];
         }).sort() : [previousValues.id, previousValues.type];
 
-        if (!_isEqual(currentIds, previousIds)) {
+        if (!isEqual(currentIds, previousIds)) {
           dirtyAccumulator.add(name);
         }
 

--- a/docs/classes/Model.html
+++ b/docs/classes/Model.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.9.2</em>
+            <em>API Docs for: 3.9.3</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -162,10 +162,6 @@
                             </li>
                             <li class="index-item method">
                                 <a href="#method_hasErrors">hasErrors</a>
-
-                            </li>
-                            <li class="index-item method">
-                                <a href="#method_isEqual">isEqual</a>
 
                             </li>
                             <li class="index-item method">
@@ -843,72 +839,6 @@ todo.dirtyRelationships
 
 
 </div>
-<div id="method_isEqual" class="method item">
-    <h3 class="name"><code>isEqual</code></h3>
-
-        <div class="args">
-            <span class="paren">(</span><ul class="args-list inline commas">
-                <li class="arg">
-                        <code>other</code>
-                </li>
-            </ul><span class="paren">)</span>
-        </div>
-
-        <span class="returns-inline">
-            <span class="type">Object</span>
-        </span>
-
-
-
-
-
-
-
-    <div class="meta">
-                <p>
-                Defined in
-        <a href="../files/src_Model.js.html#l805"><code>src&#x2F;Model.js:805</code></a>
-        </p>
-
-
-
-    </div>
-
-    <div class="description">
-        <p>Comparison by value
-returns <code>true</code> if this object has the same attrs and relationships
-as the &quot;other&quot; object, ignores differences in internal state like
-attribute &quot;dirtyness&quot; or errors</p>
-
-    </div>
-
-        <div class="params">
-            <h4>Parameters:</h4>
-
-            <ul class="params-list">
-                <li class="param">
-                        <code class="param-name">other</code>
-                        <span class="type">Object</span>
-
-
-                    <div class="param-description">
-                         
-                    </div>
-
-                </li>
-            </ul>
-        </div>
-
-        <div class="returns">
-            <h4>Returns:</h4>
-
-            <div class="returns-description">
-                        <span class="type">Object</span>:
-            </div>
-        </div>
-
-
-</div>
 <div id="method_isSame" class="method item">
     <h3 class="name"><code>isSame</code></h3>
 
@@ -933,7 +863,7 @@ attribute &quot;dirtyness&quot; or errors</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l820"><code>src&#x2F;Model.js:820</code></a>
+        <a href="../files/src_Model.js.html#l805"><code>src&#x2F;Model.js:805</code></a>
         </p>
 
 

--- a/docs/classes/RelatedRecordsArray.html
+++ b/docs/classes/RelatedRecordsArray.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.9.2</em>
+            <em>API Docs for: 3.9.3</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Schema.html
+++ b/docs/classes/Schema.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.9.2</em>
+            <em>API Docs for: 3.9.3</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Store.html
+++ b/docs/classes/Store.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.9.2</em>
+            <em>API Docs for: 3.9.3</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/data.json
+++ b/docs/data.json
@@ -3,7 +3,7 @@
         "name": "mobx-async-store",
         "description": "Asyc Data Store for mobx",
         "url": "https://github.com/artemis-ag/mobx-async-store",
-        "version": "3.9.2"
+        "version": "3.9.3"
     },
     "files": {
         "src/decorators/attributes.js": {
@@ -711,25 +711,6 @@
         {
             "file": "src/Model.js",
             "line": 805,
-            "description": "Comparison by value\nreturns `true` if this object has the same attrs and relationships\nas the \"other\" object, ignores differences in internal state like\nattribute \"dirtyness\" or errors",
-            "itemtype": "method",
-            "name": "isEqual",
-            "params": [
-                {
-                    "name": "other",
-                    "description": "",
-                    "type": "Object"
-                }
-            ],
-            "return": {
-                "description": "",
-                "type": "Object"
-            },
-            "class": "Model"
-        },
-        {
-            "file": "src/Model.js",
-            "line": 820,
             "description": "Comparison by identity\nreturns `true` if this object has the same type and id as the\n\"other\" object, ignores differences in attrs and relationships",
             "itemtype": "method",
             "name": "isSame",

--- a/docs/files/src_Model.js.html
+++ b/docs/files/src_Model.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.9.2</em>
+            <em>API Docs for: 3.9.3</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -885,21 +885,6 @@ class Model {
     const attributes = cloneDeep(this.snapshot.attributes)
     const relationships = cloneDeep(this.snapshot.relationships)
     return this.store.createModel(this.type, this.id, { attributes, relationships })
-  }
-
-  /**
-   * Comparison by value
-   * returns &#x60;true&#x60; if this object has the same attrs and relationships
-   * as the &quot;other&quot; object, ignores differences in internal state like
-   * attribute &quot;dirtyness&quot; or errors
-   *
-   * @method isEqual
-   * @param {Object} other
-   * @return {Object}
-   */
-  isEqual (other) {
-    if (!other) return false
-    return isEqual(this.attributes, other.attributes) &amp;&amp; isEqual(this.relationships, other.relationships)
   }
 
   /**

--- a/docs/files/src_Store.js.html
+++ b/docs/files/src_Store.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.9.2</em>
+            <em>API Docs for: 3.9.3</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_attributes.js.html
+++ b/docs/files/src_decorators_attributes.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.9.2</em>
+            <em>API Docs for: 3.9.3</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_relationships.js.html
+++ b/docs/files/src_decorators_relationships.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.9.2</em>
+            <em>API Docs for: 3.9.3</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_schema.js.html
+++ b/docs/files/src_schema.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.9.2</em>
+            <em>API Docs for: 3.9.3</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_utils.js.html
+++ b/docs/files/src_utils.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.9.2</em>
+            <em>API Docs for: 3.9.3</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
                 <h1><img src="./assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.9.2</em>
+            <em>API Docs for: 3.9.3</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -1168,45 +1168,6 @@ describe('Model', () => {
     })
   })
 
-  describe('.isEqual', () => {
-    let original
-    beforeEach(() => {
-      const note = store.add('notes', {
-        id: 11,
-        description: 'Example description'
-      })
-      original = store.add('todos', {
-        id: 11,
-        title: 'Buy Milk',
-        options: { color: 'green' }
-      })
-      original.notes.add(note)
-    })
-
-    it('is true for a clone and the original', () => {
-      const clone = original.clone()
-      expect(original.isEqual(clone)).toBe(true)
-    })
-
-    it('is false after attr differences', () => {
-      const clone = original.clone()
-      original.title = 'Buy Cheese'
-      expect(original.isEqual(clone)).toBe(false)
-    })
-
-    it('is false after deep attr changes', () => {
-      const clone = original.clone()
-      original.options.color = 'blue'
-      expect(original.isEqual(clone)).toBe(false)
-    })
-
-    it('is false after a change in relationships', () => {
-      const clone = original.clone()
-      clone.notes.replace([])
-      expect(original.isEqual(clone)).toBe(false)
-    })
-  })
-
   describe('.isSame', () => {
     let original
     beforeEach(() => {

--- a/src/Model.js
+++ b/src/Model.js
@@ -803,21 +803,6 @@ class Model {
   }
 
   /**
-   * Comparison by value
-   * returns `true` if this object has the same attrs and relationships
-   * as the "other" object, ignores differences in internal state like
-   * attribute "dirtyness" or errors
-   *
-   * @method isEqual
-   * @param {Object} other
-   * @return {Object}
-   */
-  isEqual (other) {
-    if (!other) return false
-    return isEqual(this.attributes, other.attributes) && isEqual(this.relationships, other.relationships)
-  }
-
-  /**
    * Comparison by identity
    * returns `true` if this object has the same type and id as the
    * "other" object, ignores differences in attrs and relationships


### PR DESCRIPTION
I looked in both the mobile app and Portal and we only use lodash's `isEqual` method, even in `mobx-async-store` itself. I think it's confusing anyway to have a method with a name identical to another method that we also use frequently, if we were using it.