### PR TITLE
Deprecate fromServer options & remove ability to specify model class on relationships  176874011

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,21 +66,6 @@ jobs:
           name: Verify docs up-to-date
           command: git diff --exit-code ./docs
 
-  verify_build:
-    docker:
-      - image: circleci/node:12.18.4
-    steps:
-      - checkout
-      - restore_cache:
-          name: Restore node_modules from cache
-          key: yarn-dependencies-v1-{{ checksum "package.json" }}
-      - run:
-          name: Build
-          command: yarn build
-      - run:
-          name: Verify build up-to-date
-          command: git diff --exit-code ./dist
-
 workflows:
   version: 2
   run_tests:
@@ -94,8 +79,5 @@ workflows:
           requires:
             - yarn_install
       - verify_docs:
-          requires:
-            - yarn_install
-      - verify_build:
           requires:
             - yarn_install

--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -519,8 +519,86 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
 
 
   _createClass(Model, [{
-    key: "rollback",
+    key: "isDirty",
+    get:
+    /**
+     * True if the instance has been modified from its persisted state
+     *
+     * NOTE that isDirty does _NOT_ track changes to the related objects
+     * but it _does_ track changes to the relationships themselves.
+     *
+     * For example, adding or removing a related object will mark this record as dirty,
+     * but changing a related object's properties will not mark this record as dirty.
+     *
+     * The caller is reponsible for asking related objects about their
+     * own dirty state.
+     *
+     * ```
+     * kpi = store.add('kpis', { name: 'A good thing to measure' })
+     * kpi.isDirty
+     * => true
+     * kpi.name
+     * => "A good thing to measure"
+     * await kpi.save()
+     * kpi.isDirty
+     * => false
+     * kpi.name = "Another good thing to measure"
+     * kpi.isDirty
+     * => true
+     * await kpi.save()
+     * kpi.isDirty
+     * => false
+     * ```
+     * @property isDirty
+     * @type {Boolean}
+     */
+    function get() {
+      return this._dirtyAttributes.size > 0 || this._dirtyRelationships.size > 0;
+    }
+    /**
+     * have any changes been made since this record was last persisted?
+     * @property hasUnpersistedChanges
+     * @type {Boolean}
+     */
 
+  }, {
+    key: "hasUnpersistedChanges",
+    get: function get() {
+      return this.isDirty || !this.previousSnapshot.persisted;
+    }
+    /**
+     * True if the model has not been sent to the store
+     * @property isNew
+     * @type {Boolean}
+     */
+
+  }, {
+    key: "isNew",
+    get: function get() {
+      var id = this.id;
+      if (!id) return true;
+      if (String(id).indexOf('tmp') === -1) return false;
+      return true;
+    }
+    /**
+     * True if the instance is coming from / going to the server
+     * ```
+     * kpi = store.find('kpis', 5)
+     * // fetch started
+     * kpi.isInFlight
+     * => true
+     * // fetch finished
+     * kpi.isInFlight
+     * => false
+     * ```
+     * @property isInFlight
+     * @type {Boolean}
+     * @default false
+     */
+
+  }, {
+    key: "rollback",
+    value:
     /**
      * restores data to its last snapshot state
      * ```
@@ -534,7 +612,7 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
      * ```
      * @method rollback
      */
-    value: function rollback() {
+    function rollback() {
       this._applySnapshot(this.previousSnapshot);
     }
     /**
@@ -836,13 +914,21 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
      */
 
   }, {
-    key: "setPreviousSnapshot",
-
+    key: "snapshot",
+    get: function get() {
+      return {
+        attributes: this.attributes,
+        relationships: mobx.toJS(this.relationships)
+      };
+    }
     /**
      * Sets previous snapshot to current snapshot
      *
      * @method setPreviousSnapshot
      */
+
+  }, {
+    key: "setPreviousSnapshot",
     value: function setPreviousSnapshot() {
       this._takeSnapshot();
     }
@@ -853,8 +939,25 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
      */
 
   }, {
-    key: "_takeSnapshot",
+    key: "previousSnapshot",
+    get: function get() {
+      var length = this._snapshots.length;
+      if (length === 0) throw new Error('Invariant violated: model has no snapshots');
+      return this._snapshots[length - 1];
+    }
+    /**
+     * the latest persisted snapshot or the first snapshot if the model was never persisted
+     *
+     * @method previousSnapshot
+     */
 
+  }, {
+    key: "persistedSnapshot",
+    get: function get() {
+      return findLast(this._snapshots, function (ss) {
+        return ss.persisted;
+      }) || this._snapshots[0];
+    }
     /**
      * take a snapshot of the current model state.
      * if persisted, clear the stack and push this snapshot to the top
@@ -862,6 +965,9 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
      * @method _takeSnapshot
      * @param {Object} options
      */
+
+  }, {
+    key: "_takeSnapshot",
     value: function _takeSnapshot() {
       var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
       var persisted = options.persisted || false;
@@ -926,312 +1032,6 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
      */
 
   }, {
-    key: "errorForKey",
-
-    /**
-     * Getter to check if the record has errors.
-     *
-     * @method hasErrors
-     * @return {Boolean}
-     */
-    value: function errorForKey(key) {
-      return this.errors[key];
-    }
-    /**
-     * Getter to just get the names of a records attributes.
-     *
-     * @method attributeNames
-     * @return {Array}
-     */
-
-  }, {
-    key: "jsonapi",
-
-    /**
-     * getter method to get data in api compliance format
-     * TODO: Figure out how to handle unpersisted ids
-     *
-     * @method jsonapi
-     * @return {Object} data in JSON::API format
-     */
-    value: function jsonapi() {
-      var _this5 = this;
-
-      var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-      var attributeDefinitions = this.attributeDefinitions,
-          attributeNames = this.attributeNames,
-          meta = this.meta,
-          id = this.id,
-          type = this.constructor.type;
-      var filteredAttributeNames = attributeNames;
-      var filteredRelationshipNames = [];
-
-      if (options.attributes) {
-        filteredAttributeNames = attributeNames.filter(function (name) {
-          return options.attributes.includes(name);
-        });
-      }
-
-      var attributes = filteredAttributeNames.reduce(function (attrs, key) {
-        var value = _this5[key];
-
-        if (value) {
-          var DataType = attributeDefinitions[key].dataType;
-          var attr;
-
-          if (DataType.name === 'Array' || DataType.name === 'Object') {
-            attr = mobx.toJS(value);
-          } else if (DataType.name === 'Date') {
-            attr = makeDate(value).toISOString();
-          } else {
-            attr = DataType(value);
-          }
-
-          attrs[key] = attr;
-        } else {
-          attrs[key] = value;
-        }
-
-        return attrs;
-      }, {});
-      var data = {
-        type: type,
-        attributes: attributes,
-        id: String(id)
-      };
-
-      if (options.relationships) {
-        filteredRelationshipNames = Object.keys(this.relationships).filter(function (name) {
-          return options.relationships.includes(name);
-        });
-        var relationships = filteredRelationshipNames.reduce(function (rels, key) {
-          rels[key] = mobx.toJS(_this5.relationships[key]);
-          stringifyIds(rels[key]);
-          return rels;
-        }, {});
-        data.relationships = relationships;
-      }
-
-      if (meta) {
-        data['meta'] = meta;
-      }
-
-      if (String(id).match(/tmp/)) {
-        delete data.id;
-      }
-
-      return data;
-    }
-  }, {
-    key: "updateAttributes",
-    value: function updateAttributes(attributes) {
-      var _this6 = this;
-
-      mobx.transaction(function () {
-        Object.keys(attributes).forEach(function (key) {
-          _this6[key] = attributes[key];
-        });
-      });
-    } // TODO: this shares a lot of functionality with Store.createOrUpdateModel
-    // Perhaps that shared code
-
-  }, {
-    key: "updateAttributesFromResponse",
-    value: function updateAttributesFromResponse(data, included) {
-      var _this7 = this;
-
-      var tmpId = this.id;
-      var id = data.id,
-          attributes = data.attributes,
-          relationships = data.relationships;
-      mobx.transaction(function () {
-        mobx.set(_this7, 'id', id);
-        Object.keys(attributes).forEach(function (key) {
-          mobx.set(_this7, key, attributes[key]);
-        });
-
-        if (relationships) {
-          Object.keys(relationships).forEach(function (key) {
-            if (!relationships[key].hasOwnProperty('meta')) {
-              // todo: throw error if relationship is not defined in model
-              mobx.set(_this7.relationships, key, relationships[key]);
-            }
-          });
-        }
-
-        if (included) {
-          _this7.store.createModelsFromData(included);
-        }
-      }); // Update target isInFlight
-
-      this.isInFlight = false;
-
-      this._takeSnapshot({
-        persisted: true
-      });
-
-      mobx.transaction(function () {
-        // NOTE: This resolves an issue where a record is persisted but the
-        // index key is still a temp uuid. We can't simply remove the temp
-        // key because there may be associated records that have the temp
-        // uuid id as its only reference to the newly persisted record.
-        // TODO: Figure out a way to update associated records to use the
-        // newly persisted id.
-        _this7.store.data[_this7.type].records.set(String(tmpId), _this7);
-
-        _this7.store.data[_this7.type].records.set(String(_this7.id), _this7);
-      });
-    }
-  }, {
-    key: "clone",
-    value: function clone() {
-      var attributes = cloneDeep(this.snapshot.attributes);
-      var relationships = cloneDeep(this.snapshot.relationships);
-      return this.store.createModel(this.type, this.id, {
-        attributes: attributes,
-        relationships: relationships
-      });
-    }
-    /**
-     * Comparison by value
-     * returns `true` if this object has the same attrs and relationships
-     * as the "other" object, ignores differences in internal state like
-     * attribute "dirtyness" or errors
-     *
-     * @method isEqual
-     * @param {Object} other
-     * @return {Object}
-     */
-
-  }, {
-    key: "isEqual",
-    value: function isEqual(other) {
-      if (!other) return false;
-      return _isEqual(this.attributes, other.attributes) && _isEqual(this.relationships, other.relationships);
-    }
-    /**
-     * Comparison by identity
-     * returns `true` if this object has the same type and id as the
-     * "other" object, ignores differences in attrs and relationships
-     *
-     * @method isSame
-     * @param {Object} other
-     * @return {Object}
-     */
-
-  }, {
-    key: "isSame",
-    value: function isSame(other) {
-      if (!other) return false;
-      return this.type === other.type && this.id === other.id;
-    }
-  }, {
-    key: "isDirty",
-
-    /**
-     * True if the instance has been modified from its persisted state
-     *
-     * NOTE that isDirty does _NOT_ track changes to the related objects
-     * but it _does_ track changes to the relationships themselves.
-     *
-     * For example, adding or removing a related object will mark this record as dirty,
-     * but changing a related object's properties will not mark this record as dirty.
-     *
-     * The caller is reponsible for asking related objects about their
-     * own dirty state.
-     *
-     * ```
-     * kpi = store.add('kpis', { name: 'A good thing to measure' })
-     * kpi.isDirty
-     * => true
-     * kpi.name
-     * => "A good thing to measure"
-     * await kpi.save()
-     * kpi.isDirty
-     * => false
-     * kpi.name = "Another good thing to measure"
-     * kpi.isDirty
-     * => true
-     * await kpi.save()
-     * kpi.isDirty
-     * => false
-     * ```
-     * @property isDirty
-     * @type {Boolean}
-     */
-    get: function get() {
-      return this._dirtyAttributes.size > 0 || this._dirtyRelationships.size > 0;
-    }
-    /**
-     * have any changes been made since this record was last persisted?
-     * @property hasUnpersistedChanges
-     * @type {Boolean}
-     */
-
-  }, {
-    key: "hasUnpersistedChanges",
-    get: function get() {
-      return this.isDirty || !this.previousSnapshot.persisted;
-    }
-    /**
-     * True if the model has not been sent to the store
-     * @property isNew
-     * @type {Boolean}
-     */
-
-  }, {
-    key: "isNew",
-    get: function get() {
-      var id = this.id;
-      if (!id) return true;
-      if (String(id).indexOf('tmp') === -1) return false;
-      return true;
-    }
-    /**
-     * True if the instance is coming from / going to the server
-     * ```
-     * kpi = store.find('kpis', 5)
-     * // fetch started
-     * kpi.isInFlight
-     * => true
-     * // fetch finished
-     * kpi.isInFlight
-     * => false
-     * ```
-     * @property isInFlight
-     * @type {Boolean}
-     * @default false
-     */
-
-  }, {
-    key: "snapshot",
-    get: function get() {
-      return {
-        attributes: this.attributes,
-        relationships: mobx.toJS(this.relationships)
-      };
-    }
-  }, {
-    key: "previousSnapshot",
-    get: function get() {
-      var length = this._snapshots.length;
-      if (length === 0) throw new Error('Invariant violated: model has no snapshots');
-      return this._snapshots[length - 1];
-    }
-    /**
-     * the latest persisted snapshot or the first snapshot if the model was never persisted
-     *
-     * @method previousSnapshot
-     */
-
-  }, {
-    key: "persistedSnapshot",
-    get: function get() {
-      return findLast(this._snapshots, function (ss) {
-        return ss.persisted;
-      }) || this._snapshots[0];
-    }
-  }, {
     key: "dirtyAttributes",
     get: function get() {
       var relationships = Array.from(this._dirtyRelationships).map(function (property) {
@@ -1262,10 +1062,10 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
   }, {
     key: "attributes",
     get: function get() {
-      var _this8 = this;
+      var _this5 = this;
 
       return this.attributeNames.reduce(function (attributes, key) {
-        var value = mobx.toJS(_this8[key]);
+        var value = mobx.toJS(_this5[key]);
 
         if (value == null) {
           delete attributes[key];
@@ -1314,6 +1114,25 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
     get: function get() {
       return Object.keys(this.errors).length > 0;
     }
+    /**
+     * Getter to check if the record has errors.
+     *
+     * @method hasErrors
+     * @return {Boolean}
+     */
+
+  }, {
+    key: "errorForKey",
+    value: function errorForKey(key) {
+      return this.errors[key];
+    }
+    /**
+     * Getter to just get the names of a records attributes.
+     *
+     * @method attributeNames
+     * @return {Array}
+     */
+
   }, {
     key: "attributeNames",
     get: function get() {
@@ -1349,6 +1168,187 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
       }, {
         relationships: {}
       });
+    }
+    /**
+     * getter method to get data in api compliance format
+     * TODO: Figure out how to handle unpersisted ids
+     *
+     * @method jsonapi
+     * @return {Object} data in JSON::API format
+     */
+
+  }, {
+    key: "jsonapi",
+    value: function jsonapi() {
+      var _this6 = this;
+
+      var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+      var attributeDefinitions = this.attributeDefinitions,
+          attributeNames = this.attributeNames,
+          meta = this.meta,
+          id = this.id,
+          type = this.constructor.type;
+      var filteredAttributeNames = attributeNames;
+      var filteredRelationshipNames = [];
+
+      if (options.attributes) {
+        filteredAttributeNames = attributeNames.filter(function (name) {
+          return options.attributes.includes(name);
+        });
+      }
+
+      var attributes = filteredAttributeNames.reduce(function (attrs, key) {
+        var value = _this6[key];
+
+        if (value) {
+          var DataType = attributeDefinitions[key].dataType;
+          var attr;
+
+          if (DataType.name === 'Array' || DataType.name === 'Object') {
+            attr = mobx.toJS(value);
+          } else if (DataType.name === 'Date') {
+            attr = makeDate(value).toISOString();
+          } else {
+            attr = DataType(value);
+          }
+
+          attrs[key] = attr;
+        } else {
+          attrs[key] = value;
+        }
+
+        return attrs;
+      }, {});
+      var data = {
+        type: type,
+        attributes: attributes,
+        id: String(id)
+      };
+
+      if (options.relationships) {
+        filteredRelationshipNames = Object.keys(this.relationships).filter(function (name) {
+          return options.relationships.includes(name);
+        });
+        var relationships = filteredRelationshipNames.reduce(function (rels, key) {
+          rels[key] = mobx.toJS(_this6.relationships[key]);
+          stringifyIds(rels[key]);
+          return rels;
+        }, {});
+        data.relationships = relationships;
+      }
+
+      if (meta) {
+        data['meta'] = meta;
+      }
+
+      if (String(id).match(/tmp/)) {
+        delete data.id;
+      }
+
+      return data;
+    }
+  }, {
+    key: "updateAttributes",
+    value: function updateAttributes(attributes) {
+      var _this7 = this;
+
+      mobx.transaction(function () {
+        Object.keys(attributes).forEach(function (key) {
+          _this7[key] = attributes[key];
+        });
+      });
+    } // TODO: this shares a lot of functionality with Store.createOrUpdateModel
+    // Perhaps that shared code
+
+  }, {
+    key: "updateAttributesFromResponse",
+    value: function updateAttributesFromResponse(data, included) {
+      var _this8 = this;
+
+      var tmpId = this.id;
+      var id = data.id,
+          attributes = data.attributes,
+          relationships = data.relationships;
+      mobx.transaction(function () {
+        mobx.set(_this8, 'id', id);
+        Object.keys(attributes).forEach(function (key) {
+          mobx.set(_this8, key, attributes[key]);
+        });
+
+        if (relationships) {
+          Object.keys(relationships).forEach(function (key) {
+            if (!relationships[key].hasOwnProperty('meta')) {
+              // todo: throw error if relationship is not defined in model
+              mobx.set(_this8.relationships, key, relationships[key]);
+            }
+          });
+        }
+
+        if (included) {
+          _this8.store.createModelsFromData(included);
+        }
+      }); // Update target isInFlight
+
+      this.isInFlight = false;
+
+      this._takeSnapshot({
+        persisted: true
+      });
+
+      mobx.transaction(function () {
+        // NOTE: This resolves an issue where a record is persisted but the
+        // index key is still a temp uuid. We can't simply remove the temp
+        // key because there may be associated records that have the temp
+        // uuid id as its only reference to the newly persisted record.
+        // TODO: Figure out a way to update associated records to use the
+        // newly persisted id.
+        _this8.store.data[_this8.type].records.set(String(tmpId), _this8);
+
+        _this8.store.data[_this8.type].records.set(String(_this8.id), _this8);
+      });
+    }
+  }, {
+    key: "clone",
+    value: function clone() {
+      var attributes = cloneDeep(this.snapshot.attributes);
+      var relationships = cloneDeep(this.snapshot.relationships);
+      return this.store.createModel(this.type, this.id, {
+        attributes: attributes,
+        relationships: relationships
+      });
+    }
+    /**
+     * Comparison by value
+     * returns `true` if this object has the same attrs and relationships
+     * as the "other" object, ignores differences in internal state like
+     * attribute "dirtyness" or errors
+     *
+     * @method isEqual
+     * @param {Object} other
+     * @return {Object}
+     */
+
+  }, {
+    key: "isEqual",
+    value: function isEqual(other) {
+      if (!other) return false;
+      return _isEqual(this.attributes, other.attributes) && _isEqual(this.relationships, other.relationships);
+    }
+    /**
+     * Comparison by identity
+     * returns `true` if this object has the same type and id as the
+     * "other" object, ignores differences in attrs and relationships
+     *
+     * @method isSame
+     * @param {Object} other
+     * @return {Object}
+     */
+
+  }, {
+    key: "isSame",
+    value: function isSame(other) {
+      if (!other) return false;
+      return this.type === other.type && this.id === other.id;
     }
   }]);
 
@@ -1502,44 +1502,87 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
 
     _initializerDefineProperty(this, "remove", _descriptor3$1, this);
 
-    this.findOne = function (type, id) {
+    this.getOne = function (type, id) {
       var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
-      var fromServer = options.fromServer,
-          queryParams = options.queryParams;
+      var queryParams = options.queryParams;
 
-      if (fromServer === true) {
-        // If fromServer is true always fetch the data and return
-        return _this.fetchOne(type, id, queryParams);
-      } else if (fromServer === false) {
-        // If fromServer is false never fetch the data and return
-        return _this.getRecord(type, id, queryParams);
+      if (queryParams) {
+        return _this.getCachedRecord(type, id, queryParams);
       } else {
-        return _this.findOrFetchOne(type, id, queryParams);
+        return _this.getRecord(type, id);
       }
     };
 
-    this.findOrFetchOne = function (type, id, queryParams) {
-      // Get the matching record
-      var record = _this.getMatchingRecord(type, id, queryParams); // If the cached record is present
+    this.findOne = function (type, id) {
+      var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+      var fromServer = options.fromServer;
 
+      if ([true, false].includes(fromServer)) {
+        console.warn('DeprecationWarning: using `fromServer` options is deprecated and will be removed - use getOne, fetchOne, or findOne.');
+      }
 
-      if (record && record.id) {
-        // Return data
+      if (fromServer === true) {
+        return _this.fetchOne(type, id, options);
+      } else if (fromServer === false) {
+        return _this.getOne(type, id, options);
+      }
+
+      var record = _this.getOne(type, id, options);
+
+      if (record !== null && record !== void 0 && record.id) {
         return record;
       } else {
-        // Otherwise fetch it from the server
-        return _this.fetchOne(type, id, queryParams);
+        return _this.fetchOne(type, id, options);
       }
+    };
+
+    this.getMany = function (type, ids) {
+      var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+      var idsToQuery = ids.slice().map(String);
+
+      var records = _this.getAll(type, options);
+
+      return records.filter(function (record) {
+        return idsToQuery.includes(record.id);
+      });
+    };
+
+    this.fetchMany = function (type, ids) {
+      var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+      var idsToQuery = ids.slice().map(String);
+      var queryParams = options.queryParams || {};
+      queryParams.filter = queryParams.filter || {};
+
+      var baseUrl = _this.fetchUrl(type, queryParams);
+
+      var idQueries = deriveIdQueryStrings(idsToQuery, baseUrl);
+      var queries = idQueries.map(function (queryIds) {
+        queryParams.filter.ids = queryIds;
+        return _this.fetchAll(type, {
+          queryParams: queryParams
+        });
+      });
+      return Promise.all(queries).then(function (records) {
+        var _ref2;
+
+        return (_ref2 = []).concat.apply(_ref2, _toConsumableArray(records));
+      }).catch(function (err) {
+        return Promise.reject(err);
+      });
     };
 
     this.findMany = function (type, ids) {
       var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
       var fromServer = options.fromServer;
+
+      if ([true, false].includes(fromServer)) {
+        console.warn('DeprecationWarning: using `fromServer` options is deprecated and will be removed - use getMany, fetchMany, or findMany.');
+      }
+
       var idsToQuery = ids.slice().map(String);
 
       if (fromServer === false) {
-        // If fromServer is false never fetch the data and return
-        return _this.getRecords(type).filter(function (record) {
+        return _this.getAll(type).filter(function (record) {
           return idsToQuery.includes(record.id);
         });
       }
@@ -1552,15 +1595,13 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
         });
 
         if (recordsInStore.length === idsToQuery.length) {
-          // if fromServer is not false or true, but all the records are in store, wrap it in a promise
-          return Promise.resolve(recordsInStore);
+          return recordsInStore;
         }
 
-        var recordIdsInStore = recordsInStore.map(function (_ref2) {
-          var id = _ref2.id;
+        var recordIdsInStore = recordsInStore.map(function (_ref3) {
+          var id = _ref3.id;
           return String(id);
-        }); // If fromServer is not true, we will only query records that are not already in the store
-
+        });
         idsToQuery = idsToQuery.filter(function (id) {
           return !recordIdsInStore.includes(id);
         });
@@ -1574,7 +1615,9 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
       var idQueries = deriveIdQueryStrings(idsToQuery, baseUrl);
       var query = Promise.all(idQueries.map(function (queryIds) {
         queryParams.filter.ids = queryIds;
-        return _this.fetchAll(type, queryParams);
+        return _this.fetchAll(type, {
+          queryParams: queryParams
+        });
       }));
       return query.then(function (recordsFromServer) {
         var _recordsInStore;
@@ -1583,69 +1626,38 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
       });
     };
 
+    this.getAll = function (type) {
+      var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+      var queryParams = options.queryParams;
+
+      if (queryParams) {
+        return _this.getCachedRecords(type, queryParams);
+      } else {
+        return _this.getRecords(type);
+      }
+    };
+
     this.findAll = function (type) {
       var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-      var fromServer = options.fromServer,
-          queryParams = options.queryParams;
+      var fromServer = options.fromServer;
+
+      if ([true, false].includes(fromServer)) {
+        console.warn('DeprecationWarning: using `fromServer` options is deprecated and will be removed - use getAll, fetchAll, or findAll.');
+      }
 
       if (fromServer === true) {
-        // If fromServer is true always fetch the data and return
-        return _this.fetchAll(type, queryParams);
+        return _this.fetchAll(type, options);
       } else if (fromServer === false) {
-        // If fromServer is false never fetch the data and return
-        return _this.getMatchingRecords(type, queryParams) || [];
+        var records = _this.getAll(type, options) || [];
+        return records;
       } else {
-        return _this.findOrFetchAll(type, queryParams) || [];
-      }
-    };
+        var _records = _this.getAll(type, options);
 
-    this.findAndFetchAll = function (type) {
-      var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-      var beforeFetch = options.beforeFetch,
-          afterFetch = options.afterFetch,
-          beforeRefetch = options.beforeRefetch,
-          afterRefetch = options.afterRefetch,
-          afterError = options.afterError,
-          queryParams = options.queryParams;
-
-      var records = _this.getMatchingRecords(type, queryParams); // NOTE: See note findOrFetchAll about this conditional logic.
-
-
-      if (records.length > 0) {
-        beforeRefetch && beforeRefetch(records);
-
-        _this.fetchAll(type, queryParams).then(function (result) {
-          return afterRefetch && afterRefetch(result);
-        }).catch(function (error) {
-          return afterError && afterError(error);
-        });
-      } else {
-        beforeFetch && beforeFetch(records);
-
-        _this.fetchAll(type, queryParams).then(function (result) {
-          return afterFetch && afterFetch(result);
-        }).catch(function (error) {
-          return afterError && afterError(error);
-        });
-      }
-
-      return records || [];
-    };
-
-    this.findOrFetchAll = function (type, queryParams) {
-      // Get any matching records
-      var records = _this.getMatchingRecords(type, queryParams); // NOTE: A broader RFC is in development to improve how we keep data in sync
-      // with the server. We likely will want to getMatchingRecords and getRecords
-      // to return null if nothing is found. However, this causes several regressions
-      // in portal we will need to address in a larger PR for mobx-async-store updates.
-
-
-      if (records.length > 0) {
-        // Return data
-        return Promise.resolve(records);
-      } else {
-        // Otherwise fetch it from the server
-        return _this.fetchAll(type, queryParams);
+        if (_records.length > 0) {
+          return Promise.resolve(_records);
+        } else {
+          return _this.fetchAll(type, options);
+        }
       }
     };
 
@@ -1667,8 +1679,277 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
 
 
   _createClass(Store, [{
-    key: "reset",
+    key: "fetchOne",
+    value:
+    /**
+     * Fetches record by `id` from the server and returns a Promise.
+     *
+     * @async
+     * @method fetchOne
+     * @param {String} type the record type to fetch
+     * @param {String} id the id of the record to fetch
+     * @param {Object} options { queryParams }
+     * @return {Object} record
+     */
+    function () {
+      var _fetchOne = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee2(type, id) {
+        var options,
+            queryParams,
+            url,
+            response,
+            json,
+            data,
+            included,
+            record,
+            _args2 = arguments;
+        return _regeneratorRuntime.wrap(function _callee2$(_context2) {
+          while (1) {
+            switch (_context2.prev = _context2.next) {
+              case 0:
+                options = _args2.length > 2 && _args2[2] !== undefined ? _args2[2] : {};
+                queryParams = options.queryParams;
+                url = this.fetchUrl(type, queryParams, id);
+                _context2.next = 5;
+                return this.fetch(url, {
+                  method: 'GET'
+                });
 
+              case 5:
+                response = _context2.sent;
+
+                if (!(response.status === 200)) {
+                  _context2.next = 17;
+                  break;
+                }
+
+                _context2.next = 9;
+                return response.json();
+
+              case 9:
+                json = _context2.sent;
+                data = json.data, included = json.included;
+
+                if (included) {
+                  this.createModelsFromData(included);
+                }
+
+                record = this.createOrUpdateModel(data);
+                this.data[type].cache.set(url, [record.id]);
+                return _context2.abrupt("return", record);
+
+              case 17:
+                return _context2.abrupt("return", null);
+
+              case 18:
+              case "end":
+                return _context2.stop();
+            }
+          }
+        }, _callee2, this);
+      }));
+
+      function fetchOne(_x4, _x5) {
+        return _fetchOne.apply(this, arguments);
+      }
+
+      return fetchOne;
+    }()
+    /**
+     * Finds a record by `id`.
+     * If available in the store, it returns that record. Otherwise, it fetches the record from the server.
+     *
+     *   store.findOne('todos', 5)
+     *   // fetch triggered
+     *   => event1
+     *   store.findOne('todos', 5)
+     *   // no fetch triggered
+     *   => event1
+     *
+     * Deprecated: Passing `fromServer` as an option will always trigger a fetch if `true` and never trigger a fetch if `false`.
+     * Otherwise, it will trigger the default behavior
+     *
+     *   store.findOne('todos', 5, { fromServer: false })
+     *   // no fetch triggered
+     *   => undefined
+     *
+     *   store.findOne('todos', 5)
+     *   // fetch triggered
+     *   => event1
+     *
+     *   store.findOne('todos', 5, { fromServer: true })
+     *   // fetch triggered
+     *   => event1
+     *
+     * @method findOne
+     * @param {String} type the type to find
+     * @param {String} id the id of the record to find
+     * @param {Object} options { fromServer, queryParams }
+     * @return {Object} record
+     */
+
+  }, {
+    key: "fetchUrl",
+    value:
+    /**
+     * Builds fetch url based
+     *
+     * @method fetchUrl
+     * @param {String} type the type to find
+     * @param {Object} options
+     */
+    function fetchUrl(type, queryParams, id, options) {
+      var baseUrl = this.baseUrl,
+          modelTypeIndex = this.modelTypeIndex;
+      var endpoint = modelTypeIndex[type].endpoint;
+      return requestUrl(baseUrl, endpoint, queryParams, id, options);
+    }
+    /**
+     * Gets all records with the given `type` from the store. This will never fetch from the server.
+     *
+     * @method getAll
+     * @param {String} type the type to find
+     * @param {Object} options
+     * @return {Array} array of records
+     */
+
+  }, {
+    key: "fetchAll",
+    value:
+    /**
+     * Finds all records with the given `type`. Always fetches from the server.
+     *
+     * @async
+     * @method fetchAll
+     * @param {String} type the type to find
+     * @param {Object} options
+     * @return {Promise} Promise.resolve(records) or Promise.reject(status)
+     */
+    function () {
+      var _fetchAll = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee3(type) {
+        var _this2 = this;
+
+        var options,
+            store,
+            queryParams,
+            url,
+            response,
+            json,
+            _args3 = arguments;
+        return _regeneratorRuntime.wrap(function _callee3$(_context3) {
+          while (1) {
+            switch (_context3.prev = _context3.next) {
+              case 0:
+                options = _args3.length > 1 && _args3[1] !== undefined ? _args3[1] : {};
+                store = this;
+                queryParams = options.queryParams;
+                url = this.fetchUrl(type, queryParams);
+                _context3.next = 6;
+                return this.fetch(url, {
+                  method: 'GET'
+                });
+
+              case 6:
+                response = _context3.sent;
+
+                if (!(response.status === 200)) {
+                  _context3.next = 16;
+                  break;
+                }
+
+                this.data[type].cache.set(url, []);
+                _context3.next = 11;
+                return response.json();
+
+              case 11:
+                json = _context3.sent;
+
+                if (json.included) {
+                  this.createModelsFromData(json.included);
+                }
+
+                return _context3.abrupt("return", mobx.transaction(function () {
+                  return json.data.map(function (dataObject) {
+                    var id = dataObject.id,
+                        _dataObject$attribute = dataObject.attributes,
+                        attributes = _dataObject$attribute === void 0 ? {} : _dataObject$attribute,
+                        _dataObject$relations = dataObject.relationships,
+                        relationships = _dataObject$relations === void 0 ? {} : _dataObject$relations;
+                    var ModelKlass = _this2.modelTypeIndex[type];
+                    var record = new ModelKlass(_objectSpread$2({
+                      store: store,
+                      relationships: relationships
+                    }, attributes));
+
+                    var cachedIds = _this2.data[type].cache.get(url);
+
+                    _this2.data[type].cache.set(url, [].concat(_toConsumableArray(cachedIds), [id]));
+
+                    _this2.data[type].records.set(String(id), record);
+
+                    return record;
+                  });
+                }));
+
+              case 16:
+                return _context3.abrupt("return", Promise.reject(response.status));
+
+              case 17:
+              case "end":
+                return _context3.stop();
+            }
+          }
+        }, _callee3, this);
+      }));
+
+      function fetchAll(_x6) {
+        return _fetchAll.apply(this, arguments);
+      }
+
+      return fetchAll;
+    }()
+    /**
+     * Finds all records of the given `type`.
+     * If all records are in the store, it returns those.
+     * Otherwise, it fetches all records from the server.
+     * Deprecated: Passing `fromServer` as an option will fetch all records from the server if `true` and never fetch from the server if `false`.
+     *
+     *   store.findAll('todos')
+     *   // fetch triggered
+     *   => [todo1, todo2, todo3]
+     *
+     *   store.findAll('todos')
+     *   // no fetch triggered
+     *   => [todo1, todo2, todo3]
+     *
+     * Query params can be passed as part of the options hash.
+     * The response will be cached, so the next time `findAll`
+     * is called with identical params and values, the store will
+     * first look for the local result.
+     *
+     *   store.findAll('todos', {
+     *     queryParams: {
+     *       filter: {
+     *         start_time: '2020-06-01T00:00:00.000Z',
+     *         end_time: '2020-06-02T00:00:00.000Z'
+     *       }
+     *     }
+     *   })
+     *
+     *
+     * NOTE: A broader RFC is in development to improve how we keep data in sync
+     * with the server. We likely will want to getAll and getRecords
+     * to return null if nothing is found. However, this causes several regressions
+     * in portal we will need to address in a larger PR for mobx-async-store updates.
+     *
+     * @method findAll
+     * @param {String} type the type to find
+     * @param {Object} options { fromServer, queryParams }
+     * @return {Promise} Promise.resolve(records) or Promise.reject(status)
+     */
+
+  }, {
+    key: "reset",
+    value:
     /**
      * Clears the store of a given type, or clears all if no type given
      *
@@ -1679,7 +1960,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
      *
      * @method reset
      */
-    value: function reset(type) {
+    function reset(type) {
       if (type) {
         this.data[type] = {
           records: mobx.observable.map({}),
@@ -1747,13 +2028,13 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
   }, {
     key: "initializeObservableDataProperty",
     value: function initializeObservableDataProperty() {
-      var _this2 = this;
+      var _this3 = this;
 
       var types = this.constructor.types; // NOTE: Is there a performance cost to setting
       // each property individually?
 
       types.forEach(function (modelKlass) {
-        _this2.data[modelKlass.type] = {
+        _this3.data[modelKlass.type] = {
           records: mobx.observable.map({}),
           cache: mobx.observable.map({})
         };
@@ -1792,7 +2073,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
       return combineRacedRequests(key, function () {
         return fetch(url, _objectSpread$2(_objectSpread$2({}, defaultFetchOptions), options));
       });
-    })
+    }
     /**
      * Gets type of collection from data observable
      *
@@ -1800,31 +2081,11 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
      * @param {String} type
      * @return {Object} observable type object structure
      */
-
+    )
   }, {
     key: "getType",
     value: function getType(type) {
       return this.data[type];
-    }
-    /**
-     * Get single all record
-     * based on query params
-     *
-     * @method getMatchingRecord
-     * @param {String} type
-     * @param id
-     * @param {Object} queryParams
-     * @return {Array} array or records
-     */
-
-  }, {
-    key: "getMatchingRecord",
-    value: function getMatchingRecord(type, id, queryParams) {
-      if (queryParams) {
-        return this.getCachedRecord(type, id, queryParams);
-      } else {
-        return this.getRecord(type, id);
-      }
     }
     /**
      * Gets individual record from store
@@ -1849,6 +2110,13 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
     /**
      * Gets records for type of collection from observable
      *
+     * NOTE: We only return records by unique id, this handles a scenario
+     * where the store keeps around a reference to a newly persisted record by its temp uuid.
+     * We can't simply remove the temp uuid reference because other
+     * related models may be still using the temp uuid in their relationships
+     * data object. However, when we are listing out records we want them
+     * to be unique by the persisted id (which is updated after a Model.save)
+     *
      * @method getRecords
      * @param {String} type
      * @return {Array} array of objects
@@ -1859,14 +2127,32 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
     value: function getRecords(type) {
       var records = Array.from(this.getType(type).records.values()).filter(function (value) {
         return value && value !== 'undefined';
-      }); // NOTE: Handles a scenario where the store keeps around a reference
-      // to a newly persisted record by its temp uuid. This is required
-      // because we can't simply remove the temp uuid reference because other
-      // related models may be still using the temp uuid in their relationships
-      // data object. However, when we are listing out records we want them
-      // to be unique by the persisted id (which is updated after a Model.save)
-
+      });
       return uniqueBy(records, 'id');
+    }
+    /**
+     * Get multiple records by id
+     *
+     * @method getRecordsById
+     * @param {String} type
+     * @param {Array} ids
+     * @return {Array} array or records
+     */
+
+  }, {
+    key: "getRecordsById",
+    value: function getRecordsById(type) {
+      var _this4 = this;
+
+      var ids = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : [];
+      // NOTE: Is there a better way to do this?
+      return ids.map(function (id) {
+        return _this4.getRecord(type, id);
+      }).filter(function (record) {
+        return record;
+      }).filter(function (record) {
+        return typeof record !== 'undefined';
+      });
     }
     /**
      * Gets single from store based on cached query
@@ -1875,7 +2161,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
      * @param {String} type
      * @param id
      * @param {Object} queryParams
-     * @return {Array} array or records
+     * @return {Object} record
      */
 
   }, {
@@ -1888,9 +2174,10 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
      * Gets records from store based on cached query
      *
      * @method getCachedRecords
-     * @param {String} type
+     * @param {String} type type of records to get
      * @param {Object} queryParams
-     * @return {Array} array or records
+     * @param {String} id optional param if only getting 1 cached record by id
+     * @return {Array} array of records
      */
 
   }, {
@@ -1935,49 +2222,6 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
       return this.getType(type).cache.get(String(id));
     }
     /**
-     * Get multiple records by id
-     *
-     * @method getRecordsById
-     * @param {String} type
-     * @param {Array} ids
-     * @return {Array} array or records
-     */
-
-  }, {
-    key: "getRecordsById",
-    value: function getRecordsById(type) {
-      var _this3 = this;
-
-      var ids = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : [];
-      // NOTE: Is there a better way to do this?
-      return ids.map(function (id) {
-        return _this3.getRecord(type, id);
-      }).filter(function (record) {
-        return record;
-      }).filter(function (record) {
-        return typeof record !== 'undefined';
-      });
-    }
-    /**
-     * Gets records all records or records
-     * based on query params
-     *
-     * @method getMatchingRecords
-     * @param {String} type
-     * @param {Object} queryParams
-     * @return {Array} array or records
-     */
-
-  }, {
-    key: "getMatchingRecords",
-    value: function getMatchingRecords(type, queryParams) {
-      if (queryParams) {
-        return this.getCachedRecords(type, queryParams);
-      } else {
-        return this.getRecords(type);
-      }
-    }
-    /**
      * Helper to look up model class for type.
      *
      * @method getKlass
@@ -2000,11 +2244,11 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
   }, {
     key: "createOrUpdateModel",
     value: function createOrUpdateModel(dataObject) {
-      var _dataObject$attribute = dataObject.attributes,
-          attributes = _dataObject$attribute === void 0 ? {} : _dataObject$attribute,
+      var _dataObject$attribute2 = dataObject.attributes,
+          attributes = _dataObject$attribute2 === void 0 ? {} : _dataObject$attribute2,
           id = dataObject.id,
-          _dataObject$relations = dataObject.relationships,
-          relationships = _dataObject$relations === void 0 ? {} : _dataObject$relations,
+          _dataObject$relations2 = dataObject.relationships,
+          relationships = _dataObject$relations2 === void 0 ? {} : _dataObject$relations2,
           type = dataObject.type;
       var record = this.getRecord(type, id);
 
@@ -2047,15 +2291,15 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
   }, {
     key: "createModelsFromData",
     value: function createModelsFromData(data) {
-      var _this4 = this;
+      var _this5 = this;
 
       return mobx.transaction(function () {
         return data.map(function (dataObject) {
           // Only build objects for which we have a type defined.
           // And ignore silently anything else included in the JSON response.
           // TODO: Put some console message in development mode
-          if (_this4.getType(dataObject.type)) {
-            return _this4.createOrUpdateModel(dataObject);
+          if (_this5.getType(dataObject.type)) {
+            return _this5.createOrUpdateModel(dataObject);
           }
         });
       });
@@ -2093,172 +2337,6 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
       }, attributes));
     }
     /**
-     * Builds fetch url based
-     *
-     * @method fetchUrl
-     * @param {String} type the type to find
-     * @param {Object} options
-     */
-
-  }, {
-    key: "fetchUrl",
-    value: function fetchUrl(type, queryParams, id, options) {
-      var baseUrl = this.baseUrl,
-          modelTypeIndex = this.modelTypeIndex;
-      var endpoint = modelTypeIndex[type].endpoint;
-      return requestUrl(baseUrl, endpoint, queryParams, id, options);
-    }
-    /**
-     * finds an instance by `id`. If available in the store, returns that instance. Otherwise, triggers a fetch.
-     *
-     * @method fetchAll
-     * @param {String} type the type to find
-     * @param {Object} options
-     */
-
-  }, {
-    key: "fetchAll",
-    value: function () {
-      var _fetchAll = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee2(type, queryParams) {
-        var _this5 = this;
-
-        var store, url, response, json;
-        return _regeneratorRuntime.wrap(function _callee2$(_context2) {
-          while (1) {
-            switch (_context2.prev = _context2.next) {
-              case 0:
-                store = this;
-                url = this.fetchUrl(type, queryParams);
-                _context2.next = 4;
-                return this.fetch(url, {
-                  method: 'GET'
-                });
-
-              case 4:
-                response = _context2.sent;
-
-                if (!(response.status === 200)) {
-                  _context2.next = 14;
-                  break;
-                }
-
-                this.data[type].cache.set(url, []);
-                _context2.next = 9;
-                return response.json();
-
-              case 9:
-                json = _context2.sent;
-
-                if (json.included) {
-                  this.createModelsFromData(json.included);
-                }
-
-                return _context2.abrupt("return", mobx.transaction(function () {
-                  return json.data.map(function (dataObject) {
-                    var id = dataObject.id,
-                        _dataObject$attribute2 = dataObject.attributes,
-                        attributes = _dataObject$attribute2 === void 0 ? {} : _dataObject$attribute2,
-                        _dataObject$relations2 = dataObject.relationships,
-                        relationships = _dataObject$relations2 === void 0 ? {} : _dataObject$relations2;
-                    var ModelKlass = _this5.modelTypeIndex[type];
-                    var record = new ModelKlass(_objectSpread$2({
-                      store: store,
-                      relationships: relationships
-                    }, attributes));
-
-                    var cachedIds = _this5.data[type].cache.get(url);
-
-                    _this5.data[type].cache.set(url, [].concat(_toConsumableArray(cachedIds), [id]));
-
-                    _this5.data[type].records.set(String(id), record);
-
-                    return record;
-                  });
-                }));
-
-              case 14:
-                return _context2.abrupt("return", Promise.reject(response.status));
-
-              case 15:
-              case "end":
-                return _context2.stop();
-            }
-          }
-        }, _callee2, this);
-      }));
-
-      function fetchAll(_x4, _x5) {
-        return _fetchAll.apply(this, arguments);
-      }
-
-      return fetchAll;
-    }()
-    /**
-     * fetches record by `id`.
-     *
-     * @async
-     * @method fetchOne
-     * @param {String} type the type to find
-     * @param {String} id
-     */
-
-  }, {
-    key: "fetchOne",
-    value: function () {
-      var _fetchOne = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee3(type, id, queryParams) {
-        var url, response, json, data, included, record;
-        return _regeneratorRuntime.wrap(function _callee3$(_context3) {
-          while (1) {
-            switch (_context3.prev = _context3.next) {
-              case 0:
-                url = this.fetchUrl(type, queryParams, id); // Trigger request
-
-                _context3.next = 3;
-                return this.fetch(url, {
-                  method: 'GET'
-                });
-
-              case 3:
-                response = _context3.sent;
-
-                if (!(response.status === 200)) {
-                  _context3.next = 15;
-                  break;
-                }
-
-                _context3.next = 7;
-                return response.json();
-
-              case 7:
-                json = _context3.sent;
-                data = json.data, included = json.included;
-
-                if (included) {
-                  this.createModelsFromData(included);
-                }
-
-                record = this.createOrUpdateModel(data);
-                this.data[type].cache.set(url, [record.id]);
-                return _context3.abrupt("return", record);
-
-              case 15:
-                return _context3.abrupt("return", null);
-
-              case 16:
-              case "end":
-                return _context3.stop();
-            }
-          }
-        }, _callee3, this);
-      }));
-
-      function fetchOne(_x6, _x7, _x8) {
-        return _fetchOne.apply(this, arguments);
-      }
-
-      return fetchOne;
-    }()
-    /**
      * Defines a resolution for an API call that will update a record or
      * set of records with the data returned from the API
      *
@@ -2279,7 +2357,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
         record.isInFlight = true;
       });
       return promise.then( /*#__PURE__*/function () {
-        var _ref3 = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee4(response) {
+        var _ref4 = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee4(response) {
           var status, json, data, included, _json, errorString;
 
           return _regeneratorRuntime.wrap(function _callee4$(_context4) {
@@ -2369,8 +2447,8 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
           }, _callee4, null, [[16, 22]]);
         }));
 
-        return function (_x9) {
-          return _ref3.apply(this, arguments);
+        return function (_x7) {
+          return _ref4.apply(this, arguments);
         };
       }(), function (error) {
         // TODO: Handle error states correctly, including handling errors for multiple targets
@@ -2571,32 +2649,16 @@ function _objectSpread$3(target) { for (var i = 1; i < arguments.length; i++) { 
  */
 
 function relatedToMany(targetOrModelKlass, property, descriptor) {
-  if (typeof targetOrModelKlass === 'function') {
-    return function (target2, property2, descriptor2) {
-      schema.addRelationship({
-        type: target2.constructor.type,
-        property: property2,
-        dataType: Array
-      });
-      return {
-        get: function get() {
-          var type = targetOrModelKlass.type;
-          return getRelatedRecords(this, property2, type);
-        }
-      };
-    };
-  } else {
-    schema.addRelationship({
-      type: targetOrModelKlass.constructor.type,
-      property: property,
-      dataType: Array
-    });
-    return {
-      get: function get() {
-        return getRelatedRecords(this, property);
-      }
-    };
-  }
+  schema.addRelationship({
+    type: targetOrModelKlass.constructor.type,
+    property: property,
+    dataType: Array
+  });
+  return {
+    get: function get() {
+      return getRelatedRecords(this, property);
+    }
+  };
 }
 /**
  * Syntactic sugar of relatedToMany relationship. Basically
@@ -2606,39 +2668,19 @@ function relatedToMany(targetOrModelKlass, property, descriptor) {
  */
 
 function relatedToOne(targetOrModelKlass, property, descriptor) {
-  if (typeof targetOrModelKlass === 'function') {
-    return function (target2, property2, descriptor2) {
-      schema.addRelationship({
-        type: target2.constructor.type,
-        property: property2,
-        dataType: Object
-      });
-      return {
-        get: function get() {
-          var type = targetOrModelKlass.type;
-          return getRelatedRecord(this, property2, type);
-        },
-        set: function set(record) {
-          var type = targetOrModelKlass.type;
-          return setRelatedRecord(this, record, property2, type);
-        }
-      };
-    };
-  } else {
-    schema.addRelationship({
-      type: targetOrModelKlass.constructor.type,
-      property: property,
-      dataType: Object
-    });
-    return {
-      get: function get() {
-        return getRelatedRecord(this, property);
-      },
-      set: function set(record) {
-        return setRelatedRecord(this, record, property);
-      }
-    };
-  }
+  schema.addRelationship({
+    type: targetOrModelKlass.constructor.type,
+    property: property,
+    dataType: Object
+  });
+  return {
+    get: function get() {
+      return getRelatedRecord(this, property);
+    },
+    set: function set(record) {
+      return setRelatedRecord(this, record, property);
+    }
+  };
 }
 /**
  * Handles getting polymorphic records or only a specific
@@ -2876,7 +2918,10 @@ var RelatedRecordsArray = /*#__PURE__*/function (_Array) {
         var referenceIndexToRemove = relationships[property].data.findIndex(function (model) {
           return model.id.toString() === id.toString() && model.type === type;
         });
-        if (referenceIndexToRemove >= 0) relationships[property].data.splice(referenceIndexToRemove, 1);
+
+        if (referenceIndexToRemove >= 0) {
+          relationships[property].data.splice(referenceIndexToRemove, 1);
+        }
 
         var recordIndexToRemove = _this.findIndex(function (model) {
           return model.id.toString() === id.toString() && model.type === type;

--- a/docs/classes/Model.html
+++ b/docs/classes/Model.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.2.9</em>
+            <em>API Docs for: 3.3.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/RelatedRecordsArray.html
+++ b/docs/classes/RelatedRecordsArray.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.2.9</em>
+            <em>API Docs for: 3.3.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -84,7 +84,7 @@
 
 
         <div class="foundat">
-            Defined in: <a href="../files/src_decorators_relationships.js.html#l224"><code>src&#x2F;decorators&#x2F;relationships.js:224</code></a>
+            Defined in: <a href="../files/src_decorators_relationships.js.html#l207"><code>src&#x2F;decorators&#x2F;relationships.js:207</code></a>
         </div>
 
 
@@ -125,7 +125,7 @@
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_decorators_relationships.js.html#l224"><code>src&#x2F;decorators&#x2F;relationships.js:224</code></a>
+        <a href="../files/src_decorators_relationships.js.html#l207"><code>src&#x2F;decorators&#x2F;relationships.js:207</code></a>
         </p>
 
 
@@ -274,7 +274,7 @@
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_decorators_relationships.js.html#l255"><code>src&#x2F;decorators&#x2F;relationships.js:255</code></a>
+        <a href="../files/src_decorators_relationships.js.html#l238"><code>src&#x2F;decorators&#x2F;relationships.js:238</code></a>
         </p>
 
 
@@ -396,7 +396,7 @@ Attributes can be defined with a default.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_decorators_relationships.js.html#l150"><code>src&#x2F;decorators&#x2F;relationships.js:150</code></a>
+        <a href="../files/src_decorators_relationships.js.html#l121"><code>src&#x2F;decorators&#x2F;relationships.js:121</code></a>
         </p>
 
 
@@ -439,7 +439,7 @@ Attributes can be defined with a default.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_decorators_relationships.js.html#l94"><code>src&#x2F;decorators&#x2F;relationships.js:94</code></a>
+        <a href="../files/src_decorators_relationships.js.html#l56"><code>src&#x2F;decorators&#x2F;relationships.js:56</code></a>
         </p>
 
 
@@ -573,7 +573,7 @@ type if specified.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_decorators_relationships.js.html#l51"><code>src&#x2F;decorators&#x2F;relationships.js:51</code></a>
+        <a href="../files/src_decorators_relationships.js.html#l34"><code>src&#x2F;decorators&#x2F;relationships.js:34</code></a>
         </p>
 
 
@@ -614,7 +614,7 @@ everything the same except it only returns a single record.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_decorators_relationships.js.html#l297"><code>src&#x2F;decorators&#x2F;relationships.js:297</code></a>
+        <a href="../files/src_decorators_relationships.js.html#l293"><code>src&#x2F;decorators&#x2F;relationships.js:293</code></a>
         </p>
 
 
@@ -686,7 +686,7 @@ everything the same except it only returns a single record.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_decorators_relationships.js.html#l175"><code>src&#x2F;decorators&#x2F;relationships.js:175</code></a>
+        <a href="../files/src_decorators_relationships.js.html#l146"><code>src&#x2F;decorators&#x2F;relationships.js:146</code></a>
         </p>
 
 

--- a/docs/classes/Schema.html
+++ b/docs/classes/Schema.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.2.9</em>
+            <em>API Docs for: 3.3.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Store.html
+++ b/docs/classes/Store.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.2.9</em>
+            <em>API Docs for: 3.3.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -84,7 +84,7 @@
 
 
         <div class="foundat">
-            Defined in: <a href="../files/src_Store.js.html#l5"><code>src&#x2F;Store.js:5</code></a>
+            Defined in: <a href="../files/src_Store.js.html#l12"><code>src&#x2F;Store.js:12</code></a>
         </div>
 
 
@@ -113,7 +113,7 @@
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l5"><code>src&#x2F;Store.js:5</code></a>
+        <a href="../files/src_Store.js.html#l12"><code>src&#x2F;Store.js:12</code></a>
         </p>
 
 
@@ -191,6 +191,10 @@
 
                             </li>
                             <li class="index-item method">
+                                <a href="#method_fetchMany">fetchMany</a>
+
+                            </li>
+                            <li class="index-item method">
                                 <a href="#method_fetchOne">fetchOne</a>
 
                             </li>
@@ -203,10 +207,6 @@
 
                             </li>
                             <li class="index-item method">
-                                <a href="#method_findAndFetchAll">findAndFetchAll</a>
-
-                            </li>
-                            <li class="index-item method">
                                 <a href="#method_findMany">findMany</a>
 
                             </li>
@@ -215,11 +215,7 @@
 
                             </li>
                             <li class="index-item method">
-                                <a href="#method_findOrFetchAll">findOrFetchAll</a>
-
-                            </li>
-                            <li class="index-item method">
-                                <a href="#method_findOrFetchOne">findOrFetchOne</a>
+                                <a href="#method_getAll">getAll</a>
 
                             </li>
                             <li class="index-item method">
@@ -243,11 +239,11 @@
 
                             </li>
                             <li class="index-item method">
-                                <a href="#method_getMatchingRecord">getMatchingRecord</a>
+                                <a href="#method_getMany">getMany</a>
 
                             </li>
                             <li class="index-item method">
-                                <a href="#method_getMatchingRecords">getMatchingRecords</a>
+                                <a href="#method_getOne">getOne</a>
 
                             </li>
                             <li class="index-item method">
@@ -341,7 +337,7 @@
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l33"><code>src&#x2F;Store.js:33</code></a>
+        <a href="../files/src_Store.js.html#l40"><code>src&#x2F;Store.js:40</code></a>
         </p>
 
 
@@ -425,7 +421,7 @@ kpi.name
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l74"><code>src&#x2F;Store.js:74</code></a>
+        <a href="../files/src_Store.js.html#l81"><code>src&#x2F;Store.js:81</code></a>
         </p>
 
 
@@ -503,7 +499,7 @@ kpi.name
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l91"><code>src&#x2F;Store.js:91</code></a>
+        <a href="../files/src_Store.js.html#l98"><code>src&#x2F;Store.js:98</code></a>
         </p>
 
 
@@ -581,7 +577,7 @@ kpi.name
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l54"><code>src&#x2F;Store.js:54</code></a>
+        <a href="../files/src_Store.js.html#l61"><code>src&#x2F;Store.js:61</code></a>
         </p>
 
 
@@ -665,7 +661,7 @@ kpi.name
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l101"><code>src&#x2F;Store.js:101</code></a>
+        <a href="../files/src_Store.js.html#l108"><code>src&#x2F;Store.js:108</code></a>
         </p>
 
 
@@ -734,7 +730,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l24"><code>src&#x2F;Store.js:24</code></a>
+        <a href="../files/src_Store.js.html#l31"><code>src&#x2F;Store.js:31</code></a>
         </p>
 
 
@@ -780,7 +776,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l755"><code>src&#x2F;Store.js:755</code></a>
+        <a href="../files/src_Store.js.html#l818"><code>src&#x2F;Store.js:818</code></a>
         </p>
 
 
@@ -862,7 +858,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l738"><code>src&#x2F;Store.js:738</code></a>
+        <a href="../files/src_Store.js.html#l799"><code>src&#x2F;Store.js:799</code></a>
         </p>
 
 
@@ -915,7 +911,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l702"><code>src&#x2F;Store.js:702</code></a>
+        <a href="../files/src_Store.js.html#l760"><code>src&#x2F;Store.js:760</code></a>
         </p>
 
 
@@ -971,7 +967,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l516"><code>src&#x2F;Store.js:516</code></a>
+        <a href="../files/src_Store.js.html#l604"><code>src&#x2F;Store.js:604</code></a>
         </p>
 
 
@@ -1027,17 +1023,21 @@ endpoint. All records need to be of the same type.</p>
             </ul><span class="paren">)</span>
         </div>
 
+        <span class="returns-inline">
+            <span class="type">Promise</span>
+        </span>
 
 
 
 
 
 
+        <span class="flag async">async</span>
 
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l790"><code>src&#x2F;Store.js:790</code></a>
+        <a href="../files/src_Store.js.html#l418"><code>src&#x2F;Store.js:418</code></a>
         </p>
 
 
@@ -1045,7 +1045,7 @@ endpoint. All records need to be of the same type.</p>
     </div>
 
     <div class="description">
-        <p>finds an instance by <code>id</code>. If available in the store, returns that instance. Otherwise, triggers a fetch.</p>
+        <p>Finds all records with the given <code>type</code>. Always fetches from the server.</p>
 
     </div>
 
@@ -1077,6 +1077,109 @@ endpoint. All records need to be of the same type.</p>
             </ul>
         </div>
 
+        <div class="returns">
+            <h4>Returns:</h4>
+
+            <div class="returns-description">
+                        <span class="type">Promise</span>:
+                    <p>Promise.resolve(records) or Promise.reject(status)</p>
+
+            </div>
+        </div>
+
+
+</div>
+<div id="method_fetchMany" class="method item">
+    <h3 class="name"><code>fetchMany</code></h3>
+
+        <div class="args">
+            <span class="paren">(</span><ul class="args-list inline commas">
+                <li class="arg">
+                        <code>type</code>
+                </li>
+                <li class="arg">
+                        <code>ids</code>
+                </li>
+                <li class="arg">
+                        <code>options</code>
+                </li>
+            </ul><span class="paren">)</span>
+        </div>
+
+        <span class="returns-inline">
+            <span class="type">Promise</span>
+        </span>
+
+
+
+
+
+
+
+    <div class="meta">
+                <p>
+                Defined in
+        <a href="../files/src_Store.js.html#l284"><code>src&#x2F;Store.js:284</code></a>
+        </p>
+
+
+
+    </div>
+
+    <div class="description">
+        <p>Fetch all records with the given <code>type</code> and <code>ids</code> from the server.</p>
+
+    </div>
+
+        <div class="params">
+            <h4>Parameters:</h4>
+
+            <ul class="params-list">
+                <li class="param">
+                        <code class="param-name">type</code>
+                        <span class="type">String</span>
+
+
+                    <div class="param-description">
+                        <p>the type to get</p>
+
+                    </div>
+
+                </li>
+                <li class="param">
+                        <code class="param-name">ids</code>
+                        <span class="type">String</span>
+
+
+                    <div class="param-description">
+                        <p>the ids of the records to get</p>
+
+                    </div>
+
+                </li>
+                <li class="param">
+                        <code class="param-name">options</code>
+                        <span class="type">Object</span>
+
+
+                    <div class="param-description">
+                        <p>{ queryParams }</p>
+
+                    </div>
+
+                </li>
+            </ul>
+        </div>
+
+        <div class="returns">
+            <h4>Returns:</h4>
+
+            <div class="returns-description">
+                        <span class="type">Promise</span>:
+                    <p>Promise.resolve(records) or Promise.reject(status)</p>
+
+            </div>
+        </div>
 
 
 </div>
@@ -1091,9 +1194,15 @@ endpoint. All records need to be of the same type.</p>
                 <li class="arg">
                         <code>id</code>
                 </li>
+                <li class="arg">
+                        <code>options</code>
+                </li>
             </ul><span class="paren">)</span>
         </div>
 
+        <span class="returns-inline">
+            <span class="type">Object</span>
+        </span>
 
 
 
@@ -1105,7 +1214,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l824"><code>src&#x2F;Store.js:824</code></a>
+        <a href="../files/src_Store.js.html#l181"><code>src&#x2F;Store.js:181</code></a>
         </p>
 
 
@@ -1113,7 +1222,7 @@ endpoint. All records need to be of the same type.</p>
     </div>
 
     <div class="description">
-        <p>fetches record by <code>id</code>.</p>
+        <p>Fetches record by <code>id</code> from the server and returns a Promise.</p>
 
     </div>
 
@@ -1127,7 +1236,7 @@ endpoint. All records need to be of the same type.</p>
 
 
                     <div class="param-description">
-                        <p>the type to find</p>
+                        <p>the record type to fetch</p>
 
                     </div>
 
@@ -1138,13 +1247,34 @@ endpoint. All records need to be of the same type.</p>
 
 
                     <div class="param-description">
-                         
+                        <p>the id of the record to fetch</p>
+
+                    </div>
+
+                </li>
+                <li class="param">
+                        <code class="param-name">options</code>
+                        <span class="type">Object</span>
+
+
+                    <div class="param-description">
+                        <p>{ queryParams }</p>
+
                     </div>
 
                 </li>
             </ul>
         </div>
 
+        <div class="returns">
+            <h4>Returns:</h4>
+
+            <div class="returns-description">
+                        <span class="type">Object</span>:
+                    <p>record</p>
+
+            </div>
+        </div>
 
 
 </div>
@@ -1172,7 +1302,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l776"><code>src&#x2F;Store.js:776</code></a>
+        <a href="../files/src_Store.js.html#l387"><code>src&#x2F;Store.js:387</code></a>
         </p>
 
 
@@ -1229,6 +1359,9 @@ endpoint. All records need to be of the same type.</p>
             </ul><span class="paren">)</span>
         </div>
 
+        <span class="returns-inline">
+            <span class="type">Promise</span>
+        </span>
 
 
 
@@ -1239,7 +1372,7 @@ endpoint. All records need to be of the same type.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l312"><code>src&#x2F;Store.js:312</code></a>
+        <a href="../files/src_Store.js.html#l461"><code>src&#x2F;Store.js:461</code></a>
         </p>
 
 
@@ -1247,34 +1380,20 @@ endpoint. All records need to be of the same type.</p>
     </div>
 
     <div class="description">
-        <p>finds all of the instances of a given type. If there are instances available in the store,
-it will return those, otherwise it will trigger a fetch</p>
+        <p>Finds all records of the given <code>type</code>.
+If all records are in the store, it returns those.
+Otherwise, it fetches all records from the server.
+Deprecated: Passing <code>fromServer</code> as an option will fetch all records from the server if <code>true</code> and never fetch from the server if <code>false</code>.</p>
 <p>store.findAll('todos')
 // fetch triggered
-=&gt; [event1, event2, event3]
-store.findAll('todos')
-// no fetch triggered
-=&gt; [event1, event2, event3]</p>
-<p>passing <code>fromServer</code> as an option will always trigger a
-fetch if <code>true</code> and never trigger a fetch if <code>false</code>.
-Otherwise, it will trigger the default behavior</p>
-<p>store.findAll('todos', { fromServer: false })
-// no fetch triggered
-=&gt; []</p>
+=&gt; [todo1, todo2, todo3]</p>
 <p>store.findAll('todos')
-// fetch triggered
-=&gt; [event1, event2, event3]</p>
-<p>// async stuff happens on the server
-store.findAll('todos')
 // no fetch triggered
-=&gt; [event1, event2, event3]</p>
-<p>store.findAll('todos', { fromServer: true })
-// fetch triggered
-=&gt; [event1, event2, event3, event4]</p>
+=&gt; [todo1, todo2, todo3]</p>
 <p>Query params can be passed as part of the options hash.
 The response will be cached, so the next time <code>findAll</code>
 is called with identical params and values, the store will
-first look for the local result (unless <code>fromServer</code> is <code>true</code>)</p>
+first look for the local result.</p>
 <p>store.findAll('todos', {
 queryParams: {
 filter: {
@@ -1283,6 +1402,10 @@ end_time: '2020-06-02T00:00:00.000Z'
 }
 }
 })</p>
+<p>NOTE: A broader RFC is in development to improve how we keep data in sync
+with the server. We likely will want to getAll and getRecords
+to return null if nothing is found. However, this causes several regressions
+in portal we will need to address in a larger PR for mobx-async-store updates.</p>
 
     </div>
 
@@ -1307,18 +1430,250 @@ end_time: '2020-06-02T00:00:00.000Z'
 
 
                     <div class="param-description">
-                         
+                        <p>{ fromServer, queryParams }</p>
+
                     </div>
 
                 </li>
             </ul>
         </div>
 
+        <div class="returns">
+            <h4>Returns:</h4>
+
+            <div class="returns-description">
+                        <span class="type">Promise</span>:
+                    <p>Promise.resolve(records) or Promise.reject(status)</p>
+
+            </div>
+        </div>
 
 
 </div>
-<div id="method_findAndFetchAll" class="method item">
-    <h3 class="name"><code>findAndFetchAll</code></h3>
+<div id="method_findMany" class="method item">
+    <h3 class="name"><code>findMany</code></h3>
+
+        <div class="args">
+            <span class="paren">(</span><ul class="args-list inline commas">
+                <li class="arg">
+                        <code>type</code>
+                </li>
+                <li class="arg">
+                        <code>ids</code>
+                </li>
+                <li class="arg">
+                        <code>options</code>
+                </li>
+            </ul><span class="paren">)</span>
+        </div>
+
+        <span class="returns-inline">
+            <span class="type">Promise</span>
+        </span>
+
+
+
+
+
+
+
+    <div class="meta">
+                <p>
+                Defined in
+        <a href="../files/src_Store.js.html#l310"><code>src&#x2F;Store.js:310</code></a>
+        </p>
+
+
+
+    </div>
+
+    <div class="description">
+        <p>Finds multiple records of the given <code>type</code> with the given <code>ids</code>.
+If all records are in the store, it returns those.
+If some records are in the store, it returns those plus fetches all other records.
+Otherwise, it fetches all records from the server.
+Deprecated: Passing <code>fromServer</code> as an option will fetch all records from the server if <code>true</code> and never fetch from the server if <code>false</code>.</p>
+<p>store.findMany('todos', [1, 2, 3])
+// fetch triggered
+=&gt; [todo1, todo2, todo3]</p>
+<p>store.findMany('todos', [3, 2, 1])
+// no fetch triggered
+=&gt; [todo1, todo2, todo3]</p>
+<p>store.findMany('todos', [1, 2, 3, 4], { fromServer: false })
+// no fetch triggered, only returns the records already in the store
+=&gt; [todo1, todo2, todo3]</p>
+<p>store.findMany('todos', [1, 2, 3, 4], { fromServer: true })
+// fetch triggered
+=&gt; [todo1, todo2, todo3, event4]</p>
+
+    </div>
+
+        <div class="params">
+            <h4>Parameters:</h4>
+
+            <ul class="params-list">
+                <li class="param">
+                        <code class="param-name">type</code>
+                        <span class="type">String</span>
+
+
+                    <div class="param-description">
+                        <p>the type to find</p>
+
+                    </div>
+
+                </li>
+                <li class="param">
+                        <code class="param-name">ids</code>
+                        <span class="type">String</span>
+
+
+                    <div class="param-description">
+                        <p>the ids of the records to find</p>
+
+                    </div>
+
+                </li>
+                <li class="param">
+                        <code class="param-name">options</code>
+                        <span class="type">Object</span>
+
+
+                    <div class="param-description">
+                        <p>{ fromServer, queryParams }</p>
+
+                    </div>
+
+                </li>
+            </ul>
+        </div>
+
+        <div class="returns">
+            <h4>Returns:</h4>
+
+            <div class="returns-description">
+                        <span class="type">Promise</span>:
+                    <p>Promise.resolve(records) or Promise.reject(status)</p>
+
+            </div>
+        </div>
+
+
+</div>
+<div id="method_findOne" class="method item">
+    <h3 class="name"><code>findOne</code></h3>
+
+        <div class="args">
+            <span class="paren">(</span><ul class="args-list inline commas">
+                <li class="arg">
+                        <code>type</code>
+                </li>
+                <li class="arg">
+                        <code>id</code>
+                </li>
+                <li class="arg">
+                        <code>options</code>
+                </li>
+            </ul><span class="paren">)</span>
+        </div>
+
+        <span class="returns-inline">
+            <span class="type">Object</span>
+        </span>
+
+
+
+
+
+
+
+    <div class="meta">
+                <p>
+                Defined in
+        <a href="../files/src_Store.js.html#l214"><code>src&#x2F;Store.js:214</code></a>
+        </p>
+
+
+
+    </div>
+
+    <div class="description">
+        <p>Finds a record by <code>id</code>.
+If available in the store, it returns that record. Otherwise, it fetches the record from the server.</p>
+<p>store.findOne('todos', 5)
+// fetch triggered
+=&gt; event1
+store.findOne('todos', 5)
+// no fetch triggered
+=&gt; event1</p>
+<p>Deprecated: Passing <code>fromServer</code> as an option will always trigger a fetch if <code>true</code> and never trigger a fetch if <code>false</code>.
+Otherwise, it will trigger the default behavior</p>
+<p>store.findOne('todos', 5, { fromServer: false })
+// no fetch triggered
+=&gt; undefined</p>
+<p>store.findOne('todos', 5)
+// fetch triggered
+=&gt; event1</p>
+<p>store.findOne('todos', 5, { fromServer: true })
+// fetch triggered
+=&gt; event1</p>
+
+    </div>
+
+        <div class="params">
+            <h4>Parameters:</h4>
+
+            <ul class="params-list">
+                <li class="param">
+                        <code class="param-name">type</code>
+                        <span class="type">String</span>
+
+
+                    <div class="param-description">
+                        <p>the type to find</p>
+
+                    </div>
+
+                </li>
+                <li class="param">
+                        <code class="param-name">id</code>
+                        <span class="type">String</span>
+
+
+                    <div class="param-description">
+                        <p>the id of the record to find</p>
+
+                    </div>
+
+                </li>
+                <li class="param">
+                        <code class="param-name">options</code>
+                        <span class="type">Object</span>
+
+
+                    <div class="param-description">
+                        <p>{ fromServer, queryParams }</p>
+
+                    </div>
+
+                </li>
+            </ul>
+        </div>
+
+        <div class="returns">
+            <h4>Returns:</h4>
+
+            <div class="returns-description">
+                        <span class="type">Object</span>:
+                    <p>record</p>
+
+            </div>
+        </div>
+
+
+</div>
+<div id="method_getAll" class="method item">
+    <h3 class="name"><code>getAll</code></h3>
 
         <div class="args">
             <span class="paren">(</span><ul class="args-list inline commas">
@@ -1344,7 +1699,7 @@ end_time: '2020-06-02T00:00:00.000Z'
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l376"><code>src&#x2F;Store.js:376</code></a>
+        <a href="../files/src_Store.js.html#l401"><code>src&#x2F;Store.js:401</code></a>
         </p>
 
 
@@ -1352,7 +1707,8 @@ end_time: '2020-06-02T00:00:00.000Z'
     </div>
 
     <div class="description">
-        
+        <p>Gets all records with the given <code>type</code> from the store. This will never fetch from the server.</p>
+
     </div>
 
         <div class="params">
@@ -1388,359 +1744,10 @@ end_time: '2020-06-02T00:00:00.000Z'
 
             <div class="returns-description">
                         <span class="type">Array</span>:
+                    <p>array of records</p>
+
             </div>
         </div>
-
-
-</div>
-<div id="method_findMany" class="method item">
-    <h3 class="name"><code>findMany</code></h3>
-
-        <div class="args">
-            <span class="paren">(</span><ul class="args-list inline commas">
-                <li class="arg">
-                        <code>type</code>
-                </li>
-                <li class="arg">
-                        <code>options</code>
-                </li>
-            </ul><span class="paren">)</span>
-        </div>
-
-
-
-
-
-
-
-
-    <div class="meta">
-                <p>
-                Defined in
-        <a href="../files/src_Store.js.html#l218"><code>src&#x2F;Store.js:218</code></a>
-        </p>
-
-
-
-    </div>
-
-    <div class="description">
-        <p>Like 'findOne', but with an array ids. If there are instances available in the store,
-it will return those, otherwise it will trigger a fetch</p>
-<p>store.findMany('todos', [1, 2, 3])
-// fetch triggered
-=&gt; [event1, event2, event3]
-store.findMany('todos', [3, 2, 1])
-// no fetch triggered
-=&gt; [event1, event2, event3]</p>
-<p>passing <code>fromServer</code> as an option will always trigger a
-fetch if <code>true</code> and never trigger a fetch if <code>false</code>.
-Otherwise, it will trigger the default behavior</p>
-<p>store.findMany('todos', [1, 2])
-// fetch triggered
-=&gt; [event1, event2]</p>
-<p>store.findMany('todos', [1, 2, 3], { fromServer: false })
-// no fetch triggered, only returns the records already in the store
-=&gt; [event1, event2]</p>
-<p>store.findMany('todos')
-// fetch triggered
-=&gt; [event1, event2, event3]</p>
-<p>// async stuff happens on the server
-store.findMany('todos', [1, 2, 3])
-// no fetch triggered
-=&gt; [event1, event2, event3]</p>
-<p>store.findMany('todos', [1, 2, 3], { fromServer: true })
-// fetch triggered
-=&gt; [event1, event2, event3]</p>
-<p>Query params can be passed as part of the options hash.
-The response will be cached, so the next time <code>findMany</code>
-is called with identical params and values, the store will
-first look for the local result (unless <code>fromServer</code> is <code>true</code>)</p>
-<p>store.findMany('todos', [1, 2, 3], {
-queryParams: {
-filter: {
-start_time: '2020-06-01T00:00:00.000Z',
-end_time: '2020-06-02T00:00:00.000Z'
-}
-}
-})</p>
-
-    </div>
-
-        <div class="params">
-            <h4>Parameters:</h4>
-
-            <ul class="params-list">
-                <li class="param">
-                        <code class="param-name">type</code>
-                        <span class="type">String</span>
-
-
-                    <div class="param-description">
-                        <p>the type to find</p>
-
-                    </div>
-
-                </li>
-                <li class="param">
-                        <code class="param-name">options</code>
-                        <span class="type">Object</span>
-
-
-                    <div class="param-description">
-                         
-                    </div>
-
-                </li>
-            </ul>
-        </div>
-
-
-
-</div>
-<div id="method_findOne" class="method item">
-    <h3 class="name"><code>findOne</code></h3>
-
-        <div class="args">
-            <span class="paren">(</span><ul class="args-list inline commas">
-                <li class="arg">
-                        <code>type</code>
-                </li>
-                <li class="arg">
-                        <code>id</code>
-                </li>
-                <li class="arg">
-                        <code>options</code>
-                </li>
-            </ul><span class="paren">)</span>
-        </div>
-
-
-
-
-
-
-
-
-    <div class="meta">
-                <p>
-                Defined in
-        <a href="../files/src_Store.js.html#l152"><code>src&#x2F;Store.js:152</code></a>
-        </p>
-
-
-
-    </div>
-
-    <div class="description">
-        <p>finds an instance by <code>id</code>. If available in the store, returns that instance. Otherwise, triggers a fetch.</p>
-<p>store.findOne('todos', 5)
-// fetch triggered
-=&gt; event1
-store.findOne('todos', 5)
-// no fetch triggered
-=&gt; event1</p>
-<p>Passing <code>fromServer</code> as an option will always trigger a fetch if <code>true</code> and never trigger a fetch if <code>false</code>.
-Otherwise, it will trigger the default behavior</p>
-<p>store.findOne('todos', 5, { fromServer: false })
-// no fetch triggered
-=&gt; undefined</p>
-<p>store.findOne('todos', 5)
-// fetch triggered
-=&gt; event1</p>
-<p>store.findOne('todos', 5, { fromServer: true })
-// fetch triggered
-=&gt; event1</p>
-
-    </div>
-
-        <div class="params">
-            <h4>Parameters:</h4>
-
-            <ul class="params-list">
-                <li class="param">
-                        <code class="param-name">type</code>
-                        <span class="type">String</span>
-
-
-                    <div class="param-description">
-                        <p>the type to find</p>
-
-                    </div>
-
-                </li>
-                <li class="param">
-                        <code class="param-name">id</code>
-                        <span class="type">Object</span>
-
-
-                    <div class="param-description">
-                         
-                    </div>
-
-                </li>
-                <li class="param">
-                        <code class="param-name">options</code>
-                        <span class="type">Object</span>
-
-
-                    <div class="param-description">
-                         
-                    </div>
-
-                </li>
-            </ul>
-        </div>
-
-
-
-</div>
-<div id="method_findOrFetchAll" class="method item">
-    <h3 class="name"><code>findOrFetchAll</code></h3>
-
-        <div class="args">
-            <span class="paren">(</span><ul class="args-list inline commas">
-                <li class="arg">
-                        <code>type</code>
-                </li>
-                <li class="arg">
-                        <code>queryParams</code>
-                </li>
-            </ul><span class="paren">)</span>
-        </div>
-
-
-
-
-
-
-
-
-    <div class="meta">
-                <p>
-                Defined in
-        <a href="../files/src_Store.js.html#l410"><code>src&#x2F;Store.js:410</code></a>
-        </p>
-
-
-
-    </div>
-
-    <div class="description">
-        <p>returns cache if exists, returns promise if not</p>
-
-    </div>
-
-        <div class="params">
-            <h4>Parameters:</h4>
-
-            <ul class="params-list">
-                <li class="param">
-                        <code class="param-name">type</code>
-                        <span class="type">String</span>
-
-
-                    <div class="param-description">
-                        <p>record type</p>
-
-                    </div>
-
-                </li>
-                <li class="param">
-                        <code class="param-name">queryParams</code>
-                        <span class="type">Object</span>
-
-
-                    <div class="param-description">
-                        <p>will inform whether to return cached or fetch</p>
-
-                    </div>
-
-                </li>
-            </ul>
-        </div>
-
-
-
-</div>
-<div id="method_findOrFetchOne" class="method item">
-    <h3 class="name"><code>findOrFetchOne</code></h3>
-
-        <div class="args">
-            <span class="paren">(</span><ul class="args-list inline commas">
-                <li class="arg">
-                        <code>type</code>
-                </li>
-                <li class="arg">
-                        <code>id</code>
-                </li>
-                <li class="arg">
-                        <code>queryParams</code>
-                </li>
-            </ul><span class="paren">)</span>
-        </div>
-
-
-
-
-
-
-
-
-    <div class="meta">
-                <p>
-                Defined in
-        <a href="../files/src_Store.js.html#l196"><code>src&#x2F;Store.js:196</code></a>
-        </p>
-
-
-
-    </div>
-
-    <div class="description">
-        <p>returns cache if exists, returns promise if not</p>
-
-    </div>
-
-        <div class="params">
-            <h4>Parameters:</h4>
-
-            <ul class="params-list">
-                <li class="param">
-                        <code class="param-name">type</code>
-                        <span class="type">String</span>
-
-
-                    <div class="param-description">
-                        <p>record type</p>
-
-                    </div>
-
-                </li>
-                <li class="param">
-                        <code class="param-name">id</code>
-                        <span class="type">Object</span>
-
-
-                    <div class="param-description">
-                         
-                    </div>
-
-                </li>
-                <li class="param">
-                        <code class="param-name">queryParams</code>
-                        <span class="type">Object</span>
-
-
-                    <div class="param-description">
-                        <p>will inform whether to return cached or fetch</p>
-
-                    </div>
-
-                </li>
-            </ul>
-        </div>
-
 
 
 </div>
@@ -1771,7 +1778,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l647"><code>src&#x2F;Store.js:647</code></a>
+        <a href="../files/src_Store.js.html#l737"><code>src&#x2F;Store.js:737</code></a>
         </p>
 
 
@@ -1849,7 +1856,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l632"><code>src&#x2F;Store.js:632</code></a>
+        <a href="../files/src_Store.js.html#l722"><code>src&#x2F;Store.js:722</code></a>
         </p>
 
 
@@ -1918,7 +1925,7 @@ Otherwise, it will trigger the default behavior</p>
         </div>
 
         <span class="returns-inline">
-            <span class="type">Array</span>
+            <span class="type">Object</span>
         </span>
 
 
@@ -1930,7 +1937,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l600"><code>src&#x2F;Store.js:600</code></a>
+        <a href="../files/src_Store.js.html#l689"><code>src&#x2F;Store.js:689</code></a>
         </p>
 
 
@@ -1983,8 +1990,8 @@ Otherwise, it will trigger the default behavior</p>
             <h4>Returns:</h4>
 
             <div class="returns-description">
-                        <span class="type">Array</span>:
-                    <p>array or records</p>
+                        <span class="type">Object</span>:
+                    <p>record</p>
 
             </div>
         </div>
@@ -2002,6 +2009,9 @@ Otherwise, it will trigger the default behavior</p>
                 <li class="arg">
                         <code>queryParams</code>
                 </li>
+                <li class="arg">
+                        <code>id</code>
+                </li>
             </ul><span class="paren">)</span>
         </div>
 
@@ -2018,7 +2028,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l615"><code>src&#x2F;Store.js:615</code></a>
+        <a href="../files/src_Store.js.html#l704"><code>src&#x2F;Store.js:704</code></a>
         </p>
 
 
@@ -2040,7 +2050,8 @@ Otherwise, it will trigger the default behavior</p>
 
 
                     <div class="param-description">
-                         
+                        <p>type of records to get</p>
+
                     </div>
 
                 </li>
@@ -2054,6 +2065,17 @@ Otherwise, it will trigger the default behavior</p>
                     </div>
 
                 </li>
+                <li class="param">
+                        <code class="param-name">id</code>
+                        <span class="type">String</span>
+
+
+                    <div class="param-description">
+                        <p>optional param if only getting 1 cached record by id</p>
+
+                    </div>
+
+                </li>
             </ul>
         </div>
 
@@ -2062,7 +2084,7 @@ Otherwise, it will trigger the default behavior</p>
 
             <div class="returns-description">
                         <span class="type">Array</span>:
-                    <p>array or records</p>
+                    <p>array of records</p>
 
             </div>
         </div>
@@ -2093,7 +2115,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l691"><code>src&#x2F;Store.js:691</code></a>
+        <a href="../files/src_Store.js.html#l749"><code>src&#x2F;Store.js:749</code></a>
         </p>
 
 
@@ -2134,8 +2156,102 @@ Otherwise, it will trigger the default behavior</p>
 
 
 </div>
-<div id="method_getMatchingRecord" class="method item">
-    <h3 class="name"><code>getMatchingRecord</code></h3>
+<div id="method_getMany" class="method item">
+    <h3 class="name"><code>getMany</code></h3>
+
+        <div class="args">
+            <span class="paren">(</span><ul class="args-list inline commas">
+                <li class="arg">
+                        <code>type</code>
+                </li>
+                <li class="arg">
+                        <code>ids</code>
+                </li>
+                <li class="arg">
+                        <code>options</code>
+                </li>
+            </ul><span class="paren">)</span>
+        </div>
+
+        <span class="returns-inline">
+            <span class="type">Array</span>
+        </span>
+
+
+
+
+
+
+
+    <div class="meta">
+                <p>
+                Defined in
+        <a href="../files/src_Store.js.html#l268"><code>src&#x2F;Store.js:268</code></a>
+        </p>
+
+
+
+    </div>
+
+    <div class="description">
+        <p>Get all records with the given <code>type</code> and <code>ids</code> from the store. This will never fetch from the server.</p>
+
+    </div>
+
+        <div class="params">
+            <h4>Parameters:</h4>
+
+            <ul class="params-list">
+                <li class="param">
+                        <code class="param-name">type</code>
+                        <span class="type">String</span>
+
+
+                    <div class="param-description">
+                        <p>the type to get</p>
+
+                    </div>
+
+                </li>
+                <li class="param">
+                        <code class="param-name">ids</code>
+                        <span class="type">String</span>
+
+
+                    <div class="param-description">
+                        <p>the ids of the records to get</p>
+
+                    </div>
+
+                </li>
+                <li class="param">
+                        <code class="param-name">options</code>
+                        <span class="type">Object</span>
+
+
+                    <div class="param-description">
+                        <p>{ queryParams }</p>
+
+                    </div>
+
+                </li>
+            </ul>
+        </div>
+
+        <div class="returns">
+            <h4>Returns:</h4>
+
+            <div class="returns-description">
+                        <span class="type">Array</span>:
+                    <p>array of records</p>
+
+            </div>
+        </div>
+
+
+</div>
+<div id="method_getOne" class="method item">
+    <h3 class="name"><code>getOne</code></h3>
 
         <div class="args">
             <span class="paren">(</span><ul class="args-list inline commas">
@@ -2146,13 +2262,13 @@ Otherwise, it will trigger the default behavior</p>
                         <code>id</code>
                 </li>
                 <li class="arg">
-                        <code>queryParams</code>
+                        <code>options</code>
                 </li>
             </ul><span class="paren">)</span>
         </div>
 
         <span class="returns-inline">
-            <span class="type">Array</span>
+            <span class="type">Object</span>
         </span>
 
 
@@ -2164,7 +2280,7 @@ Otherwise, it will trigger the default behavior</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l542"><code>src&#x2F;Store.js:542</code></a>
+        <a href="../files/src_Store.js.html#l162"><code>src&#x2F;Store.js:162</code></a>
         </p>
 
 
@@ -2172,8 +2288,8 @@ Otherwise, it will trigger the default behavior</p>
     </div>
 
     <div class="description">
-        <p>Get single all record
-based on query params</p>
+        <p>Gets a record from the store, will not fetch from the server if it doesn't exist in store.
+If given queryParams, it will check the cache for the record.</p>
 
     </div>
 
@@ -2187,106 +2303,30 @@ based on query params</p>
 
 
                     <div class="param-description">
-                         
+                        <p>the type to find</p>
+
                     </div>
 
                 </li>
                 <li class="param">
                         <code class="param-name">id</code>
-                        <span class="type">Object</span>
-
-
-                    <div class="param-description">
-                         
-                    </div>
-
-                </li>
-                <li class="param">
-                        <code class="param-name">queryParams</code>
-                        <span class="type">Object</span>
-
-
-                    <div class="param-description">
-                         
-                    </div>
-
-                </li>
-            </ul>
-        </div>
-
-        <div class="returns">
-            <h4>Returns:</h4>
-
-            <div class="returns-description">
-                        <span class="type">Array</span>:
-                    <p>array or records</p>
-
-            </div>
-        </div>
-
-
-</div>
-<div id="method_getMatchingRecords" class="method item">
-    <h3 class="name"><code>getMatchingRecords</code></h3>
-
-        <div class="args">
-            <span class="paren">(</span><ul class="args-list inline commas">
-                <li class="arg">
-                        <code>type</code>
-                </li>
-                <li class="arg">
-                        <code>queryParams</code>
-                </li>
-            </ul><span class="paren">)</span>
-        </div>
-
-        <span class="returns-inline">
-            <span class="type">Array</span>
-        </span>
-
-
-
-
-
-
-
-    <div class="meta">
-                <p>
-                Defined in
-        <a href="../files/src_Store.js.html#l674"><code>src&#x2F;Store.js:674</code></a>
-        </p>
-
-
-
-    </div>
-
-    <div class="description">
-        <p>Gets records all records or records
-based on query params</p>
-
-    </div>
-
-        <div class="params">
-            <h4>Parameters:</h4>
-
-            <ul class="params-list">
-                <li class="param">
-                        <code class="param-name">type</code>
                         <span class="type">String</span>
 
 
                     <div class="param-description">
-                         
+                        <p>the id of the record to get</p>
+
                     </div>
 
                 </li>
                 <li class="param">
-                        <code class="param-name">queryParams</code>
+                        <code class="param-name">options</code>
                         <span class="type">Object</span>
 
 
                     <div class="param-description">
-                         
+                        <p>{ queryParams }</p>
+
                     </div>
 
                 </li>
@@ -2297,8 +2337,8 @@ based on query params</p>
             <h4>Returns:</h4>
 
             <div class="returns-description">
-                        <span class="type">Array</span>:
-                    <p>array or records</p>
+                        <span class="type">Object</span>:
+                    <p>record</p>
 
             </div>
         </div>
@@ -2332,7 +2372,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l560"><code>src&#x2F;Store.js:560</code></a>
+        <a href="../files/src_Store.js.html#l632"><code>src&#x2F;Store.js:632</code></a>
         </p>
 
 
@@ -2407,7 +2447,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l580"><code>src&#x2F;Store.js:580</code></a>
+        <a href="../files/src_Store.js.html#l652"><code>src&#x2F;Store.js:652</code></a>
         </p>
 
 
@@ -2416,6 +2456,12 @@ based on query params</p>
 
     <div class="description">
         <p>Gets records for type of collection from observable</p>
+<p>NOTE: We only return records by unique id, this handles a scenario
+where the store keeps around a reference to a newly persisted record by its temp uuid.
+We can't simply remove the temp uuid reference because other
+related models may be still using the temp uuid in their relationships
+data object. However, when we are listing out records we want them
+to be unique by the persisted id (which is updated after a Model.save)</p>
 
     </div>
 
@@ -2475,7 +2521,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l659"><code>src&#x2F;Store.js:659</code></a>
+        <a href="../files/src_Store.js.html#l673"><code>src&#x2F;Store.js:673</code></a>
         </p>
 
 
@@ -2550,7 +2596,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l531"><code>src&#x2F;Store.js:531</code></a>
+        <a href="../files/src_Store.js.html#l621"><code>src&#x2F;Store.js:621</code></a>
         </p>
 
 
@@ -2612,7 +2658,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l458"><code>src&#x2F;Store.js:458</code></a>
+        <a href="../files/src_Store.js.html#l546"><code>src&#x2F;Store.js:546</code></a>
         </p>
 
 
@@ -2666,7 +2712,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l470"><code>src&#x2F;Store.js:470</code></a>
+        <a href="../files/src_Store.js.html#l558"><code>src&#x2F;Store.js:558</code></a>
         </p>
 
 
@@ -2720,7 +2766,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l481"><code>src&#x2F;Store.js:481</code></a>
+        <a href="../files/src_Store.js.html#l569"><code>src&#x2F;Store.js:569</code></a>
         </p>
 
 
@@ -2768,7 +2814,7 @@ based on query params</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l495"><code>src&#x2F;Store.js:495</code></a>
+        <a href="../files/src_Store.js.html#l583"><code>src&#x2F;Store.js:583</code></a>
         </p>
 
 
@@ -2810,7 +2856,7 @@ as the primary key</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l138"><code>src&#x2F;Store.js:138</code></a>
+        <a href="../files/src_Store.js.html#l148"><code>src&#x2F;Store.js:148</code></a>
         </p>
 
 
@@ -2870,7 +2916,7 @@ in mobx.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l435"><code>src&#x2F;Store.js:435</code></a>
+        <a href="../files/src_Store.js.html#l523"><code>src&#x2F;Store.js:523</code></a>
         </p>
 
 
@@ -2914,7 +2960,7 @@ store.reset()
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l857"><code>src&#x2F;Store.js:857</code></a>
+        <a href="../files/src_Store.js.html#l839"><code>src&#x2F;Store.js:839</code></a>
         </p>
 
 
@@ -2975,7 +3021,7 @@ set of records with the data returned from the API</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Store.js.html#l12"><code>src&#x2F;Store.js:12</code></a>
+        <a href="../files/src_Store.js.html#l19"><code>src&#x2F;Store.js:19</code></a>
         </p>
 
 

--- a/docs/data.json
+++ b/docs/data.json
@@ -3,7 +3,7 @@
         "name": "mobx-async-store",
         "description": "Asyc Data Store for mobx",
         "url": "https://github.com/artemis-ag/mobx-async-store",
-        "version": "3.2.9"
+        "version": "3.3.0"
     },
     "files": {
         "src/decorators/attributes.js": {
@@ -68,7 +68,7 @@
             "plugin_for": [],
             "extension_for": [],
             "file": "src/decorators/relationships.js",
-            "line": 224,
+            "line": 207,
             "description": "An array that allows for updating store references and relationships",
             "is_constructor": 1,
             "params": [
@@ -109,7 +109,7 @@
             "plugin_for": [],
             "extension_for": [],
             "file": "src/Store.js",
-            "line": 5,
+            "line": 12,
             "description": "Defines the Artemis Data Store class.",
             "is_constructor": 1
         },
@@ -186,7 +186,7 @@
         },
         {
             "file": "src/decorators/relationships.js",
-            "line": 51,
+            "line": 34,
             "description": "Syntactic sugar of relatedToMany relationship. Basically\neverything the same except it only returns a single record.",
             "itemtype": "method",
             "name": "relatedToOne",
@@ -194,7 +194,7 @@
         },
         {
             "file": "src/decorators/relationships.js",
-            "line": 94,
+            "line": 56,
             "description": "Handles getting polymorphic records or only a specific\ntype if specified.",
             "itemtype": "method",
             "name": "getRelatedRecords",
@@ -219,7 +219,7 @@
         },
         {
             "file": "src/decorators/relationships.js",
-            "line": 150,
+            "line": 121,
             "description": "Handles getting polymorphic has_one/belong_to.",
             "itemtype": "method",
             "name": "getRelatedRecord",
@@ -227,7 +227,7 @@
         },
         {
             "file": "src/decorators/relationships.js",
-            "line": 175,
+            "line": 146,
             "description": "Handles setting polymorphic has_one/belong_to.\n- Validates the related record to make sure it inherits from `Model` class\n- Sets the relationship\n- Attempts to find an inverse relationship, and if successful adds it as well",
             "itemtype": "method",
             "name": "setRelatedRecord",
@@ -257,7 +257,7 @@
         },
         {
             "file": "src/decorators/relationships.js",
-            "line": 255,
+            "line": 238,
             "description": "Adds a record to the array, and updates references in the store, as well as inverse references",
             "itemtype": "method",
             "name": "add",
@@ -276,7 +276,7 @@
         },
         {
             "file": "src/decorators/relationships.js",
-            "line": 297,
+            "line": 293,
             "description": "Removes a record from the array, and updates references in the store, as well as inverse references",
             "itemtype": "method",
             "name": "remove",
@@ -761,7 +761,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 12,
+            "line": 19,
             "description": "Observable property used to store data and\nhandle changes to state",
             "itemtype": "property",
             "name": "data",
@@ -771,7 +771,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 24,
+            "line": 31,
             "description": "Initializer for Store class",
             "itemtype": "method",
             "name": "constructor",
@@ -779,7 +779,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 33,
+            "line": 40,
             "description": "Adds an instance or an array of instances to the store.\n```\nkpiHash = { name: \"A good thing to measure\" }\nkpi = store.add('kpis', kpiHash)\nkpi.name\n=> \"A good thing to measure\"\n```",
             "itemtype": "method",
             "name": "add",
@@ -803,7 +803,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 54,
+            "line": 61,
             "description": "Builds an instance of a model that includes either an automatically or manually created temporary ID, but does not add it to the store.\n```\nkpiHash = { name: \"A good thing to measure\" }\nkpi = store.build('kpis', kpiHash)\nkpi.name\n=> \"A good thing to measure\"\n```",
             "itemtype": "method",
             "name": "build",
@@ -827,7 +827,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 74,
+            "line": 81,
             "itemtype": "method",
             "name": "addModel",
             "params": [
@@ -850,7 +850,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 91,
+            "line": 98,
             "itemtype": "method",
             "name": "addModels",
             "params": [
@@ -873,7 +873,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 101,
+            "line": 108,
             "description": "Saves a collection of records via a bulk-supported JSONApi\nendpoint. All records need to be of the same type.",
             "itemtype": "method",
             "name": "bulkSave",
@@ -898,7 +898,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 138,
+            "line": 148,
             "description": "Adds a record from the store. We can't simply remove the record\nby deleting the records property/key via delete due to a bug\nin mobx.",
             "itemtype": "method",
             "name": "remove",
@@ -918,8 +918,67 @@
         },
         {
             "file": "src/Store.js",
-            "line": 152,
-            "description": "finds an instance by `id`. If available in the store, returns that instance. Otherwise, triggers a fetch.\n\n  store.findOne('todos', 5)\n  // fetch triggered\n  => event1\n  store.findOne('todos', 5)\n  // no fetch triggered\n  => event1\n\nPassing `fromServer` as an option will always trigger a fetch if `true` and never trigger a fetch if `false`.\nOtherwise, it will trigger the default behavior\n\n  store.findOne('todos', 5, { fromServer: false })\n  // no fetch triggered\n  => undefined\n\n  store.findOne('todos', 5)\n  // fetch triggered\n  => event1\n\n  store.findOne('todos', 5, { fromServer: true })\n  // fetch triggered\n  => event1",
+            "line": 162,
+            "description": "Gets a record from the store, will not fetch from the server if it doesn't exist in store.\nIf given queryParams, it will check the cache for the record.",
+            "itemtype": "method",
+            "name": "getOne",
+            "params": [
+                {
+                    "name": "type",
+                    "description": "the type to find",
+                    "type": "String"
+                },
+                {
+                    "name": "id",
+                    "description": "the id of the record to get",
+                    "type": "String"
+                },
+                {
+                    "name": "options",
+                    "description": "{ queryParams }",
+                    "type": "Object"
+                }
+            ],
+            "return": {
+                "description": "record",
+                "type": "Object"
+            },
+            "class": "Store"
+        },
+        {
+            "file": "src/Store.js",
+            "line": 181,
+            "description": "Fetches record by `id` from the server and returns a Promise.",
+            "async": 1,
+            "itemtype": "method",
+            "name": "fetchOne",
+            "params": [
+                {
+                    "name": "type",
+                    "description": "the record type to fetch",
+                    "type": "String"
+                },
+                {
+                    "name": "id",
+                    "description": "the id of the record to fetch",
+                    "type": "String"
+                },
+                {
+                    "name": "options",
+                    "description": "{ queryParams }",
+                    "type": "Object"
+                }
+            ],
+            "return": {
+                "description": "record",
+                "type": "Object"
+            },
+            "class": "Store"
+        },
+        {
+            "file": "src/Store.js",
+            "line": 214,
+            "description": "Finds a record by `id`.\nIf available in the store, it returns that record. Otherwise, it fetches the record from the server.\n\n  store.findOne('todos', 5)\n  // fetch triggered\n  => event1\n  store.findOne('todos', 5)\n  // no fetch triggered\n  => event1\n\nDeprecated: Passing `fromServer` as an option will always trigger a fetch if `true` and never trigger a fetch if `false`.\nOtherwise, it will trigger the default behavior\n\n  store.findOne('todos', 5, { fromServer: false })\n  // no fetch triggered\n  => undefined\n\n  store.findOne('todos', 5)\n  // fetch triggered\n  => event1\n\n  store.findOne('todos', 5, { fromServer: true })\n  // fetch triggered\n  => event1",
             "itemtype": "method",
             "name": "findOne",
             "params": [
@@ -930,44 +989,83 @@
                 },
                 {
                     "name": "id",
-                    "description": ""
-                },
-                {
-                    "name": "options",
-                    "description": "",
-                    "type": "Object"
-                }
-            ],
-            "class": "Store"
-        },
-        {
-            "file": "src/Store.js",
-            "line": 196,
-            "description": "returns cache if exists, returns promise if not",
-            "itemtype": "method",
-            "name": "findOrFetchOne",
-            "params": [
-                {
-                    "name": "type",
-                    "description": "record type",
+                    "description": "the id of the record to find",
                     "type": "String"
                 },
                 {
-                    "name": "id",
-                    "description": ""
-                },
-                {
-                    "name": "queryParams",
-                    "description": "will inform whether to return cached or fetch",
+                    "name": "options",
+                    "description": "{ fromServer, queryParams }",
                     "type": "Object"
                 }
             ],
+            "return": {
+                "description": "record",
+                "type": "Object"
+            },
             "class": "Store"
         },
         {
             "file": "src/Store.js",
-            "line": 218,
-            "description": "Like 'findOne', but with an array ids. If there are instances available in the store,\nit will return those, otherwise it will trigger a fetch\n\n  store.findMany('todos', [1, 2, 3])\n  // fetch triggered\n  => [event1, event2, event3]\n  store.findMany('todos', [3, 2, 1])\n  // no fetch triggered\n  => [event1, event2, event3]\n\npassing `fromServer` as an option will always trigger a\nfetch if `true` and never trigger a fetch if `false`.\nOtherwise, it will trigger the default behavior\n\n  store.findMany('todos', [1, 2])\n  // fetch triggered\n  => [event1, event2]\n\n  store.findMany('todos', [1, 2, 3], { fromServer: false })\n  // no fetch triggered, only returns the records already in the store\n  => [event1, event2]\n\n  store.findMany('todos')\n  // fetch triggered\n  => [event1, event2, event3]\n\n  // async stuff happens on the server\n  store.findMany('todos', [1, 2, 3])\n  // no fetch triggered\n  => [event1, event2, event3]\n\n  store.findMany('todos', [1, 2, 3], { fromServer: true })\n  // fetch triggered\n  => [event1, event2, event3]\n\nQuery params can be passed as part of the options hash.\nThe response will be cached, so the next time `findMany`\nis called with identical params and values, the store will\nfirst look for the local result (unless `fromServer` is `true`)\n\n  store.findMany('todos', [1, 2, 3], {\n    queryParams: {\n      filter: {\n        start_time: '2020-06-01T00:00:00.000Z',\n        end_time: '2020-06-02T00:00:00.000Z'\n      }\n    }\n  })",
+            "line": 268,
+            "description": "Get all records with the given `type` and `ids` from the store. This will never fetch from the server.",
+            "itemtype": "method",
+            "name": "getMany",
+            "params": [
+                {
+                    "name": "type",
+                    "description": "the type to get",
+                    "type": "String"
+                },
+                {
+                    "name": "ids",
+                    "description": "the ids of the records to get",
+                    "type": "String"
+                },
+                {
+                    "name": "options",
+                    "description": "{ queryParams }",
+                    "type": "Object"
+                }
+            ],
+            "return": {
+                "description": "array of records",
+                "type": "Array"
+            },
+            "class": "Store"
+        },
+        {
+            "file": "src/Store.js",
+            "line": 284,
+            "description": "Fetch all records with the given `type` and `ids` from the server.",
+            "itemtype": "method",
+            "name": "fetchMany",
+            "params": [
+                {
+                    "name": "type",
+                    "description": "the type to get",
+                    "type": "String"
+                },
+                {
+                    "name": "ids",
+                    "description": "the ids of the records to get",
+                    "type": "String"
+                },
+                {
+                    "name": "options",
+                    "description": "{ queryParams }",
+                    "type": "Object"
+                }
+            ],
+            "return": {
+                "description": "Promise.resolve(records) or Promise.reject(status)",
+                "type": "Promise"
+            },
+            "class": "Store"
+        },
+        {
+            "file": "src/Store.js",
+            "line": 310,
+            "description": "Finds multiple records of the given `type` with the given `ids`.\nIf all records are in the store, it returns those.\nIf some records are in the store, it returns those plus fetches all other records.\nOtherwise, it fetches all records from the server.\nDeprecated: Passing `fromServer` as an option will fetch all records from the server if `true` and never fetch from the server if `false`.\n\n  store.findMany('todos', [1, 2, 3])\n  // fetch triggered\n  => [todo1, todo2, todo3]\n\n  store.findMany('todos', [3, 2, 1])\n  // no fetch triggered\n  => [todo1, todo2, todo3]\n\n  store.findMany('todos', [1, 2, 3, 4], { fromServer: false })\n  // no fetch triggered, only returns the records already in the store\n  => [todo1, todo2, todo3]\n\n  store.findMany('todos', [1, 2, 3, 4], { fromServer: true })\n  // fetch triggered\n  => [todo1, todo2, todo3, event4]",
             "itemtype": "method",
             "name": "findMany",
             "params": [
@@ -977,19 +1075,28 @@
                     "type": "String"
                 },
                 {
+                    "name": "ids",
+                    "description": "the ids of the records to find",
+                    "type": "String"
+                },
+                {
                     "name": "options",
-                    "description": "",
+                    "description": "{ fromServer, queryParams }",
                     "type": "Object"
                 }
             ],
+            "return": {
+                "description": "Promise.resolve(records) or Promise.reject(status)",
+                "type": "Promise"
+            },
             "class": "Store"
         },
         {
             "file": "src/Store.js",
-            "line": 312,
-            "description": "finds all of the instances of a given type. If there are instances available in the store,\nit will return those, otherwise it will trigger a fetch\n\n  store.findAll('todos')\n  // fetch triggered\n  => [event1, event2, event3]\n  store.findAll('todos')\n  // no fetch triggered\n  => [event1, event2, event3]\n\npassing `fromServer` as an option will always trigger a\nfetch if `true` and never trigger a fetch if `false`.\nOtherwise, it will trigger the default behavior\n\n  store.findAll('todos', { fromServer: false })\n  // no fetch triggered\n  => []\n\n  store.findAll('todos')\n  // fetch triggered\n  => [event1, event2, event3]\n\n  // async stuff happens on the server\n  store.findAll('todos')\n  // no fetch triggered\n  => [event1, event2, event3]\n\n  store.findAll('todos', { fromServer: true })\n  // fetch triggered\n  => [event1, event2, event3, event4]\n\nQuery params can be passed as part of the options hash.\nThe response will be cached, so the next time `findAll`\nis called with identical params and values, the store will\nfirst look for the local result (unless `fromServer` is `true`)\n\n  store.findAll('todos', {\n    queryParams: {\n      filter: {\n        start_time: '2020-06-01T00:00:00.000Z',\n        end_time: '2020-06-02T00:00:00.000Z'\n      }\n    }\n  })",
+            "line": 387,
+            "description": "Builds fetch url based",
             "itemtype": "method",
-            "name": "findAll",
+            "name": "fetchUrl",
             "params": [
                 {
                     "name": "type",
@@ -1006,9 +1113,10 @@
         },
         {
             "file": "src/Store.js",
-            "line": 376,
+            "line": 401,
+            "description": "Gets all records with the given `type` from the store. This will never fetch from the server.",
             "itemtype": "method",
-            "name": "findAndFetchAll",
+            "name": "getAll",
             "params": [
                 {
                     "name": "type",
@@ -1022,34 +1130,63 @@
                 }
             ],
             "return": {
-                "description": "",
+                "description": "array of records",
                 "type": "Array"
             },
             "class": "Store"
         },
         {
             "file": "src/Store.js",
-            "line": 410,
-            "description": "returns cache if exists, returns promise if not",
+            "line": 418,
+            "description": "Finds all records with the given `type`. Always fetches from the server.",
+            "async": 1,
             "itemtype": "method",
-            "name": "findOrFetchAll",
+            "name": "fetchAll",
             "params": [
                 {
                     "name": "type",
-                    "description": "record type",
+                    "description": "the type to find",
                     "type": "String"
                 },
                 {
-                    "name": "queryParams",
-                    "description": "will inform whether to return cached or fetch",
+                    "name": "options",
+                    "description": "",
                     "type": "Object"
                 }
             ],
+            "return": {
+                "description": "Promise.resolve(records) or Promise.reject(status)",
+                "type": "Promise"
+            },
             "class": "Store"
         },
         {
             "file": "src/Store.js",
-            "line": 435,
+            "line": 461,
+            "description": "Finds all records of the given `type`.\nIf all records are in the store, it returns those.\nOtherwise, it fetches all records from the server.\nDeprecated: Passing `fromServer` as an option will fetch all records from the server if `true` and never fetch from the server if `false`.\n\n  store.findAll('todos')\n  // fetch triggered\n  => [todo1, todo2, todo3]\n\n  store.findAll('todos')\n  // no fetch triggered\n  => [todo1, todo2, todo3]\n\nQuery params can be passed as part of the options hash.\nThe response will be cached, so the next time `findAll`\nis called with identical params and values, the store will\nfirst look for the local result.\n\n  store.findAll('todos', {\n    queryParams: {\n      filter: {\n        start_time: '2020-06-01T00:00:00.000Z',\n        end_time: '2020-06-02T00:00:00.000Z'\n      }\n    }\n  })\n\n\nNOTE: A broader RFC is in development to improve how we keep data in sync\nwith the server. We likely will want to getAll and getRecords\nto return null if nothing is found. However, this causes several regressions\nin portal we will need to address in a larger PR for mobx-async-store updates.",
+            "itemtype": "method",
+            "name": "findAll",
+            "params": [
+                {
+                    "name": "type",
+                    "description": "the type to find",
+                    "type": "String"
+                },
+                {
+                    "name": "options",
+                    "description": "{ fromServer, queryParams }",
+                    "type": "Object"
+                }
+            ],
+            "return": {
+                "description": "Promise.resolve(records) or Promise.reject(status)",
+                "type": "Promise"
+            },
+            "class": "Store"
+        },
+        {
+            "file": "src/Store.js",
+            "line": 523,
             "description": "Clears the store of a given type, or clears all if no type given\n\n  store.reset('todos')\n  // removes all todos from store\n  store.reset()\n  // clears store",
             "itemtype": "method",
             "name": "reset",
@@ -1057,7 +1194,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 458,
+            "line": 546,
             "description": "Entry point for configuring the store",
             "itemtype": "method",
             "name": "init",
@@ -1072,7 +1209,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 470,
+            "line": 558,
             "description": "Entry point for configuring the store",
             "itemtype": "method",
             "name": "initializeNetworkConfiguration",
@@ -1087,7 +1224,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 481,
+            "line": 569,
             "description": "Entry point for configuring the store",
             "itemtype": "method",
             "name": "initializeNetworkConfiguration",
@@ -1102,7 +1239,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 495,
+            "line": 583,
             "description": "Creates an obserable index with model types\nas the primary key\n\nObservable({ todos: {} })",
             "itemtype": "method",
             "name": "initializeObservableDataProperty",
@@ -1110,7 +1247,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 516,
+            "line": 604,
             "description": "Wrapper around fetch applies user defined fetch options",
             "itemtype": "method",
             "name": "fetch",
@@ -1130,7 +1267,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 531,
+            "line": 621,
             "description": "Gets type of collection from data observable",
             "itemtype": "method",
             "name": "getType",
@@ -1149,35 +1286,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 542,
-            "description": "Get single all record\nbased on query params",
-            "itemtype": "method",
-            "name": "getMatchingRecord",
-            "params": [
-                {
-                    "name": "type",
-                    "description": "",
-                    "type": "String"
-                },
-                {
-                    "name": "id",
-                    "description": ""
-                },
-                {
-                    "name": "queryParams",
-                    "description": "",
-                    "type": "Object"
-                }
-            ],
-            "return": {
-                "description": "array or records",
-                "type": "Array"
-            },
-            "class": "Store"
-        },
-        {
-            "file": "src/Store.js",
-            "line": 560,
+            "line": 632,
             "description": "Gets individual record from store",
             "itemtype": "method",
             "name": "getRecord",
@@ -1201,8 +1310,8 @@
         },
         {
             "file": "src/Store.js",
-            "line": 580,
-            "description": "Gets records for type of collection from observable",
+            "line": 652,
+            "description": "Gets records for type of collection from observable\n\nNOTE: We only return records by unique id, this handles a scenario\nwhere the store keeps around a reference to a newly persisted record by its temp uuid.\nWe can't simply remove the temp uuid reference because other\nrelated models may be still using the temp uuid in their relationships\ndata object. However, when we are listing out records we want them\nto be unique by the persisted id (which is updated after a Model.save)",
             "itemtype": "method",
             "name": "getRecords",
             "params": [
@@ -1220,107 +1329,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 600,
-            "description": "Gets single from store based on cached query",
-            "itemtype": "method",
-            "name": "getCachedRecord",
-            "params": [
-                {
-                    "name": "type",
-                    "description": "",
-                    "type": "String"
-                },
-                {
-                    "name": "id",
-                    "description": ""
-                },
-                {
-                    "name": "queryParams",
-                    "description": "",
-                    "type": "Object"
-                }
-            ],
-            "return": {
-                "description": "array or records",
-                "type": "Array"
-            },
-            "class": "Store"
-        },
-        {
-            "file": "src/Store.js",
-            "line": 615,
-            "description": "Gets records from store based on cached query",
-            "itemtype": "method",
-            "name": "getCachedRecords",
-            "params": [
-                {
-                    "name": "type",
-                    "description": "",
-                    "type": "String"
-                },
-                {
-                    "name": "queryParams",
-                    "description": "",
-                    "type": "Object"
-                }
-            ],
-            "return": {
-                "description": "array or records",
-                "type": "Array"
-            },
-            "class": "Store"
-        },
-        {
-            "file": "src/Store.js",
-            "line": 632,
-            "description": "Gets records from store based on cached query",
-            "itemtype": "method",
-            "name": "getCachedIds",
-            "params": [
-                {
-                    "name": "type",
-                    "description": "",
-                    "type": "String"
-                },
-                {
-                    "name": "url",
-                    "description": "",
-                    "type": "String"
-                }
-            ],
-            "return": {
-                "description": "array of ids",
-                "type": "Array"
-            },
-            "class": "Store"
-        },
-        {
-            "file": "src/Store.js",
-            "line": 647,
-            "description": "Gets records from store based on cached query",
-            "itemtype": "method",
-            "name": "getCachedId",
-            "params": [
-                {
-                    "name": "type",
-                    "description": "",
-                    "type": "String"
-                },
-                {
-                    "name": "url",
-                    "description": "",
-                    "type": "String"
-                }
-            ],
-            "return": {
-                "description": "array of ids",
-                "type": "Array"
-            },
-            "class": "Store"
-        },
-        {
-            "file": "src/Store.js",
-            "line": 659,
+            "line": 673,
             "description": "Get multiple records by id",
             "itemtype": "method",
             "name": "getRecordsById",
@@ -1344,15 +1353,19 @@
         },
         {
             "file": "src/Store.js",
-            "line": 674,
-            "description": "Gets records all records or records\nbased on query params",
+            "line": 689,
+            "description": "Gets single from store based on cached query",
             "itemtype": "method",
-            "name": "getMatchingRecords",
+            "name": "getCachedRecord",
             "params": [
                 {
                     "name": "type",
                     "description": "",
                     "type": "String"
+                },
+                {
+                    "name": "id",
+                    "description": ""
                 },
                 {
                     "name": "queryParams",
@@ -1361,14 +1374,91 @@
                 }
             ],
             "return": {
-                "description": "array or records",
+                "description": "record",
+                "type": "Object"
+            },
+            "class": "Store"
+        },
+        {
+            "file": "src/Store.js",
+            "line": 704,
+            "description": "Gets records from store based on cached query",
+            "itemtype": "method",
+            "name": "getCachedRecords",
+            "params": [
+                {
+                    "name": "type",
+                    "description": "type of records to get",
+                    "type": "String"
+                },
+                {
+                    "name": "queryParams",
+                    "description": "",
+                    "type": "Object"
+                },
+                {
+                    "name": "id",
+                    "description": "optional param if only getting 1 cached record by id",
+                    "type": "String"
+                }
+            ],
+            "return": {
+                "description": "array of records",
                 "type": "Array"
             },
             "class": "Store"
         },
         {
             "file": "src/Store.js",
-            "line": 691,
+            "line": 722,
+            "description": "Gets records from store based on cached query",
+            "itemtype": "method",
+            "name": "getCachedIds",
+            "params": [
+                {
+                    "name": "type",
+                    "description": "",
+                    "type": "String"
+                },
+                {
+                    "name": "url",
+                    "description": "",
+                    "type": "String"
+                }
+            ],
+            "return": {
+                "description": "array of ids",
+                "type": "Array"
+            },
+            "class": "Store"
+        },
+        {
+            "file": "src/Store.js",
+            "line": 737,
+            "description": "Gets records from store based on cached query",
+            "itemtype": "method",
+            "name": "getCachedId",
+            "params": [
+                {
+                    "name": "type",
+                    "description": "",
+                    "type": "String"
+                },
+                {
+                    "name": "url",
+                    "description": "",
+                    "type": "String"
+                }
+            ],
+            "return": {
+                "description": "array of ids",
+                "type": "Array"
+            },
+            "class": "Store"
+        },
+        {
+            "file": "src/Store.js",
+            "line": 749,
             "description": "Helper to look up model class for type.",
             "itemtype": "method",
             "name": "getKlass",
@@ -1387,7 +1477,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 702,
+            "line": 760,
             "description": "Creates or updates a model",
             "itemtype": "method",
             "name": "createOrUpdateModel",
@@ -1402,7 +1492,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 738,
+            "line": 799,
             "description": "Create multiple models from an array of data",
             "itemtype": "method",
             "name": "createModelsFromData",
@@ -1417,7 +1507,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 755,
+            "line": 818,
             "description": "Helper to create a new model",
             "itemtype": "method",
             "name": "createModel",
@@ -1446,68 +1536,7 @@
         },
         {
             "file": "src/Store.js",
-            "line": 776,
-            "description": "Builds fetch url based",
-            "itemtype": "method",
-            "name": "fetchUrl",
-            "params": [
-                {
-                    "name": "type",
-                    "description": "the type to find",
-                    "type": "String"
-                },
-                {
-                    "name": "options",
-                    "description": "",
-                    "type": "Object"
-                }
-            ],
-            "class": "Store"
-        },
-        {
-            "file": "src/Store.js",
-            "line": 790,
-            "description": "finds an instance by `id`. If available in the store, returns that instance. Otherwise, triggers a fetch.",
-            "itemtype": "method",
-            "name": "fetchAll",
-            "params": [
-                {
-                    "name": "type",
-                    "description": "the type to find",
-                    "type": "String"
-                },
-                {
-                    "name": "options",
-                    "description": "",
-                    "type": "Object"
-                }
-            ],
-            "class": "Store"
-        },
-        {
-            "file": "src/Store.js",
-            "line": 824,
-            "description": "fetches record by `id`.",
-            "async": 1,
-            "itemtype": "method",
-            "name": "fetchOne",
-            "params": [
-                {
-                    "name": "type",
-                    "description": "the type to find",
-                    "type": "String"
-                },
-                {
-                    "name": "id",
-                    "description": "",
-                    "type": "String"
-                }
-            ],
-            "class": "Store"
-        },
-        {
-            "file": "src/Store.js",
-            "line": 857,
+            "line": 839,
             "description": "Defines a resolution for an API call that will update a record or\nset of records with the data returned from the API",
             "itemtype": "method",
             "name": "updateRecords",

--- a/docs/files/src_Model.js.html
+++ b/docs/files/src_Model.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.2.9</em>
+            <em>API Docs for: 3.3.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_Store.js.html
+++ b/docs/files/src_Store.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.2.9</em>
+            <em>API Docs for: 3.3.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -84,8 +84,15 @@
 <div class="file">
     <pre class="code prettyprint linenums">
 /* global fetch */
-import { action, observable, transaction, set, toJS } from &#x27;mobx&#x27;
-import { dbOrNewId, parseErrorPointer, requestUrl, uniqueBy, combineRacedRequests, deriveIdQueryStrings } from &#x27;./utils&#x27;
+import { action, observable, set, toJS, transaction } from &#x27;mobx&#x27;
+import {
+  combineRacedRequests,
+  dbOrNewId,
+  deriveIdQueryStrings,
+  parseErrorPointer,
+  requestUrl,
+  uniqueBy
+} from &#x27;./utils&#x27;
 
 /**
  * Defines the Artemis Data Store class.
@@ -211,7 +218,10 @@ class Store {
 
     // send request
     const response = this.fetch(url, {
-      headers: { ...this.defaultFetchOptions.headers, &#x27;Content-Type&#x27;: &#x60;application/vnd.api+json; ${extensionStr}&#x60; },
+      headers: {
+        ...this.defaultFetchOptions.headers,
+        &#x27;Content-Type&#x27;: &#x60;application/vnd.api+json; ${extensionStr}&#x60;
+      },
       method: &#x27;POST&#x27;,
       body
     })
@@ -235,7 +245,60 @@ class Store {
   }
 
   /**
-   * finds an instance by &#x60;id&#x60;. If available in the store, returns that instance. Otherwise, triggers a fetch.
+   * Gets a record from the store, will not fetch from the server if it doesn&#x27;t exist in store.
+   * If given queryParams, it will check the cache for the record.
+   *
+   * @method getOne
+   * @param {String} type the type to find
+   * @param {String} id the id of the record to get
+   * @param {Object} options { queryParams }
+   * @return {Object} record
+   */
+  getOne = (type, id, options = {}) =&gt; {
+    const { queryParams } = options
+    if (queryParams) {
+      return this.getCachedRecord(type, id, queryParams)
+    } else {
+      return this.getRecord(type, id)
+    }
+  }
+
+  /**
+   * Fetches record by &#x60;id&#x60; from the server and returns a Promise.
+   *
+   * @async
+   * @method fetchOne
+   * @param {String} type the record type to fetch
+   * @param {String} id the id of the record to fetch
+   * @param {Object} options { queryParams }
+   * @return {Object} record
+   */
+  async fetchOne (type, id, options = {}) {
+    const { queryParams } = options
+    const url = this.fetchUrl(type, queryParams, id)
+    const response = await this.fetch(url, { method: &#x27;GET&#x27; })
+
+    if (response.status === 200) {
+      const json = await response.json()
+      const { data, included } = json
+
+      if (included) {
+        this.createModelsFromData(included)
+      }
+
+      const record = this.createOrUpdateModel(data)
+
+      this.data[type].cache.set(url, [record.id])
+      return record
+    } else {
+      // TODO: return Promise.reject(response.status)
+      return null
+    }
+  }
+
+  /**
+   * Finds a record by &#x60;id&#x60;.
+   * If available in the store, it returns that record. Otherwise, it fetches the record from the server.
    *
    *   store.findOne(&#x27;todos&#x27;, 5)
    *   // fetch triggered
@@ -244,7 +307,7 @@ class Store {
    *   // no fetch triggered
    *   =&gt; event1
    *
-   * Passing &#x60;fromServer&#x60; as an option will always trigger a fetch if &#x60;true&#x60; and never trigger a fetch if &#x60;false&#x60;.
+   * Deprecated: Passing &#x60;fromServer&#x60; as an option will always trigger a fetch if &#x60;true&#x60; and never trigger a fetch if &#x60;false&#x60;.
    * Otherwise, it will trigger the default behavior
    *
    *   store.findOne(&#x27;todos&#x27;, 5, { fromServer: false })
@@ -261,122 +324,132 @@ class Store {
    *
    * @method findOne
    * @param {String} type the type to find
-   * @param id
-   * @param {Object} options
+   * @param {String} id the id of the record to find
+   * @param {Object} options { fromServer, queryParams }
+   * @return {Object} record
    */
   findOne = (type, id, options = {}) =&gt; {
-    const { fromServer, queryParams } = options
+    const { fromServer } = options
+    if ([true, false].includes(fromServer)) {
+      console.warn(
+        &#x27;DeprecationWarning: using &#x60;fromServer&#x60; options is deprecated and will be removed - use getOne, fetchOne, or findOne.&#x27;
+      )
+    }
 
     if (fromServer === true) {
-      // If fromServer is true always fetch the data and return
-      return this.fetchOne(type, id, queryParams)
+      return this.fetchOne(type, id, options)
     } else if (fromServer === false) {
-      // If fromServer is false never fetch the data and return
-      return this.getRecord(type, id, queryParams)
-    } else {
-      return this.findOrFetchOne(type, id, queryParams)
+      return this.getOne(type, id, options)
     }
-  }
 
-  /**
-   * returns cache if exists, returns promise if not
-   *
-   * @method findOrFetchOne
-   * @param {String} type record type
-   * @param id
-   * @param {Object} queryParams will inform whether to return cached or fetch
-   */
-  findOrFetchOne = (type, id, queryParams) =&gt; {
-    // Get the matching record
-    const record = this.getMatchingRecord(type, id, queryParams)
-
-    // If the cached record is present
-    if (record &amp;&amp; record.id) {
-      // Return data
+    const record = this.getOne(type, id, options)
+    if (record?.id) {
       return record
     } else {
-      // Otherwise fetch it from the server
-      return this.fetchOne(type, id, queryParams)
+      return this.fetchOne(type, id, options)
     }
   }
 
   /**
-   * Like &#x27;findOne&#x27;, but with an array ids. If there are instances available in the store,
-   * it will return those, otherwise it will trigger a fetch
+   * Get all records with the given &#x60;type&#x60; and &#x60;ids&#x60; from the store. This will never fetch from the server.
+   *
+   * @method getMany
+   * @param {String} type the type to get
+   * @param {String} ids the ids of the records to get
+   * @param {Object} options { queryParams }
+   * @return {Array} array of records
+   */
+  getMany = (type, ids, options = {}) =&gt; {
+    const idsToQuery = ids.slice().map(String)
+    const records = this.getAll(type, options)
+
+    return records.filter((record) =&gt; idsToQuery.includes(record.id))
+  }
+
+  /**
+   * Fetch all records with the given &#x60;type&#x60; and &#x60;ids&#x60; from the server.
+   *
+   * @method fetchMany
+   * @param {String} type the type to get
+   * @param {String} ids the ids of the records to get
+   * @param {Object} options { queryParams }
+   * @return {Promise} Promise.resolve(records) or Promise.reject(status)
+   */
+  fetchMany = (type, ids, options = {}) =&gt; {
+    let idsToQuery = ids.slice().map(String)
+    const queryParams = options.queryParams || {}
+    queryParams.filter = queryParams.filter || {}
+
+    const baseUrl = this.fetchUrl(type, queryParams)
+    const idQueries = deriveIdQueryStrings(idsToQuery, baseUrl)
+    const queries = idQueries.map((queryIds) =&gt; {
+      queryParams.filter.ids = queryIds
+      return this.fetchAll(type, { queryParams })
+    })
+
+    return Promise.all(queries)
+      .then(records =&gt; [].concat(...records))
+      .catch(err =&gt; Promise.reject(err))
+  }
+
+  /**
+   * Finds multiple records of the given &#x60;type&#x60; with the given &#x60;ids&#x60;.
+   * If all records are in the store, it returns those.
+   * If some records are in the store, it returns those plus fetches all other records.
+   * Otherwise, it fetches all records from the server.
+   * Deprecated: Passing &#x60;fromServer&#x60; as an option will fetch all records from the server if &#x60;true&#x60; and never fetch from the server if &#x60;false&#x60;.
    *
    *   store.findMany(&#x27;todos&#x27;, [1, 2, 3])
    *   // fetch triggered
-   *   =&gt; [event1, event2, event3]
+   *   =&gt; [todo1, todo2, todo3]
+   *
    *   store.findMany(&#x27;todos&#x27;, [3, 2, 1])
    *   // no fetch triggered
-   *   =&gt; [event1, event2, event3]
+   *   =&gt; [todo1, todo2, todo3]
    *
-   * passing &#x60;fromServer&#x60; as an option will always trigger a
-   * fetch if &#x60;true&#x60; and never trigger a fetch if &#x60;false&#x60;.
-   * Otherwise, it will trigger the default behavior
-   *
-   *   store.findMany(&#x27;todos&#x27;, [1, 2])
-   *   // fetch triggered
-   *   =&gt; [event1, event2]
-   *
-   *   store.findMany(&#x27;todos&#x27;, [1, 2, 3], { fromServer: false })
+   *   store.findMany(&#x27;todos&#x27;, [1, 2, 3, 4], { fromServer: false })
    *   // no fetch triggered, only returns the records already in the store
-   *   =&gt; [event1, event2]
-   *
-   *   store.findMany(&#x27;todos&#x27;)
+   *   =&gt; [todo1, todo2, todo3]
+
+   *   store.findMany(&#x27;todos&#x27;, [1, 2, 3, 4], { fromServer: true })
    *   // fetch triggered
-   *   =&gt; [event1, event2, event3]
-   *
-   *   // async stuff happens on the server
-   *   store.findMany(&#x27;todos&#x27;, [1, 2, 3])
-   *   // no fetch triggered
-   *   =&gt; [event1, event2, event3]
-   *
-   *   store.findMany(&#x27;todos&#x27;, [1, 2, 3], { fromServer: true })
-   *   // fetch triggered
-   *   =&gt; [event1, event2, event3]
-   *
-   * Query params can be passed as part of the options hash.
-   * The response will be cached, so the next time &#x60;findMany&#x60;
-   * is called with identical params and values, the store will
-   * first look for the local result (unless &#x60;fromServer&#x60; is &#x60;true&#x60;)
-   *
-   *   store.findMany(&#x27;todos&#x27;, [1, 2, 3], {
-   *     queryParams: {
-   *       filter: {
-   *         start_time: &#x27;2020-06-01T00:00:00.000Z&#x27;,
-   *         end_time: &#x27;2020-06-02T00:00:00.000Z&#x27;
-   *       }
-   *     }
-   *   })
+   *   =&gt; [todo1, todo2, todo3, event4]
    *
    * @method findMany
    * @param {String} type the type to find
-   * @param {Object} options
+   * @param {String} ids the ids of the records to find
+   * @param {Object} options { fromServer, queryParams }
+   * @return {Promise} Promise.resolve(records) or Promise.reject(status)
    */
   findMany = (type, ids, options = {}) =&gt; {
     const { fromServer } = options
+    if ([true, false].includes(fromServer)) {
+      console.warn(
+        &#x27;DeprecationWarning: using &#x60;fromServer&#x60; options is deprecated and will be removed - use getMany, fetchMany, or findMany.&#x27;
+      )
+    }
 
     let idsToQuery = ids.slice().map(String)
 
     if (fromServer === false) {
-      // If fromServer is false never fetch the data and return
-      return this.getRecords(type).filter(record =&gt; idsToQuery.includes(record.id))
+      return this.getAll(type).filter((record) =&gt;
+        idsToQuery.includes(record.id)
+      )
     }
 
     let recordsInStore = []
 
     if (fromServer !== true) {
-      recordsInStore = this.getRecords(type).filter(record =&gt; idsToQuery.includes(record.id))
+      recordsInStore = this.getRecords(type).filter((record) =&gt;
+        idsToQuery.includes(record.id)
+      )
 
       if (recordsInStore.length === idsToQuery.length) {
-        // if fromServer is not false or true, but all the records are in store, wrap it in a promise
-        return Promise.resolve(recordsInStore)
+        return recordsInStore
       }
 
       const recordIdsInStore = recordsInStore.map(({ id }) =&gt; String(id))
-      // If fromServer is not true, we will only query records that are not already in the store
-      idsToQuery = idsToQuery.filter(id =&gt; !recordIdsInStore.includes(id))
+      idsToQuery = idsToQuery.filter((id) =&gt; !recordIdsInStore.includes(id))
     }
 
     const queryParams = options.queryParams || {}
@@ -387,49 +460,107 @@ class Store {
     const query = Promise.all(
       idQueries.map((queryIds) =&gt; {
         queryParams.filter.ids = queryIds
-        return this.fetchAll(type, queryParams)
+        return this.fetchAll(type, { queryParams })
       })
     )
 
-    return query.then(recordsFromServer =&gt; recordsInStore.concat(...recordsFromServer))
+    return query.then((recordsFromServer) =&gt;
+      recordsInStore.concat(...recordsFromServer)
+    )
   }
 
   /**
-   * finds all of the instances of a given type. If there are instances available in the store,
-   * it will return those, otherwise it will trigger a fetch
+   * Builds fetch url based
+   *
+   * @method fetchUrl
+   * @param {String} type the type to find
+   * @param {Object} options
+   */
+  fetchUrl (type, queryParams, id, options) {
+    const { baseUrl, modelTypeIndex } = this
+    const { endpoint } = modelTypeIndex[type]
+
+    return requestUrl(baseUrl, endpoint, queryParams, id, options)
+  }
+
+  /**
+   * Gets all records with the given &#x60;type&#x60; from the store. This will never fetch from the server.
+   *
+   * @method getAll
+   * @param {String} type the type to find
+   * @param {Object} options
+   * @return {Array} array of records
+   */
+  getAll = (type, options = {}) =&gt; {
+    const { queryParams } = options
+    if (queryParams) {
+      return this.getCachedRecords(type, queryParams)
+    } else {
+      return this.getRecords(type)
+    }
+  }
+
+  /**
+   * Finds all records with the given &#x60;type&#x60;. Always fetches from the server.
+   *
+   * @async
+   * @method fetchAll
+   * @param {String} type the type to find
+   * @param {Object} options
+   * @return {Promise} Promise.resolve(records) or Promise.reject(status)
+   */
+  async fetchAll (type, options = {}) {
+    const store = this
+    const { queryParams } = options
+    const url = this.fetchUrl(type, queryParams)
+    const response = await this.fetch(url, { method: &#x27;GET&#x27; })
+
+    if (response.status === 200) {
+      this.data[type].cache.set(url, [])
+      const json = await response.json()
+
+      if (json.included) {
+        this.createModelsFromData(json.included)
+      }
+
+      return transaction(() =&gt;
+        json.data.map((dataObject) =&gt; {
+          const { id, attributes = {}, relationships = {} } = dataObject
+          const ModelKlass = this.modelTypeIndex[type]
+          const record = new ModelKlass({
+            store,
+            relationships,
+            ...attributes
+          })
+          const cachedIds = this.data[type].cache.get(url)
+          this.data[type].cache.set(url, [...cachedIds, id])
+          this.data[type].records.set(String(id), record)
+          return record
+        })
+      )
+    } else {
+      return Promise.reject(response.status)
+    }
+  }
+
+  /**
+   * Finds all records of the given &#x60;type&#x60;.
+   * If all records are in the store, it returns those.
+   * Otherwise, it fetches all records from the server.
+   * Deprecated: Passing &#x60;fromServer&#x60; as an option will fetch all records from the server if &#x60;true&#x60; and never fetch from the server if &#x60;false&#x60;.
    *
    *   store.findAll(&#x27;todos&#x27;)
    *   // fetch triggered
-   *   =&gt; [event1, event2, event3]
-   *   store.findAll(&#x27;todos&#x27;)
-   *   // no fetch triggered
-   *   =&gt; [event1, event2, event3]
-   *
-   * passing &#x60;fromServer&#x60; as an option will always trigger a
-   * fetch if &#x60;true&#x60; and never trigger a fetch if &#x60;false&#x60;.
-   * Otherwise, it will trigger the default behavior
-   *
-   *   store.findAll(&#x27;todos&#x27;, { fromServer: false })
-   *   // no fetch triggered
-   *   =&gt; []
+   *   =&gt; [todo1, todo2, todo3]
    *
    *   store.findAll(&#x27;todos&#x27;)
-   *   // fetch triggered
-   *   =&gt; [event1, event2, event3]
-   *
-   *   // async stuff happens on the server
-   *   store.findAll(&#x27;todos&#x27;)
    *   // no fetch triggered
-   *   =&gt; [event1, event2, event3]
-   *
-   *   store.findAll(&#x27;todos&#x27;, { fromServer: true })
-   *   // fetch triggered
-   *   =&gt; [event1, event2, event3, event4]
+   *   =&gt; [todo1, todo2, todo3]
    *
    * Query params can be passed as part of the options hash.
    * The response will be cached, so the next time &#x60;findAll&#x60;
    * is called with identical params and values, the store will
-   * first look for the local result (unless &#x60;fromServer&#x60; is &#x60;true&#x60;)
+   * first look for the local result.
    *
    *   store.findAll(&#x27;todos&#x27;, {
    *     queryParams: {
@@ -440,80 +571,37 @@ class Store {
    *     }
    *   })
    *
+   *
+   * NOTE: A broader RFC is in development to improve how we keep data in sync
+   * with the server. We likely will want to getAll and getRecords
+   * to return null if nothing is found. However, this causes several regressions
+   * in portal we will need to address in a larger PR for mobx-async-store updates.
+   *
    * @method findAll
    * @param {String} type the type to find
-   * @param {Object} options
+   * @param {Object} options { fromServer, queryParams }
+   * @return {Promise} Promise.resolve(records) or Promise.reject(status)
    */
   findAll = (type, options = {}) =&gt; {
-    const { fromServer, queryParams } = options
+    const { fromServer } = options
+    if ([true, false].includes(fromServer)) {
+      console.warn(
+        &#x27;DeprecationWarning: using &#x60;fromServer&#x60; options is deprecated and will be removed - use getAll, fetchAll, or findAll.&#x27;
+      )
+    }
 
     if (fromServer === true) {
-      // If fromServer is true always fetch the data and return
-      return this.fetchAll(type, queryParams)
+      return this.fetchAll(type, options)
     } else if (fromServer === false) {
-      // If fromServer is false never fetch the data and return
-      return this.getMatchingRecords(type, queryParams) || []
+      const records = this.getAll(type, options) || []
+      return records
     } else {
-      return this.findOrFetchAll(type, queryParams) || []
-    }
-  }
-
-  /**
-   * @method findAndFetchAll
-   * @param {String} type the type to find
-   * @param {Object} options
-   * @return {Array}
-   */
-  findAndFetchAll = (type, options = {}) =&gt; {
-    const {
-      beforeFetch,
-      afterFetch,
-      beforeRefetch,
-      afterRefetch,
-      afterError,
-      queryParams
-    } = options
-
-    const records = this.getMatchingRecords(type, queryParams)
-
-    // NOTE: See note findOrFetchAll about this conditional logic.
-    if (records.length &gt; 0) {
-      beforeRefetch &amp;&amp; beforeRefetch(records)
-      this.fetchAll(type, queryParams)
-          .then((result) =&gt; afterRefetch &amp;&amp; afterRefetch(result))
-          .catch((error) =&gt; afterError &amp;&amp; afterError(error))
-    } else {
-      beforeFetch &amp;&amp; beforeFetch(records)
-      this.fetchAll(type, queryParams)
-          .then((result) =&gt; afterFetch &amp;&amp; afterFetch(result))
-          .catch((error) =&gt; afterError &amp;&amp; afterError(error))
-    }
-
-    return records || []
-  }
-
-  /**
-   * returns cache if exists, returns promise if not
-   *
-   * @method findOrFetchAll
-   * @param {String} type record type
-   * @param {Object} queryParams will inform whether to return cached or fetch
-   */
-  findOrFetchAll = (type, queryParams) =&gt; {
-    // Get any matching records
-    const records = this.getMatchingRecords(type, queryParams)
-
-    // NOTE: A broader RFC is in development to improve how we keep data in sync
-    // with the server. We likely will want to getMatchingRecords and getRecords
-    // to return null if nothing is found. However, this causes several regressions
-    // in portal we will need to address in a larger PR for mobx-async-store updates.
-
-    if (records.length &gt; 0) {
-      // Return data
-      return Promise.resolve(records)
-    } else {
-      // Otherwise fetch it from the server
-      return this.fetchAll(type, queryParams)
+      const records = this.getAll(type, options)
+      if (records.length &gt; 0) {
+        return Promise.resolve(records)
+      } else {
+        return this.fetchAll(type, options)
+      }
     }
   }
 
@@ -590,7 +678,7 @@ class Store {
 
     // NOTE: Is there a performance cost to setting
     // each property individually?
-    types.forEach(modelKlass =&gt; {
+    types.forEach((modelKlass) =&gt; {
       this.data[modelKlass.type] = {
         records: observable.map({}),
         cache: observable.map({})
@@ -610,7 +698,9 @@ class Store {
     const fetchOptions = { ...defaultFetchOptions, ...options }
     const key = JSON.stringify({ url, fetchOptions })
 
-    return combineRacedRequests(key, () =&gt; fetch(url, { ...defaultFetchOptions, ...options }))
+    return combineRacedRequests(key, () =&gt;
+      fetch(url, { ...defaultFetchOptions, ...options })
+    )
   }
 
   /**
@@ -622,24 +712,6 @@ class Store {
    */
   getType (type) {
     return this.data[type]
-  }
-
-  /**
-   * Get single all record
-   * based on query params
-   *
-   * @method getMatchingRecord
-   * @param {String} type
-   * @param id
-   * @param {Object} queryParams
-   * @return {Array} array or records
-   */
-  getMatchingRecord (type, id, queryParams) {
-    if (queryParams) {
-      return this.getCachedRecord(type, id, queryParams)
-    } else {
-      return this.getRecord(type, id)
-    }
   }
 
   /**
@@ -665,21 +737,38 @@ class Store {
   /**
    * Gets records for type of collection from observable
    *
+   * NOTE: We only return records by unique id, this handles a scenario
+   * where the store keeps around a reference to a newly persisted record by its temp uuid.
+   * We can&#x27;t simply remove the temp uuid reference because other
+   * related models may be still using the temp uuid in their relationships
+   * data object. However, when we are listing out records we want them
+   * to be unique by the persisted id (which is updated after a Model.save)
+   *
    * @method getRecords
    * @param {String} type
    * @return {Array} array of objects
    */
   getRecords (type) {
-    const records = Array.from(this.getType(type).records.values())
-                         .filter(value =&gt; value &amp;&amp; value !== &#x27;undefined&#x27;)
-
-    // NOTE: Handles a scenario where the store keeps around a reference
-    // to a newly persisted record by its temp uuid. This is required
-    // because we can&#x27;t simply remove the temp uuid reference because other
-    // related models may be still using the temp uuid in their relationships
-    // data object. However, when we are listing out records we want them
-    // to be unique by the persisted id (which is updated after a Model.save)
+    const records = Array.from(this.getType(type).records.values()).filter(
+      (value) =&gt; value &amp;&amp; value !== &#x27;undefined&#x27;
+    )
     return uniqueBy(records, &#x27;id&#x27;)
+  }
+
+  /**
+   * Get multiple records by id
+   *
+   * @method getRecordsById
+   * @param {String} type
+   * @param {Array} ids
+   * @return {Array} array or records
+   */
+  getRecordsById (type, ids = []) {
+    // NOTE: Is there a better way to do this?
+    return ids
+      .map((id) =&gt; this.getRecord(type, id))
+      .filter((record) =&gt; record)
+      .filter((record) =&gt; typeof record !== &#x27;undefined&#x27;)
   }
 
   /**
@@ -689,7 +778,7 @@ class Store {
    * @param {String} type
    * @param id
    * @param {Object} queryParams
-   * @return {Array} array or records
+   * @return {Object} record
    */
   getCachedRecord (type, id, queryParams) {
     const cachedRecords = this.getCachedRecords(type, queryParams, id)
@@ -701,9 +790,10 @@ class Store {
    * Gets records from store based on cached query
    *
    * @method getCachedRecords
-   * @param {String} type
+   * @param {String} type type of records to get
    * @param {Object} queryParams
-   * @return {Array} array or records
+   * @param {String} id optional param if only getting 1 cached record by id
+   * @return {Array} array of records
    */
   getCachedRecords (type, queryParams, id) {
     // Get the url the request would use
@@ -742,38 +832,6 @@ class Store {
   }
 
   /**
-   * Get multiple records by id
-   *
-   * @method getRecordsById
-   * @param {String} type
-   * @param {Array} ids
-   * @return {Array} array or records
-   */
-  getRecordsById (type, ids = []) {
-    // NOTE: Is there a better way to do this?
-    return ids.map(id =&gt; this.getRecord(type, id))
-              .filter(record =&gt; record)
-              .filter(record =&gt; typeof record !== &#x27;undefined&#x27;)
-  }
-
-  /**
-   * Gets records all records or records
-   * based on query params
-   *
-   * @method getMatchingRecords
-   * @param {String} type
-   * @param {Object} queryParams
-   * @return {Array} array or records
-   */
-  getMatchingRecords (type, queryParams) {
-    if (queryParams) {
-      return this.getCachedRecords(type, queryParams)
-    } else {
-      return this.getRecords(type)
-    }
-  }
-
-  /**
    * Helper to look up model class for type.
    *
    * @method getKlass
@@ -797,17 +855,20 @@ class Store {
 
     if (record) {
       // Update existing object attributes
-      Object.keys(attributes).forEach(key =&gt; {
+      Object.keys(attributes).forEach((key) =&gt; {
         set(record, key, attributes[key])
       })
 
       // If relationships are present, update relationships
       if (relationships) {
-        Object.keys(relationships).forEach(key =&gt; {
+        Object.keys(relationships).forEach((key) =&gt; {
           // Don&#x27;t try to create relationship if meta included false
           if (!relationships[key].meta) {
             // defensive against existingRecord.relationships being undefined
-            set(record, &#x27;relationships&#x27;, { ...record.relationships, [key]: relationships[key] })
+            set(record, &#x27;relationships&#x27;, {
+              ...record.relationships,
+              [key]: relationships[key]
+            })
           }
         })
       }
@@ -827,14 +888,16 @@ class Store {
    * @param {Array} data
    */
   createModelsFromData (data) {
-    return transaction(() =&gt; data.map(dataObject =&gt; {
-      // Only build objects for which we have a type defined.
-      // And ignore silently anything else included in the JSON response.
-      // TODO: Put some console message in development mode
-      if (this.getType(dataObject.type)) {
-        return this.createOrUpdateModel(dataObject)
-      }
-    }))
+    return transaction(() =&gt;
+      data.map((dataObject) =&gt; {
+        // Only build objects for which we have a type defined.
+        // And ignore silently anything else included in the JSON response.
+        // TODO: Put some console message in development mode
+        if (this.getType(dataObject.type)) {
+          return this.createOrUpdateModel(dataObject)
+        }
+      })
+    )
   }
 
   /**
@@ -859,87 +922,6 @@ class Store {
   }
 
   /**
-   * Builds fetch url based
-   *
-   * @method fetchUrl
-   * @param {String} type the type to find
-   * @param {Object} options
-   */
-  fetchUrl (type, queryParams, id, options) {
-    const { baseUrl, modelTypeIndex } = this
-    const { endpoint } = modelTypeIndex[type]
-
-    return requestUrl(baseUrl, endpoint, queryParams, id, options)
-  }
-
-  /**
-   * finds an instance by &#x60;id&#x60;. If available in the store, returns that instance. Otherwise, triggers a fetch.
-   *
-   * @method fetchAll
-   * @param {String} type the type to find
-   * @param {Object} options
-   */
-  async fetchAll (type, queryParams) {
-    const store = this
-    const url = this.fetchUrl(type, queryParams)
-    const response = await this.fetch(url, { method: &#x27;GET&#x27; })
-
-    if (response.status === 200) {
-      this.data[type].cache.set(url, [])
-      const json = await response.json()
-
-      if (json.included) {
-        this.createModelsFromData(json.included)
-      }
-
-      return transaction(() =&gt; json.data.map((dataObject) =&gt; {
-        const { id, attributes = {}, relationships = {} } = dataObject
-        const ModelKlass = this.modelTypeIndex[type]
-        const record = new ModelKlass({ store, relationships, ...attributes })
-        const cachedIds = this.data[type].cache.get(url)
-        this.data[type].cache.set(url, [...cachedIds, id])
-        this.data[type].records.set(String(id), record)
-        return record
-      }))
-    } else {
-      return Promise.reject(response.status)
-    }
-  }
-
-  /**
-   * fetches record by &#x60;id&#x60;.
-   *
-   * @async
-   * @method fetchOne
-   * @param {String} type the type to find
-   * @param {String} id
-   */
-  async fetchOne (type, id, queryParams) {
-    const url = this.fetchUrl(type, queryParams, id)
-    // Trigger request
-    const response = await this.fetch(url, { method: &#x27;GET&#x27; })
-
-    // Handle response
-    if (response.status === 200) {
-      const json = await response.json()
-      const { data, included } = json
-
-      if (included) {
-        this.createModelsFromData(included)
-      }
-
-      const record = this.createOrUpdateModel(data)
-
-      this.data[type].cache.set(url, [record.id])
-
-      return record
-    } else {
-      // Return null if record is not found
-      return null
-    }
-  }
-
-  /**
    * Defines a resolution for an API call that will update a record or
    * set of records with the data returned from the API
    *
@@ -951,23 +933,34 @@ class Store {
     // records may be a single record, if so wrap it in an array to make
     // iteration simpler
     const recordsArray = Array.isArray(records) ? records : [records]
-    recordsArray.forEach((record) =&gt; { record.isInFlight = true })
+    recordsArray.forEach((record) =&gt; {
+      record.isInFlight = true
+    })
 
     return promise.then(
       async (response) =&gt; {
         const { status } = response
 
-        recordsArray.forEach(record =&gt; { record.isInFlight = false })
+        recordsArray.forEach((record) =&gt; {
+          record.isInFlight = false
+        })
 
         if (status === 200 || status === 201) {
           const json = await response.json()
           const data = Array.isArray(json.data) ? json.data : [json.data]
           const { included } = json
 
-          if (data.length !== recordsArray.length) throw new Error(&#x27;Invariant violated: API response data and records to update do not match&#x27;)
+          if (data.length !== recordsArray.length) {
+            throw new Error(
+              &#x27;Invariant violated: API response data and records to update do not match&#x27;
+            )
+          }
 
           data.forEach((targetData, index) =&gt; {
-            recordsArray[index].updateAttributesFromResponse(targetData, included)
+            recordsArray[index].updateAttributesFromResponse(
+              targetData,
+              included
+            )
           })
 
           if (json.included) {
@@ -989,7 +982,7 @@ class Store {
           // Add all errors from the API response to the record(s).
           // This is done by comparing the pointer in the error to
           // the request.
-          json.errors.forEach(error =&gt; {
+          json.errors.forEach((error) =&gt; {
             const { index, key } = parseErrorPointer(error)
             if (key != null) {
               const errors = recordsArray[index].errors[key] || []
@@ -999,14 +992,16 @@ class Store {
           })
 
           const errorString = recordsArray
-            .map(record =&gt; JSON.stringify(record.errors))
+            .map((record) =&gt; JSON.stringify(record.errors))
             .join(&#x27;;&#x27;)
           return Promise.reject(new Error(errorString))
         }
       },
       function (error) {
         // TODO: Handle error states correctly, including handling errors for multiple targets
-        recordsArray.forEach(record =&gt; { record.isInFlight = false })
+        recordsArray.forEach((record) =&gt; {
+          record.isInFlight = false
+        })
         recordsArray[0].errors = error
         throw error
       }

--- a/docs/files/src_decorators_attributes.js.html
+++ b/docs/files/src_decorators_attributes.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.2.9</em>
+            <em>API Docs for: 3.3.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_relationships.js.html
+++ b/docs/files/src_decorators_relationships.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.2.9</em>
+            <em>API Docs for: 3.3.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -83,10 +83,10 @@
 
 <div class="file">
     <pre class="code prettyprint linenums">
-import { transaction } from &#x27;mobx&#x27;
 import Model from &#x27;../Model&#x27;
 import schema from &#x27;../schema&#x27;
 import { singularizeType } from &#x27;../utils&#x27;
+import { transaction } from &#x27;mobx&#x27;
 
 /*
  * Defines a one-to-many relationship. Defaults to the class with camelized singular name of the property
@@ -103,32 +103,15 @@ import { singularizeType } from &#x27;../utils&#x27;
  * @method relatedToMany
  */
 export function relatedToMany (targetOrModelKlass, property, descriptor) {
-  if (typeof targetOrModelKlass === &#x27;function&#x27;) {
-    return function (target2, property2, descriptor2) {
-      schema.addRelationship({
-        type: target2.constructor.type,
-        property: property2,
-        dataType: Array
-      })
+  schema.addRelationship({
+    type: targetOrModelKlass.constructor.type,
+    property,
+    dataType: Array
+  })
 
-      return {
-        get () {
-          const { type } = targetOrModelKlass
-          return getRelatedRecords(this, property2, type)
-        }
-      }
-    }
-  } else {
-    schema.addRelationship({
-      type: targetOrModelKlass.constructor.type,
-      property,
-      dataType: Array
-    })
-
-    return {
-      get () {
-        return getRelatedRecords(this, property)
-      }
+  return {
+    get () {
+      return getRelatedRecords(this, property)
     }
   }
 }
@@ -140,38 +123,17 @@ export function relatedToMany (targetOrModelKlass, property, descriptor) {
  * @method relatedToOne
  */
 export function relatedToOne (targetOrModelKlass, property, descriptor) {
-  if (typeof targetOrModelKlass === &#x27;function&#x27;) {
-    return function (target2, property2, descriptor2) {
-      schema.addRelationship({
-        type: target2.constructor.type,
-        property: property2,
-        dataType: Object
-      })
-
-      return {
-        get () {
-          const { type } = targetOrModelKlass
-          return getRelatedRecord(this, property2, type)
-        },
-        set (record) {
-          const { type } = targetOrModelKlass
-          return setRelatedRecord(this, record, property2, type)
-        }
-      }
-    }
-  } else {
-    schema.addRelationship({
-      type: targetOrModelKlass.constructor.type,
-      property,
-      dataType: Object
-    })
-    return {
-      get () {
-        return getRelatedRecord(this, property)
-      },
-      set (record) {
-        return setRelatedRecord(this, record, property)
-      }
+  schema.addRelationship({
+    type: targetOrModelKlass.constructor.type,
+    property,
+    dataType: Object
+  })
+  return {
+    get () {
+      return getRelatedRecord(this, property)
+    },
+    set (record) {
+      return setRelatedRecord(this, record, property)
     }
   }
 }
@@ -201,10 +163,12 @@ export function getRelatedRecords (record, property, modelType = null) {
   // fall back to looking up records by a foreign id i.e record.related_record_id
   if (references &amp;&amp; references.data) {
     // Ignore any records of unknown types
-    relatedRecords = references.data.filter(ref =&gt; record.store.getType(ref.type)).map(ref =&gt; {
-      const recordType = ref.type
-      return record.store.getRecord(recordType, ref.id)
-    })
+    relatedRecords = references.data
+      .filter(ref =&gt; record.store.getType(ref.type))
+      .map(ref =&gt; {
+        const recordType = ref.type
+        return record.store.getRecord(recordType, ref.id)
+      })
   } else {
     const foreignReferenceName = singularizeType(record.type)
     const foreignId = &#x60;${foreignReferenceName}_id&#x60;
@@ -213,11 +177,18 @@ export function getRelatedRecords (record, property, modelType = null) {
       const allRecords = record.store.getRecords(relationType)
       if (allRecords?.[0]?.relationships?.[foreignReferenceName]?.data) {
         relatedRecords = allRecords.filter(rel =&gt; {
-          return String(rel.relationships[foreignReferenceName]?.data?.id) === String(record.id)
+          return (
+            String(rel.relationships[foreignReferenceName]?.data?.id) ===
+            String(record.id)
+          )
         })
       } else if (allRecords?.[0]?.[foreignId]) {
-        console.warn(&#x60;Support for including non-canonical jsonapi references will be removed in future versions. Record type: ${record.type}. Relation: ${relationType}. Reference: ${foreignId}.&#x60;)
-        relatedRecords = allRecords.filter(rel =&gt; String(rel[foreignId]) === String(record.id))
+        console.warn(
+          &#x60;Support for including non-canonical jsonapi references will be removed in future versions. Record type: ${record.type}. Relation: ${relationType}. Reference: ${foreignId}.&#x60;
+        )
+        relatedRecords = allRecords.filter(
+          (rel) =&gt; String(rel[foreignId]) === String(record.id)
+        )
       }
     }
 
@@ -269,16 +240,24 @@ export function getRelatedRecord (record, property, modelType = null) {
  * @param {String} property the related property to set
  * @param {String} modelType an override of the modelType
  */
-export function setRelatedRecord (record, relatedRecord, property, modelType = null) {
+export function setRelatedRecord (
+  record,
+  relatedRecord,
+  property,
+  modelType = null
+) {
   if (relatedRecord &amp;&amp; !(relatedRecord instanceof Model)) {
     throw new Error(&#x27;Related record must be a valid Model object&#x27;)
   }
 
   const { relationships, _dirtyRelationships } = record
   const relationType = modelType || property
-  const referenceRecord = relatedRecord || getRelatedRecord(record, relationType)
+  const referenceRecord =
+    relatedRecord || getRelatedRecord(record, relationType)
 
-  if (!referenceRecord) { return }
+  if (!referenceRecord) {
+    return
+  }
 
   const { id } = referenceRecord
   const { type } = referenceRecord.constructor
@@ -296,7 +275,11 @@ export function setRelatedRecord (record, relatedRecord, property, modelType = n
 
   // hack we don&#x27;t have a reference to the inverse name so we just use the record type.
   // this may cause problems with polymorphic relationships
-  const inverseRelatedToMany = getRelatedRecords(referenceRecord, null, record.constructor.type)
+  const inverseRelatedToMany = getRelatedRecords(
+    referenceRecord,
+    null,
+    record.constructor.type
+  )
 
   if (inverseRelatedToMany) {
     const inverseMethod = relatedRecord ? &#x27;add&#x27; : &#x27;remove&#x27;
@@ -343,10 +326,15 @@ export class RelatedRecordsArray extends Array {
    * @param {Object} relatedRecord the record to add to the array
    * @return {Object} the original relatedRecord
    */
-  add = (relatedRecord) =&gt; {
+  add = relatedRecord =&gt; {
     const { record, property } = this
-    const { constructor: { type: recordType } } = record
-    const { id, constructor: { type } } = relatedRecord
+    const {
+      constructor: { type: recordType }
+    } = record
+    const {
+      id,
+      constructor: { type }
+    } = relatedRecord
 
     if (!relatedRecord || !(relatedRecord instanceof Model)) {
       throw new Error(&#x27;Related record must be a valid Model object&#x27;)
@@ -367,13 +355,21 @@ export class RelatedRecordsArray extends Array {
     }
 
     const existingRelationships = relationships[property]
-    const alreadyThere = existingRelationships &amp;&amp; existingRelationships.data.find((model) =&gt; model.id === id &amp;&amp; model.type === type)
+    const alreadyThere =
+      existingRelationships &amp;&amp;
+      existingRelationships.data.find(
+        model =&gt; model.id === id &amp;&amp; model.type === type
+      )
     if (!alreadyThere) {
       relationships[property].data.push({ id, type })
       this.push(relatedRecord)
       record._dirtyRelationships.add(property)
       // setting the inverse - hack this will only work with singularized relationships.
-      setRelatedRecord(relatedRecord, record, recordType.slice(0, recordType.length - 1))
+      setRelatedRecord(
+        relatedRecord,
+        record,
+        recordType.slice(0, recordType.length - 1)
+      )
     }
 
     return relatedRecord
@@ -385,16 +381,26 @@ export class RelatedRecordsArray extends Array {
    * @param {Object} relatedRecord the record to remove from the array
    * @return {Object} the original relatedRecord
    */
-  remove = (relatedRecord) =&gt; {
+  remove = relatedRecord =&gt; {
     const { record, property } = this
-    const { relationships, constructor: { type: recordType } } = record
-    const { id, constructor: { type } } = relatedRecord
+    const {
+      relationships,
+      constructor: { type: recordType }
+    } = record
+    const {
+      id,
+      constructor: { type }
+    } = relatedRecord
 
     if (relationships &amp;&amp; relationships[property] &amp;&amp; relatedRecord) {
-      const referenceIndexToRemove = relationships[property].data.findIndex((model) =&gt; model.id.toString() === id.toString() &amp;&amp; model.type === type)
-      if (referenceIndexToRemove &gt;= 0) relationships[property].data.splice(referenceIndexToRemove, 1)
+      const referenceIndexToRemove = relationships[property].data.findIndex(
+        model =&gt; model.id.toString() === id.toString() &amp;&amp; model.type === type
+      )
+      if (referenceIndexToRemove &gt;= 0) { relationships[property].data.splice(referenceIndexToRemove, 1) }
 
-      const recordIndexToRemove = this.findIndex((model) =&gt; model.id.toString() === id.toString() &amp;&amp; model.type === type)
+      const recordIndexToRemove = this.findIndex(
+        model =&gt; model.id.toString() === id.toString() &amp;&amp; model.type === type
+      )
       if (recordIndexToRemove &gt;= 0) this.splice(recordIndexToRemove, 1)
 
       if (!relationships[property].data.length) {
@@ -408,13 +414,17 @@ export class RelatedRecordsArray extends Array {
       record._dirtyRelationships.add(property)
 
       // hack this will only work with singularized relationships.
-      setRelatedRecord(relatedRecord, null, recordType.slice(0, recordType.length - 1))
+      setRelatedRecord(
+        relatedRecord,
+        null,
+        recordType.slice(0, recordType.length - 1)
+      )
     }
 
     return relatedRecord
   }
 
-  replace = (array) =&gt; {
+  replace = array =&gt; {
     const { record, property } = this
     const { relationships } = record
 

--- a/docs/files/src_schema.js.html
+++ b/docs/files/src_schema.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.2.9</em>
+            <em>API Docs for: 3.3.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_utils.js.html
+++ b/docs/files/src_utils.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.2.9</em>
+            <em>API Docs for: 3.3.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
                 <h1><img src="./assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.2.9</em>
+            <em>API Docs for: 3.3.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "3.2.9",
+  "version": "3.3.0",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/spec/ExampleApp.js
+++ b/spec/ExampleApp.js
@@ -1,13 +1,12 @@
 import React, { Component } from 'react'
-import PropTypes from 'prop-types'
-
 import {
   action,
   computed,
   observable
 } from 'mobx'
-
 import { inject, observer } from 'mobx-react'
+
+import PropTypes from 'prop-types'
 
 const todoCardPropTypes = {
   store: PropTypes.object.isRequired,
@@ -73,7 +72,7 @@ class ExampleApp extends Component {
 
   @computed get todos () {
     const { store } = this.props
-    return store.findAll('todos', { fromServer: false })
+    return store.getAll('todos')
   }
 
   render () {

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -1,6 +1,3 @@
-/* global fetch */
-import { autorun, isObservable } from 'mobx'
-
 import {
   Model,
   Store,
@@ -9,12 +6,13 @@ import {
   relatedToOne,
   validates
 } from '../src/main'
-
+/* global fetch */
+import { autorun, isObservable } from 'mobx'
 import {
-  exampleRelatedToManyResponse,
-  exampleRelatedToManyWithNoiseResponse,
   exampleRelatedToManyIncludedResponse,
   exampleRelatedToManyIncludedWithNoiseResponse,
+  exampleRelatedToManyResponse,
+  exampleRelatedToManyWithNoiseResponse,
   exampleRelatedToOneUnmatchedTypeResponse
 } from './fixtures/exampleRelationalResponses'
 
@@ -100,8 +98,6 @@ class Organization extends Model {
   @validates(validatesOptions)
   @attribute(Object) options = {}
 
-  @relatedToMany(Note) meeting_notes
-
   @validates(validatesArrayPresence)
   @relatedToMany notes
   @relatedToMany awesome_notes
@@ -123,8 +119,6 @@ class Todo extends Model {
 
   @validates(validatesOptions)
   @attribute(Object) options = {}
-
-  @relatedToMany(Note) meeting_notes
 
   @validates(validatesArrayPresence)
   @relatedToMany notes
@@ -332,19 +326,7 @@ describe('Model', () => {
       expect(organization.name).toEqual('Do laundry')
       expect(organization.awesome_notes).toHaveLength(0)
       expect(organization.awesome_notes).toBeInstanceOf(Array)
-      expect(organization.meeting_notes).toHaveLength(0)
-      expect(organization.meeting_notes).toBeInstanceOf(Array)
     })
-
-    it('builds aliased relatedToMany relationship', async () => {
-      fetch.mockResponse(exampleRelatedToManyIncludedResponse)
-      const todo = await store.findOne('organizations', 1)
-
-      expect(todo.title).toEqual('Do laundry')
-      expect(todo.meeting_notes).toHaveLength(1)
-      expect(todo.meeting_notes[0].description).toEqual('Use fabric softener')
-    })
-
     it('ignores unexpected types in relationship data', async () => {
       fetch.mockResponse(exampleRelatedToManyWithNoiseResponse)
       const todo = await store.findOne('organizations', 1)

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -1266,16 +1266,16 @@ describe('Model', () => {
   })
 
   describe('.destroy', () => {
-    it('makes request and removes model from the store store', async () => {
+    it('makes request and removes model from the store', async () => {
       fetch.mockResponses([JSON.stringify({}), { status: 204 }])
       const todo = store.add('organizations', { id: 1, title: 'Buy Milk' })
-      expect(store.findAll('organizations', { fromServer: false }))
+      expect(store.getAll('organizations'))
         .toHaveLength(1)
       await todo.destroy()
       expect(fetch.mock.calls).toHaveLength(1)
       expect(fetch.mock.calls[0][0]).toEqual('/example_api/organizations/1')
       expect(fetch.mock.calls[0][1].method).toEqual('DELETE')
-      expect(store.findAll('organizations', { fromServer: false }))
+      expect(store.getAll('organizations'))
         .toHaveLength(0)
     })
 

--- a/spec/Store.spec.js
+++ b/spec/Store.spec.js
@@ -1,6 +1,13 @@
+import {
+  Model,
+  Store,
+  attribute,
+  relatedToMany,
+  relatedToOne
+} from '../src/main'
 /* global fetch Response */
 import { isObservable, toJS } from 'mobx'
-import { Store, Model, attribute, relatedToOne, relatedToMany } from '../src/main'
+
 import { URL_MAX_LENGTH } from '../src/utils'
 
 class Tag extends Model {
@@ -32,19 +39,13 @@ class Todo extends Model {
   static endpoint = 'todos'
 
   @attribute(String) title = ''
-  @relatedToMany(Note) user_notes
-  @relatedToOne(Note) instructions
+  @relatedToMany notes
   @relatedToOne category
   @relatedToMany tags
 }
 
 class AppStore extends Store {
-  static types = [
-    Note,
-    Todo,
-    Tag,
-    Category
-  ]
+  static types = [Note, Todo, Tag, Category]
 }
 
 const mockBaseUrl = '/example_api'
@@ -53,7 +54,7 @@ const mockFetchOptions = {
   // credentials: 'includes',
   headers: {
     'Content-Type': 'application/vnd.api+json',
-    'Accepts': 'application/json'
+    Accepts: 'application/json'
   }
 }
 
@@ -79,12 +80,18 @@ const mockTodosResponse = JSON.stringify({ data: [mockTodoData.data] })
 const createMockIds = (numberOfIds, idPrefix = '') => {
   return [...Array(numberOfIds)].map((_, index) => {
     const startingNumber = Number(idPrefix)
-    return isNaN(startingNumber) ? `${idPrefix}${index}` : String(startingNumber + index)
+    return isNaN(startingNumber)
+      ? `${idPrefix}${index}`
+      : String(startingNumber + index)
   })
 }
 
-const createMockTodosAttributes = (numberOfRecords, idPrefix = '', titlePrefix = 'Todo') => {
-  return createMockIds(numberOfRecords, idPrefix).map(id => {
+const createMockTodosAttributes = (
+  numberOfRecords,
+  idPrefix = '',
+  titlePrefix = 'Todo'
+) => {
+  return createMockIds(numberOfRecords, idPrefix).map((id) => {
     return {
       id,
       title: `${titlePrefix} ${id}`
@@ -92,8 +99,16 @@ const createMockTodosAttributes = (numberOfRecords, idPrefix = '', titlePrefix =
   })
 }
 
-const createMockTodosResponse = (numberOfRecords, idPrefix = '', titlePrefix = 'Todo') => {
-  const data = createMockTodosAttributes(numberOfRecords, idPrefix, titlePrefix).map(attributes => {
+const createMockTodosResponse = (
+  numberOfRecords,
+  idPrefix = '',
+  titlePrefix = 'Todo'
+) => {
+  const data = createMockTodosAttributes(
+    numberOfRecords,
+    idPrefix,
+    titlePrefix
+  ).map((attributes) => {
     return {
       id: attributes.id,
       type: 'todos',
@@ -151,10 +166,7 @@ describe('Store', () => {
     it('adds multiple records to the store', () => {
       expect.assertions(2)
 
-      const exampleData = [
-        { title: 'Buy Milk' },
-        { title: 'Do laundry' }
-      ]
+      const exampleData = [{ title: 'Buy Milk' }, { title: 'Do laundry' }]
 
       const examples = store.add('todos', exampleData)
       expect(examples).toHaveLength(2)
@@ -187,7 +199,7 @@ describe('Store', () => {
   })
 
   describe('bulkSave', () => {
-    it('raises an invariant error if we submit n records and don\'t receive data for n records', async () => {
+    it("raises an invariant error if we submit n records and don't receive data for n records", async () => {
       expect.assertions(1)
 
       const todo1 = store.add('todos', { title: 'Pet Dog' })
@@ -220,7 +232,8 @@ describe('Store', () => {
             attributes: {
               title: 'Give Dog Treat'
             }
-          }]
+          }
+        ]
       }
       const mockTodosResponse = JSON.stringify(mockTodosData)
       fetch.mockResponse(mockTodosResponse)
@@ -264,7 +277,8 @@ describe('Store', () => {
             attributes: {
               title: 'Give Dog Treat'
             }
-          }]
+          }
+        ]
       }
       const mockTodosResponse = JSON.stringify(mockTodosData)
 
@@ -285,15 +299,17 @@ describe('Store', () => {
             attributes: {
               title: 'Pet Dog'
             }
-          }]
+          }
+        ]
       }
       const mockTodosResponse = JSON.stringify(mockTodosData)
       fetch.mockResponse(mockTodosResponse)
 
       await store.bulkSave('todos', [todo1])
 
-      expect(fetch.mock.calls[0][1].headers['Content-Type'])
-        .toEqual('application/vnd.api+json; ext="bulk"')
+      expect(fetch.mock.calls[0][1].headers['Content-Type']).toEqual(
+        'application/vnd.api+json; ext="bulk"'
+      )
     })
 
     it('adds the extensions to the request header', async () => {
@@ -307,15 +323,17 @@ describe('Store', () => {
             attributes: {
               title: 'Pet Dog'
             }
-          }]
+          }
+        ]
       }
       const mockTodosResponse = JSON.stringify(mockTodosData)
       fetch.mockResponse(mockTodosResponse)
 
-      await store.bulkSave('todos', [todo1], {extensions})
+      await store.bulkSave('todos', [todo1], { extensions })
 
-      expect(fetch.mock.calls[0][1].headers['Content-Type'])
-        .toEqual('application/vnd.api+json; ext="bulk,artemis/group,artemis/extendDaThings"')
+      expect(fetch.mock.calls[0][1].headers['Content-Type']).toEqual(
+        'application/vnd.api+json; ext="bulk,artemis/group,artemis/extendDaThings"'
+      )
     })
 
     it('ignores empty extensions in the request header', async () => {
@@ -329,25 +347,25 @@ describe('Store', () => {
             attributes: {
               title: 'Pet Dog'
             }
-          }]
+          }
+        ]
       }
       const mockTodosResponse = JSON.stringify(mockTodosData)
       fetch.mockResponse(mockTodosResponse)
 
-      await store.bulkSave('todos', [todo1], {extensions})
+      await store.bulkSave('todos', [todo1], { extensions })
 
-      expect(fetch.mock.calls[0][1].headers['Content-Type'])
-        .toEqual('application/vnd.api+json; ext="bulk"')
+      expect(fetch.mock.calls[0][1].headers['Content-Type']).toEqual(
+        'application/vnd.api+json; ext="bulk"'
+      )
     })
   })
 
   describe('updateRecords', () => {
-    function mockRequest (errors) {
+    function mockRequest(errors) {
       return new Promise((resolve, reject) => {
         const body = JSON.stringify({ errors })
-        process.nextTick(() => resolve(
-          new Response(body, { status: 422 })
-        ))
+        process.nextTick(() => resolve(new Response(body, { status: 422 })))
       })
     }
 
@@ -495,17 +513,13 @@ describe('Store', () => {
       store.add('todos', { title: 'Buy Milk' })
       store.add('notes', { text: 'Example text' })
 
-      expect(store.findAll('todos', { fromServer: false }))
-        .toHaveLength(1)
-      expect(store.findAll('notes', { fromServer: false }))
-        .toHaveLength(1)
+      expect(store.findAll('todos', { fromServer: false })).toHaveLength(1)
+      expect(store.findAll('notes', { fromServer: false })).toHaveLength(1)
 
       store.reset()
 
-      expect(store.findAll('todos', { fromServer: false }))
-        .toHaveLength(0)
-      expect(store.findAll('notes', { fromServer: false }))
-        .toHaveLength(0)
+      expect(store.findAll('todos', { fromServer: false })).toHaveLength(0)
+      expect(store.findAll('notes', { fromServer: false })).toHaveLength(0)
     })
 
     it('removes records of a specific type if type arg is provided', async () => {
@@ -513,17 +527,13 @@ describe('Store', () => {
       store.add('todos', { title: 'Buy Milk' })
       store.add('notes', { text: 'Example text' })
 
-      expect(store.findAll('todos', { fromServer: false }))
-        .toHaveLength(1)
-      expect(store.findAll('notes', { fromServer: false }))
-        .toHaveLength(1)
+      expect(store.findAll('todos', { fromServer: false })).toHaveLength(1)
+      expect(store.findAll('notes', { fromServer: false })).toHaveLength(1)
 
       store.reset('todos')
 
-      expect(store.findAll('todos', { fromServer: false }))
-        .toHaveLength(0)
-      expect(store.findAll('notes', { fromServer: false }))
-        .toHaveLength(1)
+      expect(store.findAll('todos', { fromServer: false })).toHaveLength(0)
+      expect(store.findAll('notes', { fromServer: false })).toHaveLength(1)
     })
   })
 
@@ -555,8 +565,9 @@ describe('Store', () => {
           user_id: '1'
         }
       })
-      expect(decodeURIComponent(fetch.mock.calls[0][0]))
-        .toEqual('/example_api/todos/1?filter[due_at]=2019-01-01&include=todo.notes&user_id=1')
+      expect(decodeURIComponent(fetch.mock.calls[0][0])).toEqual(
+        '/example_api/todos/1?filter[due_at]=2019-01-01&include=todo.notes&user_id=1'
+      )
     })
   })
 
@@ -590,8 +601,7 @@ describe('Store', () => {
         expect(todos).toHaveLength(1)
         expect(todos[0].title).toEqual('Do taxes')
         expect(fetch.mock.calls).toHaveLength(1)
-        expect(fetch.mock.calls[0][0])
-          .toEqual('/example_api/todos')
+        expect(fetch.mock.calls[0][0]).toEqual('/example_api/todos')
       })
 
       it('fetches data with filter params', async () => {
@@ -607,8 +617,9 @@ describe('Store', () => {
           }
         })
         expect(fetch.mock.calls).toHaveLength(1)
-        expect(decodeURIComponent(fetch.mock.calls[0][0]))
-          .toEqual('/example_api/todos?filter[title]=Do taxes&filter[overdue]=true')
+        expect(decodeURIComponent(fetch.mock.calls[0][0])).toEqual(
+          '/example_api/todos?filter[title]=Do taxes&filter[overdue]=true'
+        )
       })
 
       it('fetches data with include params', async () => {
@@ -621,8 +632,9 @@ describe('Store', () => {
           }
         })
         expect(fetch.mock.calls).toHaveLength(1)
-        expect(decodeURIComponent(fetch.mock.calls[0][0]))
-          .toEqual('/example_api/todos?include=todo.notes,todo.comments')
+        expect(decodeURIComponent(fetch.mock.calls[0][0])).toEqual(
+          '/example_api/todos?include=todo.notes,todo.comments'
+        )
       })
 
       it('fetches data with named query params', async () => {
@@ -635,8 +647,9 @@ describe('Store', () => {
           }
         })
         expect(fetch.mock.calls).toHaveLength(1)
-        expect(decodeURIComponent(fetch.mock.calls[0][0]))
-          .toEqual('/example_api/todos?foo=bar')
+        expect(decodeURIComponent(fetch.mock.calls[0][0])).toEqual(
+          '/example_api/todos?foo=bar'
+        )
       })
 
       it('fetches data with named array filters', async () => {
@@ -651,8 +664,9 @@ describe('Store', () => {
           }
         })
         expect(fetch.mock.calls).toHaveLength(1)
-        expect(decodeURIComponent(fetch.mock.calls[0][0]))
-          .toEqual('/example_api/todos?filter[ids][]=1&filter[ids][]=2')
+        expect(decodeURIComponent(fetch.mock.calls[0][0])).toEqual(
+          '/example_api/todos?filter[ids][]=1&filter[ids][]=2'
+        )
       })
 
       it('caches list ids by request url', async () => {
@@ -774,7 +788,9 @@ describe('Store', () => {
     describe('"fromServer" is set to false', () => {
       describe('records of the specified type do not exist', () => {
         it('returns an empty array', () => {
-          const todos = store.findMany('todos', ['1001', '5000'], { fromServer: false })
+          const todos = store.findMany('todos', ['1001', '5000'], {
+            fromServer: false
+          })
           expect(todos).toHaveLength(0)
         })
       })
@@ -799,8 +815,9 @@ describe('Store', () => {
         expect(todos).toHaveLength(5)
         expect(todos[0].title).toEqual('Todo 1000')
         expect(fetch.mock.calls).toHaveLength(1)
-        expect(fetch.mock.calls[0][0])
-          .toEqual('/example_api/todos?filter%5Bids%5D=1000%2C1001%2C1002%2C1003%2C1004')
+        expect(fetch.mock.calls[0][0]).toEqual(
+          '/example_api/todos?filter%5Bids%5D=1000%2C1001%2C1002%2C1003%2C1004'
+        )
       })
 
       it('uses multiple fetches for data from server', async () => {
@@ -820,7 +837,7 @@ describe('Store', () => {
         const [firstCall] = fetch.mock.calls[0]
         expect(decodeURIComponent(firstCall)).toMatch(/1139$/)
 
-        fetch.mock.calls.forEach(call => {
+        fetch.mock.calls.forEach((call) => {
           expect(call[0].length).toBeLessThan(URL_MAX_LENGTH)
         })
       })
@@ -842,9 +859,11 @@ describe('Store', () => {
         })
 
         expect(fetch.mock.calls).toHaveLength(3)
-        fetch.mock.calls.forEach(call => {
+        fetch.mock.calls.forEach((call) => {
           const [path] = call
-          expect(decodeURIComponent(path)).toMatch('/example_api/todos?filter[title]=Do taxes&filter[overdue]=true')
+          expect(decodeURIComponent(path)).toMatch(
+            '/example_api/todos?filter[title]=Do taxes&filter[overdue]=true'
+          )
           expect(call.length).toBeLessThan(URL_MAX_LENGTH)
         })
 
@@ -866,7 +885,7 @@ describe('Store', () => {
         })
 
         expect(fetch.mock.calls).toHaveLength(3)
-        fetch.mock.calls.forEach(call => {
+        fetch.mock.calls.forEach((call) => {
           const [path] = call
           expect(decodeURIComponent(path)).toMatch('filter[category]=important')
           expect(call.length).toBeLessThan(URL_MAX_LENGTH)
@@ -898,13 +917,15 @@ describe('Store', () => {
           const todos = await store.findMany('todos', ids)
 
           expect(todos).toHaveLength(300)
-          expect(store.findAll('todos', { fromServer: false })).toHaveLength(300)
+          expect(store.findAll('todos', { fromServer: false })).toHaveLength(
+            300
+          )
 
           expect(fetch.mock.calls).toHaveLength(3)
           const [firstCall] = fetch.mock.calls[0]
           expect(decodeURIComponent(firstCall)).toMatch(/1139$/)
 
-          fetch.mock.calls.forEach(call => {
+          fetch.mock.calls.forEach((call) => {
             expect(call[0].length).toBeLessThan(URL_MAX_LENGTH)
           })
         })
@@ -923,13 +944,19 @@ describe('Store', () => {
           const todos = await store.findMany('todos', ids)
 
           expect(todos).toHaveLength(300)
-          expect(store.findAll('todos', { fromServer: false })).toHaveLength(325)
+          expect(store.findAll('todos', { fromServer: false })).toHaveLength(
+            325
+          )
 
           expect(fetch.mock.calls).toHaveLength(2)
-          expect(fetch.mock.calls.some(call => call[0].match(/1174/))).toBeTruthy()
-          expect(fetch.mock.calls.some(call => call[0].match(/1175/))).toBeFalsy()
+          expect(
+            fetch.mock.calls.some((call) => call[0].match(/1174/))
+          ).toBeTruthy()
+          expect(
+            fetch.mock.calls.some((call) => call[0].match(/1175/))
+          ).toBeFalsy()
 
-          fetch.mock.calls.forEach(call => {
+          fetch.mock.calls.forEach((call) => {
             expect(call[0].length).toBeLessThan(URL_MAX_LENGTH)
           })
         })
@@ -945,7 +972,9 @@ describe('Store', () => {
           const todos = await store.findMany('todos', ids)
 
           expect(todos).toHaveLength(300)
-          expect(store.findAll('todos', { fromServer: false })).toHaveLength(400)
+          expect(store.findAll('todos', { fromServer: false })).toHaveLength(
+            400
+          )
 
           expect(fetch.mock.calls).toHaveLength(0)
         })
@@ -990,32 +1019,6 @@ describe('Store', () => {
       expect(todo.tags[0].id).toEqual(tag.id)
       expect(todo.tags[0].label).toEqual(tag.label)
     })
-
-    it('creates a model with aliased relatedToOne property', () => {
-      const note = store.add('notes', { id: 17, text: 'Example text' })
-      const todoData = {
-        attributes: { title: 'hello!' },
-        relationships: {
-          note: { data: { id: note.id, type: 'notes' } }
-        }
-      }
-      const todo = store.createModel('todos', 1, todoData)
-      expect(todo.instructions.id).toEqual(note.id)
-      expect(todo.instructions.text).toEqual(note.text)
-    })
-
-    it('creates a model with aliased relatedToMany property', () => {
-      const note = store.add('notes', { id: 3, text: 'hi' })
-      const todoData = {
-        attributes: { title: 'hello!' },
-        relationships: {
-          notes: { data: [{ id: note.id, type: 'notes' }] }
-        }
-      }
-      const todo = store.createModel('todos', 1, todoData)
-      expect(todo.user_notes[0].id).toEqual(note.id)
-      expect(todo.user_notes[0].text).toEqual(note.text)
-    })
   })
 
   describe('createOrUpdateModel', () => {
@@ -1045,8 +1048,18 @@ describe('Store', () => {
   describe('createModelsFromData', () => {
     it('creates a list of model objs from a list of data objs', () => {
       const dataObjs = [
-        { id: 1, type: 'todos', attributes: { title: 'hello!' }, relationships: {} },
-        { id: 2, type: 'todos', attributes: { title: 'see ya!' }, relationships: {} }
+        {
+          id: 1,
+          type: 'todos',
+          attributes: { title: 'hello!' },
+          relationships: {}
+        },
+        {
+          id: 2,
+          type: 'todos',
+          attributes: { title: 'see ya!' },
+          relationships: {}
+        }
       ]
       const todos = store.createModelsFromData(dataObjs)
       expect(todos).toHaveLength(2)
@@ -1060,8 +1073,18 @@ describe('Store', () => {
 
     it('skips objs with an unknown type', () => {
       const dataObjs = [
-        { id: 1, type: 'todos', attributes: { title: 'hello!' }, relationships: {} },
-        { id: 2, type: 'unknown', attributes: { title: 'see ya!' }, relationships: {} }
+        {
+          id: 1,
+          type: 'todos',
+          attributes: { title: 'hello!' },
+          relationships: {}
+        },
+        {
+          id: 2,
+          type: 'unknown',
+          attributes: { title: 'see ya!' },
+          relationships: {}
+        }
       ]
       const todos = store.createModelsFromData(dataObjs)
       expect(todos).toHaveLength(2)


### PR DESCRIPTION
This PR is the first step in moving us away from using `fromServer` options it also removes the ability to specify model classes on relationships.

The only actual change that will need to be made in portal and mobile is that `fetchOne` method signature now takes options (ie `{queryParams: {include: 'todos'}}`) instead of the queryParams directly like it was (ie. `{include: 'todos'}`)

The corresponding PRs are
https://github.com/artemis-ag/portal/pull/4719
https://github.com/artemis-ag/artemis-mobile/pull/345