### PR TITLE
Remove attribute listeners 177025210

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -4,21 +4,21 @@ Object.defineProperty(exports, '__esModule', { value: true });
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var _toConsumableArray = _interopDefault(require('@babel/runtime/helpers/toConsumableArray'));
 var _defineProperty = _interopDefault(require('@babel/runtime/helpers/defineProperty'));
 var _regeneratorRuntime = _interopDefault(require('@babel/runtime/regenerator'));
 var _asyncToGenerator = _interopDefault(require('@babel/runtime/helpers/asyncToGenerator'));
 var _initializerDefineProperty = _interopDefault(require('@babel/runtime/helpers/initializerDefineProperty'));
 var _classCallCheck = _interopDefault(require('@babel/runtime/helpers/classCallCheck'));
 var _createClass = _interopDefault(require('@babel/runtime/helpers/createClass'));
-var _applyDecoratedDescriptor = _interopDefault(require('@babel/runtime/helpers/applyDecoratedDescriptor'));
 require('@babel/runtime/helpers/initializerWarningHelper');
+var _applyDecoratedDescriptor = _interopDefault(require('@babel/runtime/helpers/applyDecoratedDescriptor'));
 var _typeof = _interopDefault(require('@babel/runtime/helpers/typeof'));
 var mobx = require('mobx');
 var _inherits = _interopDefault(require('@babel/runtime/helpers/inherits'));
 var _possibleConstructorReturn = _interopDefault(require('@babel/runtime/helpers/possibleConstructorReturn'));
 var _getPrototypeOf = _interopDefault(require('@babel/runtime/helpers/getPrototypeOf'));
 var _wrapNativeSuper = _interopDefault(require('@babel/runtime/helpers/wrapNativeSuper'));
+var _toConsumableArray = _interopDefault(require('@babel/runtime/helpers/toConsumableArray'));
 var uuidv1 = _interopDefault(require('uuid/v1'));
 var qs = _interopDefault(require('qs'));
 var pluralize = _interopDefault(require('pluralize'));
@@ -396,7 +396,7 @@ var Schema = /*#__PURE__*/function () {
 
 var schema = new Schema();
 
-var _class, _descriptor, _descriptor2, _descriptor3, _descriptor4, _temp;
+var _class, _descriptor, _temp;
 
 function ownKeys$1(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
@@ -477,15 +477,9 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
 
     _classCallCheck(this, Model);
 
-    _initializerDefineProperty(this, "_disposed", _descriptor, this);
-
-    _initializerDefineProperty(this, "_dirtyRelationships", _descriptor2, this);
-
-    _initializerDefineProperty(this, "_dirtyAttributes", _descriptor3, this);
-
     this.isInFlight = false;
 
-    _initializerDefineProperty(this, "errors", _descriptor4, this);
+    _initializerDefineProperty(this, "errors", _descriptor, this);
 
     this._snapshots = [];
 
@@ -511,94 +505,41 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
    */
 
   /**
-    * has this object been destroyed?
-    * @property _disposed
-    * @type {Boolean}
-    * @default false
-    */
+   * True if the instance has been modified from its persisted state
+   *
+   * NOTE that isDirty does _NOT_ track changes to the related objects
+   * but it _does_ track changes to the relationships themselves.
+   *
+   * For example, adding or removing a related object will mark this record as dirty,
+   * but changing a related object's properties will not mark this record as dirty.
+   *
+   * The caller is reponsible for asking related objects about their
+   * own dirty state.
+   *
+   * ```
+   * kpi = store.add('kpis', { name: 'A good thing to measure' })
+   * kpi.isDirty
+   * => true
+   * kpi.name
+   * => "A good thing to measure"
+   * await kpi.save()
+   * kpi.isDirty
+   * => false
+   * kpi.name = "Another good thing to measure"
+   * kpi.isDirty
+   * => true
+   * await kpi.save()
+   * kpi.isDirty
+   * => false
+   * ```
+   * @property isDirty
+   * @type {Boolean}
+   */
 
 
   _createClass(Model, [{
-    key: "isDirty",
-    get:
-    /**
-     * True if the instance has been modified from its persisted state
-     *
-     * NOTE that isDirty does _NOT_ track changes to the related objects
-     * but it _does_ track changes to the relationships themselves.
-     *
-     * For example, adding or removing a related object will mark this record as dirty,
-     * but changing a related object's properties will not mark this record as dirty.
-     *
-     * The caller is reponsible for asking related objects about their
-     * own dirty state.
-     *
-     * ```
-     * kpi = store.add('kpis', { name: 'A good thing to measure' })
-     * kpi.isDirty
-     * => true
-     * kpi.name
-     * => "A good thing to measure"
-     * await kpi.save()
-     * kpi.isDirty
-     * => false
-     * kpi.name = "Another good thing to measure"
-     * kpi.isDirty
-     * => true
-     * await kpi.save()
-     * kpi.isDirty
-     * => false
-     * ```
-     * @property isDirty
-     * @type {Boolean}
-     */
-    function get() {
-      return this._dirtyAttributes.size > 0 || this._dirtyRelationships.size > 0;
-    }
-    /**
-     * have any changes been made since this record was last persisted?
-     * @property hasUnpersistedChanges
-     * @type {Boolean}
-     */
-
-  }, {
-    key: "hasUnpersistedChanges",
-    get: function get() {
-      return this.isDirty || !this.previousSnapshot.persisted;
-    }
-    /**
-     * True if the model has not been sent to the store
-     * @property isNew
-     * @type {Boolean}
-     */
-
-  }, {
-    key: "isNew",
-    get: function get() {
-      var id = this.id;
-      if (!id) return true;
-      if (String(id).indexOf('tmp') === -1) return false;
-      return true;
-    }
-    /**
-     * True if the instance is coming from / going to the server
-     * ```
-     * kpi = store.find('kpis', 5)
-     * // fetch started
-     * kpi.isInFlight
-     * => true
-     * // fetch finished
-     * kpi.isInFlight
-     * => false
-     * ```
-     * @property isInFlight
-     * @type {Boolean}
-     * @default false
-     */
-
-  }, {
     key: "rollback",
-    value:
+
     /**
      * restores data to its last snapshot state
      * ```
@@ -612,7 +553,7 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
      * ```
      * @method rollback
      */
-    function rollback() {
+    value: function rollback() {
       this._applySnapshot(this.previousSnapshot);
     }
     /**
@@ -760,7 +701,7 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
                   _this.isInFlight = false;
 
                   if (![200, 202, 204].includes(response.status)) {
-                    _context.next = 18;
+                    _context.next = 17;
                     break;
                   }
 
@@ -796,17 +737,15 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
                     _this.store.createModelsFromData(json.included);
                   }
 
-                  _this.dispose();
-
                   return _context.abrupt("return", _this);
 
-                case 18:
+                case 17:
                   _this.errors = {
                     status: response.status
                   };
                   return _context.abrupt("return", _this);
 
-                case 20:
+                case 19:
                 case "end":
                   return _context.stop();
               }
@@ -838,64 +777,6 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
     value: function _makeObservable(initialAttributes) {
       var defaultAttributes = this.defaultAttributes;
       mobx.extendObservable(this, _objectSpread$1(_objectSpread$1({}, defaultAttributes), initialAttributes));
-
-      this._listenForChanges();
-    }
-    /**
-     * sets up a reaction for each top-level attribute so we can compare
-     * values after each mutation and keep track of dirty attr states
-     * if an attr is different than the last snapshot, add it to the
-     * _dirtyAttributes set
-     * if it's the same as the last snapshot, make sure it's _not_ in the
-     * _dirtyAttributes set
-     * @method _listenForChanges
-     */
-
-  }, {
-    key: "_listenForChanges",
-    value: function _listenForChanges() {
-      var _this3 = this;
-
-      this._disposers = Object.keys(this.attributes).map(function (attr) {
-        return mobx.reaction(function () {
-          return _this3.attributes[attr];
-        }, function (value) {
-          var previousValue = _this3.previousSnapshot.attributes[attr];
-
-          if (_isEqual(previousValue, value)) {
-            _this3._dirtyAttributes.delete(attr);
-          } else if (isObject(value)) {
-            // handles Objects and Arrays
-            // clear out any dirty attrs that start with this attr prefix
-            // then we can reset them if they are still (or newly) dirty
-            Array.from(_this3._dirtyAttributes).forEach(function (path) {
-              if (path.indexOf("".concat(attr, ".")) === 0) {
-                _this3._dirtyAttributes.delete(path);
-              }
-            });
-            diff(previousValue, value).forEach(function (property) {
-              _this3._dirtyAttributes.add("".concat(attr, ".").concat(property));
-            });
-          } else {
-            _this3._dirtyAttributes.add(attr);
-          }
-        });
-      });
-    }
-    /**
-     * call this when destroying an object to make sure that we clean up
-     * any event listeners and don't leak memory
-     * @method dispose
-     */
-
-  }, {
-    key: "dispose",
-    value: function dispose() {
-      this._disposed = true;
-
-      this._disposers.forEach(function (dispose) {
-        return dispose();
-      });
     }
     /**
      * The current state of defined attributes and relationships of the instance
@@ -914,21 +795,13 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
      */
 
   }, {
-    key: "snapshot",
-    get: function get() {
-      return {
-        attributes: this.attributes,
-        relationships: mobx.toJS(this.relationships)
-      };
-    }
+    key: "setPreviousSnapshot",
+
     /**
      * Sets previous snapshot to current snapshot
      *
      * @method setPreviousSnapshot
      */
-
-  }, {
-    key: "setPreviousSnapshot",
     value: function setPreviousSnapshot() {
       this._takeSnapshot();
     }
@@ -939,25 +812,8 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
      */
 
   }, {
-    key: "previousSnapshot",
-    get: function get() {
-      var length = this._snapshots.length;
-      if (length === 0) throw new Error('Invariant violated: model has no snapshots');
-      return this._snapshots[length - 1];
-    }
-    /**
-     * the latest persisted snapshot or the first snapshot if the model was never persisted
-     *
-     * @method previousSnapshot
-     */
+    key: "_takeSnapshot",
 
-  }, {
-    key: "persistedSnapshot",
-    get: function get() {
-      return findLast(this._snapshots, function (ss) {
-        return ss.persisted;
-      }) || this._snapshots[0];
-    }
     /**
      * take a snapshot of the current model state.
      * if persisted, clear the stack and push this snapshot to the top
@@ -965,17 +821,9 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
      * @method _takeSnapshot
      * @param {Object} options
      */
-
-  }, {
-    key: "_takeSnapshot",
     value: function _takeSnapshot() {
       var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
       var persisted = options.persisted || false;
-
-      this._dirtyRelationships.clear();
-
-      this._dirtyAttributes.clear();
-
       var _this$snapshot = this.snapshot,
           attributes = _this$snapshot.attributes,
           relationships = _this$snapshot.relationships;
@@ -1001,44 +849,17 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
   }, {
     key: "_applySnapshot",
     value: function _applySnapshot(snapshot) {
-      var _this4 = this;
+      var _this3 = this;
 
       if (!snapshot) throw new Error('Invariant violated: tried to apply undefined snapshot');
       mobx.transaction(function () {
-        _this4.attributeNames.forEach(function (key) {
-          _this4[key] = snapshot.attributes[key];
+        _this3.attributeNames.forEach(function (key) {
+          _this3[key] = snapshot.attributes[key];
         });
 
-        _this4.relationships = snapshot.relationships;
-        _this4.errors = {};
+        _this3.relationships = snapshot.relationships;
+        _this3.errors = {};
       });
-    }
-    /**
-     * a list of any property paths which have been changed since the previous
-     * snapshot
-     * ```
-     * const todo = new Todo({ title: 'Buy Milk' })
-     * todo.dirtyAttributes
-     * => []
-     * todo.title = 'Buy Cheese'
-     * todo.dirtyAttributes
-     * => ['title']
-     * todo.note = note1
-     * todo.dirtyAttributes
-     * => ['title', 'relationships.note']
-     * ```
-     * @method dirtyAttributes
-     * @return {Array} dirty attribute paths
-     */
-
-  }, {
-    key: "dirtyAttributes",
-    get: function get() {
-      var relationships = Array.from(this._dirtyRelationships).map(function (property) {
-        return "relationships.".concat(property);
-      });
-      var attributes = Array.from(this._dirtyAttributes);
-      return [].concat(_toConsumableArray(relationships), _toConsumableArray(attributes));
     }
     /**
      * shortcut to get the static
@@ -1047,6 +868,363 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
      * @return {String} current attributes
     */
 
+  }, {
+    key: "errorForKey",
+
+    /**
+     * Getter to check if the record has errors.
+     *
+     * @method hasErrors
+     * @return {Boolean}
+     */
+    value: function errorForKey(key) {
+      return this.errors[key];
+    }
+    /**
+     * Getter to just get the names of a records attributes.
+     *
+     * @method attributeNames
+     * @return {Array}
+     */
+
+  }, {
+    key: "jsonapi",
+
+    /**
+     * getter method to get data in api compliance format
+     * TODO: Figure out how to handle unpersisted ids
+     *
+     * @method jsonapi
+     * @return {Object} data in JSON::API format
+     */
+    value: function jsonapi() {
+      var _this4 = this;
+
+      var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+      var attributeDefinitions = this.attributeDefinitions,
+          attributeNames = this.attributeNames,
+          meta = this.meta,
+          id = this.id,
+          type = this.constructor.type;
+      var filteredAttributeNames = attributeNames;
+      var filteredRelationshipNames = [];
+
+      if (options.attributes) {
+        filteredAttributeNames = attributeNames.filter(function (name) {
+          return options.attributes.includes(name);
+        });
+      }
+
+      var attributes = filteredAttributeNames.reduce(function (attrs, key) {
+        var value = _this4[key];
+
+        if (value) {
+          var DataType = attributeDefinitions[key].dataType;
+          var attr;
+
+          if (DataType.name === 'Array' || DataType.name === 'Object') {
+            attr = mobx.toJS(value);
+          } else if (DataType.name === 'Date') {
+            attr = makeDate(value).toISOString();
+          } else {
+            attr = DataType(value);
+          }
+
+          attrs[key] = attr;
+        } else {
+          attrs[key] = value;
+        }
+
+        return attrs;
+      }, {});
+      var data = {
+        type: type,
+        attributes: attributes,
+        id: String(id)
+      };
+
+      if (options.relationships) {
+        filteredRelationshipNames = Object.keys(this.relationships).filter(function (name) {
+          return options.relationships.includes(name);
+        });
+        var relationships = filteredRelationshipNames.reduce(function (rels, key) {
+          rels[key] = mobx.toJS(_this4.relationships[key]);
+          stringifyIds(rels[key]);
+          return rels;
+        }, {});
+        data.relationships = relationships;
+      }
+
+      if (meta) {
+        data['meta'] = meta;
+      }
+
+      if (String(id).match(/tmp/)) {
+        delete data.id;
+      }
+
+      return data;
+    }
+  }, {
+    key: "updateAttributes",
+    value: function updateAttributes(attributes) {
+      var _this5 = this;
+
+      mobx.transaction(function () {
+        Object.keys(attributes).forEach(function (key) {
+          _this5[key] = attributes[key];
+        });
+      });
+    } // TODO: this shares a lot of functionality with Store.createOrUpdateModel
+    // Perhaps that shared code
+
+  }, {
+    key: "updateAttributesFromResponse",
+    value: function updateAttributesFromResponse(data, included) {
+      var _this6 = this;
+
+      var tmpId = this.id;
+      var id = data.id,
+          attributes = data.attributes,
+          relationships = data.relationships;
+      mobx.transaction(function () {
+        mobx.set(_this6, 'id', id);
+        Object.keys(attributes).forEach(function (key) {
+          mobx.set(_this6, key, attributes[key]);
+        });
+
+        if (relationships) {
+          Object.keys(relationships).forEach(function (key) {
+            if (!relationships[key].hasOwnProperty('meta')) {
+              // todo: throw error if relationship is not defined in model
+              mobx.set(_this6.relationships, key, relationships[key]);
+            }
+          });
+        }
+
+        if (included) {
+          _this6.store.createModelsFromData(included);
+        }
+      }); // Update target isInFlight
+
+      this.isInFlight = false;
+
+      this._takeSnapshot({
+        persisted: true
+      });
+
+      mobx.transaction(function () {
+        // NOTE: This resolves an issue where a record is persisted but the
+        // index key is still a temp uuid. We can't simply remove the temp
+        // key because there may be associated records that have the temp
+        // uuid id as its only reference to the newly persisted record.
+        // TODO: Figure out a way to update associated records to use the
+        // newly persisted id.
+        _this6.store.data[_this6.type].records.set(String(tmpId), _this6);
+
+        _this6.store.data[_this6.type].records.set(String(_this6.id), _this6);
+      });
+    }
+  }, {
+    key: "clone",
+    value: function clone() {
+      var attributes = cloneDeep(this.snapshot.attributes);
+      var relationships = cloneDeep(this.snapshot.relationships);
+      return this.store.createModel(this.type, this.id, {
+        attributes: attributes,
+        relationships: relationships
+      });
+    }
+    /**
+     * Comparison by value
+     * returns `true` if this object has the same attrs and relationships
+     * as the "other" object, ignores differences in internal state like
+     * attribute "dirtyness" or errors
+     *
+     * @method isEqual
+     * @param {Object} other
+     * @return {Object}
+     */
+
+  }, {
+    key: "isEqual",
+    value: function isEqual(other) {
+      if (!other) return false;
+      return _isEqual(this.attributes, other.attributes) && _isEqual(this.relationships, other.relationships);
+    }
+    /**
+     * Comparison by identity
+     * returns `true` if this object has the same type and id as the
+     * "other" object, ignores differences in attrs and relationships
+     *
+     * @method isSame
+     * @param {Object} other
+     * @return {Object}
+     */
+
+  }, {
+    key: "isSame",
+    value: function isSame(other) {
+      if (!other) return false;
+      return this.type === other.type && this.id === other.id;
+    }
+  }, {
+    key: "isDirty",
+    get: function get() {
+      return this.dirtyAttributes.length > 0 || this.dirtyRelationships.length > 0;
+    }
+    /**
+     * A list of any attribute paths which have been changed since the previous snapshot
+     *
+     * const todo = new Todo({ title: 'Buy Milk' })
+     * todo.dirtyAttributes
+     * => []
+     * todo.title = 'Buy Cheese'
+     * todo.dirtyAttributes
+     * => ['title']
+     * todo.options = { variety: 'Cheddar' }
+     * todo.dirtyAttributes
+     * => ['title', 'options.variety']
+     *
+     * @method dirtyAttributes
+     * @return {Array} dirty attribute paths
+     */
+
+  }, {
+    key: "dirtyAttributes",
+    get: function get() {
+      var _this7 = this;
+
+      return Array.from(Object.keys(this.attributes).reduce(function (dirtyAccumulator, attr) {
+        var currentValue = _this7.attributes[attr];
+        var previousValue = _this7.previousSnapshot.attributes[attr];
+
+        if (isObject(currentValue)) {
+          diff(currentValue, previousValue).forEach(function (property) {
+            dirtyAccumulator.add("".concat(attr, ".").concat(property));
+          });
+        } else if (!_isEqual(previousValue, currentValue)) {
+          dirtyAccumulator.add(attr);
+        }
+
+        return dirtyAccumulator;
+      }, new Set()));
+    }
+    /**
+     * A list of any relationship paths which have been changed since the previous snapshot
+     * We check changes to both ids and types in case there are polymorphic relationships
+     *
+     * const todo = new Todo({ title: 'Buy Milk' })
+     * todo.dirtyRelationships
+     * => []
+     * todo.note = note1
+     * todo.dirtyRelationships
+     * => ['relationships.note']
+     *
+     * @method dirtyRelationships
+     * @return {Array} dirty relationship paths
+     */
+
+  }, {
+    key: "dirtyRelationships",
+    get: function get() {
+      // TODO: make what returns from this.relationships to be more consistent
+      var previousRelationships = this.previousSnapshot.relationships || {};
+      var currentRelationships = this.relationships || {};
+      var schemaRelationships = this.relationshipNames;
+
+      if (Object.keys(currentRelationships).length === 0) {
+        return Object.keys(previousRelationships);
+      }
+
+      return Array.from(schemaRelationships.reduce(function (dirtyAccumulator, name) {
+        var _currentRelationships, _previousRelationship;
+
+        var currentValues = ((_currentRelationships = currentRelationships[name]) === null || _currentRelationships === void 0 ? void 0 : _currentRelationships.data) || [];
+        var previousValues = ((_previousRelationship = previousRelationships[name]) === null || _previousRelationship === void 0 ? void 0 : _previousRelationship.data) || [];
+        var currentIds = Array.isArray(currentValues) ? currentValues.map(function (value) {
+          return [value.id, value.type];
+        }).sort() : [currentValues.id, currentValues.type];
+        var previousIds = Array.isArray(previousValues) ? previousValues.map(function (value) {
+          return [value.id, value.type];
+        }).sort() : [previousValues.id, previousValues.type];
+
+        if (!_isEqual(currentIds, previousIds)) {
+          dirtyAccumulator.add(name);
+        }
+
+        return dirtyAccumulator;
+      }, new Set()));
+    }
+    /**
+     * Have any changes been made since this record was last persisted?
+     * @property hasUnpersistedChanges
+     * @type {Boolean}
+     */
+
+  }, {
+    key: "hasUnpersistedChanges",
+    get: function get() {
+      return this.isDirty || !this.previousSnapshot.persisted;
+    }
+    /**
+     * True if the model has not been sent to the store
+     * @property isNew
+     * @type {Boolean}
+     */
+
+  }, {
+    key: "isNew",
+    get: function get() {
+      var id = this.id;
+      if (!id) return true;
+      if (String(id).indexOf('tmp') === -1) return false;
+      return true;
+    }
+    /**
+     * True if the instance is coming from / going to the server
+     * ```
+     * kpi = store.find('kpis', 5)
+     * // fetch started
+     * kpi.isInFlight
+     * => true
+     * // fetch finished
+     * kpi.isInFlight
+     * => false
+     * ```
+     * @property isInFlight
+     * @type {Boolean}
+     * @default false
+     */
+
+  }, {
+    key: "snapshot",
+    get: function get() {
+      return {
+        attributes: this.attributes,
+        relationships: mobx.toJS(this.relationships)
+      };
+    }
+  }, {
+    key: "previousSnapshot",
+    get: function get() {
+      var length = this._snapshots.length;
+      if (length === 0) throw new Error('Invariant violated: model has no snapshots');
+      return this._snapshots[length - 1];
+    }
+    /**
+     * the latest persisted snapshot or the first snapshot if the model was never persisted
+     *
+     * @method previousSnapshot
+     */
+
+  }, {
+    key: "persistedSnapshot",
+    get: function get() {
+      return findLast(this._snapshots, function (ss) {
+        return ss.persisted;
+      }) || this._snapshots[0];
+    }
   }, {
     key: "type",
     get: function get() {
@@ -1062,10 +1240,10 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
   }, {
     key: "attributes",
     get: function get() {
-      var _this5 = this;
+      var _this8 = this;
 
       return this.attributeNames.reduce(function (attributes, key) {
-        var value = mobx.toJS(_this5[key]);
+        var value = mobx.toJS(_this8[key]);
 
         if (value == null) {
           delete attributes[key];
@@ -1114,25 +1292,6 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
     get: function get() {
       return Object.keys(this.errors).length > 0;
     }
-    /**
-     * Getter to check if the record has errors.
-     *
-     * @method hasErrors
-     * @return {Boolean}
-     */
-
-  }, {
-    key: "errorForKey",
-    value: function errorForKey(key) {
-      return this.errors[key];
-    }
-    /**
-     * Getter to just get the names of a records attributes.
-     *
-     * @method attributeNames
-     * @return {Array}
-     */
-
   }, {
     key: "attributeNames",
     get: function get() {
@@ -1169,212 +1328,10 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
         relationships: {}
       });
     }
-    /**
-     * getter method to get data in api compliance format
-     * TODO: Figure out how to handle unpersisted ids
-     *
-     * @method jsonapi
-     * @return {Object} data in JSON::API format
-     */
-
-  }, {
-    key: "jsonapi",
-    value: function jsonapi() {
-      var _this6 = this;
-
-      var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-      var attributeDefinitions = this.attributeDefinitions,
-          attributeNames = this.attributeNames,
-          meta = this.meta,
-          id = this.id,
-          type = this.constructor.type;
-      var filteredAttributeNames = attributeNames;
-      var filteredRelationshipNames = [];
-
-      if (options.attributes) {
-        filteredAttributeNames = attributeNames.filter(function (name) {
-          return options.attributes.includes(name);
-        });
-      }
-
-      var attributes = filteredAttributeNames.reduce(function (attrs, key) {
-        var value = _this6[key];
-
-        if (value) {
-          var DataType = attributeDefinitions[key].dataType;
-          var attr;
-
-          if (DataType.name === 'Array' || DataType.name === 'Object') {
-            attr = mobx.toJS(value);
-          } else if (DataType.name === 'Date') {
-            attr = makeDate(value).toISOString();
-          } else {
-            attr = DataType(value);
-          }
-
-          attrs[key] = attr;
-        } else {
-          attrs[key] = value;
-        }
-
-        return attrs;
-      }, {});
-      var data = {
-        type: type,
-        attributes: attributes,
-        id: String(id)
-      };
-
-      if (options.relationships) {
-        filteredRelationshipNames = Object.keys(this.relationships).filter(function (name) {
-          return options.relationships.includes(name);
-        });
-        var relationships = filteredRelationshipNames.reduce(function (rels, key) {
-          rels[key] = mobx.toJS(_this6.relationships[key]);
-          stringifyIds(rels[key]);
-          return rels;
-        }, {});
-        data.relationships = relationships;
-      }
-
-      if (meta) {
-        data['meta'] = meta;
-      }
-
-      if (String(id).match(/tmp/)) {
-        delete data.id;
-      }
-
-      return data;
-    }
-  }, {
-    key: "updateAttributes",
-    value: function updateAttributes(attributes) {
-      var _this7 = this;
-
-      mobx.transaction(function () {
-        Object.keys(attributes).forEach(function (key) {
-          _this7[key] = attributes[key];
-        });
-      });
-    } // TODO: this shares a lot of functionality with Store.createOrUpdateModel
-    // Perhaps that shared code
-
-  }, {
-    key: "updateAttributesFromResponse",
-    value: function updateAttributesFromResponse(data, included) {
-      var _this8 = this;
-
-      var tmpId = this.id;
-      var id = data.id,
-          attributes = data.attributes,
-          relationships = data.relationships;
-      mobx.transaction(function () {
-        mobx.set(_this8, 'id', id);
-        Object.keys(attributes).forEach(function (key) {
-          mobx.set(_this8, key, attributes[key]);
-        });
-
-        if (relationships) {
-          Object.keys(relationships).forEach(function (key) {
-            if (!relationships[key].hasOwnProperty('meta')) {
-              // todo: throw error if relationship is not defined in model
-              mobx.set(_this8.relationships, key, relationships[key]);
-            }
-          });
-        }
-
-        if (included) {
-          _this8.store.createModelsFromData(included);
-        }
-      }); // Update target isInFlight
-
-      this.isInFlight = false;
-
-      this._takeSnapshot({
-        persisted: true
-      });
-
-      mobx.transaction(function () {
-        // NOTE: This resolves an issue where a record is persisted but the
-        // index key is still a temp uuid. We can't simply remove the temp
-        // key because there may be associated records that have the temp
-        // uuid id as its only reference to the newly persisted record.
-        // TODO: Figure out a way to update associated records to use the
-        // newly persisted id.
-        _this8.store.data[_this8.type].records.set(String(tmpId), _this8);
-
-        _this8.store.data[_this8.type].records.set(String(_this8.id), _this8);
-      });
-    }
-  }, {
-    key: "clone",
-    value: function clone() {
-      var attributes = cloneDeep(this.snapshot.attributes);
-      var relationships = cloneDeep(this.snapshot.relationships);
-      return this.store.createModel(this.type, this.id, {
-        attributes: attributes,
-        relationships: relationships
-      });
-    }
-    /**
-     * Comparison by value
-     * returns `true` if this object has the same attrs and relationships
-     * as the "other" object, ignores differences in internal state like
-     * attribute "dirtyness" or errors
-     *
-     * @method isEqual
-     * @param {Object} other
-     * @return {Object}
-     */
-
-  }, {
-    key: "isEqual",
-    value: function isEqual(other) {
-      if (!other) return false;
-      return _isEqual(this.attributes, other.attributes) && _isEqual(this.relationships, other.relationships);
-    }
-    /**
-     * Comparison by identity
-     * returns `true` if this object has the same type and id as the
-     * "other" object, ignores differences in attrs and relationships
-     *
-     * @method isSame
-     * @param {Object} other
-     * @return {Object}
-     */
-
-  }, {
-    key: "isSame",
-    value: function isSame(other) {
-      if (!other) return false;
-      return this.type === other.type && this.id === other.id;
-    }
   }]);
 
   return Model;
-}(), _temp), (_descriptor = _applyDecoratedDescriptor(_class.prototype, "_disposed", [mobx.observable], {
-  configurable: true,
-  enumerable: true,
-  writable: true,
-  initializer: function initializer() {
-    return false;
-  }
-}), _descriptor2 = _applyDecoratedDescriptor(_class.prototype, "_dirtyRelationships", [mobx.observable], {
-  configurable: true,
-  enumerable: true,
-  writable: true,
-  initializer: function initializer() {
-    return new Set();
-  }
-}), _descriptor3 = _applyDecoratedDescriptor(_class.prototype, "_dirtyAttributes", [mobx.observable], {
-  configurable: true,
-  enumerable: true,
-  writable: true,
-  initializer: function initializer() {
-    return new Set();
-  }
-}), _applyDecoratedDescriptor(_class.prototype, "isNew", [mobx.computed], Object.getOwnPropertyDescriptor(_class.prototype, "isNew"), _class.prototype), _descriptor4 = _applyDecoratedDescriptor(_class.prototype, "errors", [mobx.observable], {
+}(), _temp), (_applyDecoratedDescriptor(_class.prototype, "isNew", [mobx.computed], Object.getOwnPropertyDescriptor(_class.prototype, "isNew"), _class.prototype), _descriptor = _applyDecoratedDescriptor(_class.prototype, "errors", [mobx.observable], {
   configurable: true,
   enumerable: true,
   writable: true,
@@ -1383,7 +1340,7 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
   }
 })), _class);
 
-var _class$1, _descriptor$1, _descriptor2$1, _descriptor3$1, _temp$1;
+var _class$1, _descriptor$1, _descriptor2, _descriptor3, _temp$1;
 
 function ownKeys$2(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
@@ -1437,7 +1394,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
       return model;
     };
 
-    _initializerDefineProperty(this, "addModel", _descriptor2$1, this);
+    _initializerDefineProperty(this, "addModel", _descriptor2, this);
 
     this.addModels = function (type, data) {
       return mobx.transaction(function () {
@@ -1500,7 +1457,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
       };
     }();
 
-    _initializerDefineProperty(this, "remove", _descriptor3$1, this);
+    _initializerDefineProperty(this, "remove", _descriptor3, this);
 
     this.getOne = function (type, id) {
       var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
@@ -1680,7 +1637,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
 
   _createClass(Store, [{
     key: "fetchOne",
-    value:
+
     /**
      * Fetches record by `id` from the server and returns a Promise.
      *
@@ -1691,7 +1648,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
      * @param {Object} options { queryParams }
      * @return {Object} record
      */
-    function () {
+    value: function () {
       var _fetchOne = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee2(type, id) {
         var options,
             queryParams,
@@ -1789,7 +1746,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
 
   }, {
     key: "fetchUrl",
-    value:
+
     /**
      * Builds fetch url based
      *
@@ -1797,7 +1754,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
      * @param {String} type the type to find
      * @param {Object} options
      */
-    function fetchUrl(type, queryParams, id, options) {
+    value: function fetchUrl(type, queryParams, id, options) {
       var baseUrl = this.baseUrl,
           modelTypeIndex = this.modelTypeIndex;
       var endpoint = modelTypeIndex[type].endpoint;
@@ -1814,7 +1771,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
 
   }, {
     key: "fetchAll",
-    value:
+
     /**
      * Finds all records with the given `type`. Always fetches from the server.
      *
@@ -1824,7 +1781,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
      * @param {Object} options
      * @return {Promise} Promise.resolve(records) or Promise.reject(status)
      */
-    function () {
+    value: function () {
       var _fetchAll = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee3(type) {
         var _this2 = this;
 
@@ -1949,7 +1906,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
 
   }, {
     key: "reset",
-    value:
+
     /**
      * Clears the store of a given type, or clears all if no type given
      *
@@ -1960,7 +1917,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
      *
      * @method reset
      */
-    function reset(type) {
+    value: function reset(type) {
       if (type) {
         this.data[type] = {
           records: mobx.observable.map({}),
@@ -2073,7 +2030,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
       return combineRacedRequests(key, function () {
         return fetch(url, _objectSpread$2(_objectSpread$2({}, defaultFetchOptions), options));
       });
-    }
+    })
     /**
      * Gets type of collection from data observable
      *
@@ -2081,7 +2038,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
      * @param {String} type
      * @return {Object} observable type object structure
      */
-    )
+
   }, {
     key: "getType",
     value: function getType(type) {
@@ -2469,7 +2426,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
   initializer: function initializer() {
     return {};
   }
-}), _descriptor2$1 = _applyDecoratedDescriptor(_class$1.prototype, "addModel", [mobx.action], {
+}), _descriptor2 = _applyDecoratedDescriptor(_class$1.prototype, "addModel", [mobx.action], {
   configurable: true,
   enumerable: true,
   writable: true,
@@ -2489,7 +2446,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
       return model;
     };
   }
-}), _descriptor3$1 = _applyDecoratedDescriptor(_class$1.prototype, "remove", [mobx.action], {
+}), _descriptor3 = _applyDecoratedDescriptor(_class$1.prototype, "remove", [mobx.action], {
   configurable: true,
   enumerable: true,
   writable: true,
@@ -2792,8 +2749,7 @@ function setRelatedRecord(record, relatedRecord, property) {
     throw new Error('Related record must be a valid Model object');
   }
 
-  var relationships = record.relationships,
-      _dirtyRelationships = record._dirtyRelationships;
+  var relationships = record.relationships;
   var relationType = modelType || property;
   var referenceRecord = relatedRecord || getRelatedRecord(record, relationType);
 
@@ -2807,8 +2763,6 @@ function setRelatedRecord(record, relatedRecord, property) {
 
   if (!relatedRecord) {
     delete relationships[relationType];
-
-    _dirtyRelationships.add(relationType);
   } else if (!data || !(data.type === type && data.id === id)) {
     relationships[relationType] = {
       data: {
@@ -2816,8 +2770,6 @@ function setRelatedRecord(record, relatedRecord, property) {
         type: type
       }
     };
-
-    _dirtyRelationships.add(relationType);
   } else {
     return relatedRecord;
   } // hack we don't have a reference to the inverse name so we just use the record type.
@@ -2893,9 +2845,7 @@ var RelatedRecordsArray = /*#__PURE__*/function (_Array) {
           type: type
         });
 
-        _this.push(relatedRecord);
-
-        record._dirtyRelationships.add(property); // setting the inverse - hack this will only work with singularized relationships.
+        _this.push(relatedRecord); // setting the inverse - hack this will only work with singularized relationships.
 
 
         setRelatedRecord(relatedRecord, record, recordType.slice(0, recordType.length - 1));
@@ -2935,9 +2885,7 @@ var RelatedRecordsArray = /*#__PURE__*/function (_Array) {
 
         if (!Object.keys(record.relationships).length) {
           delete record.relationships;
-        }
-
-        record._dirtyRelationships.add(property); // hack this will only work with singularized relationships.
+        } // hack this will only work with singularized relationships.
 
 
         setRelatedRecord(relatedRecord, null, recordType.slice(0, recordType.length - 1));
@@ -2959,8 +2907,6 @@ var RelatedRecordsArray = /*#__PURE__*/function (_Array) {
         array.forEach(function (object) {
           return _this.add(object);
         });
-
-        record._dirtyRelationships.add(property);
       });
     };
 

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -1,18 +1,18 @@
-import _toConsumableArray from '@babel/runtime/helpers/toConsumableArray';
 import _defineProperty from '@babel/runtime/helpers/defineProperty';
 import _regeneratorRuntime from '@babel/runtime/regenerator';
 import _asyncToGenerator from '@babel/runtime/helpers/asyncToGenerator';
 import _initializerDefineProperty from '@babel/runtime/helpers/initializerDefineProperty';
 import _classCallCheck from '@babel/runtime/helpers/classCallCheck';
 import _createClass from '@babel/runtime/helpers/createClass';
-import _applyDecoratedDescriptor from '@babel/runtime/helpers/applyDecoratedDescriptor';
 import '@babel/runtime/helpers/initializerWarningHelper';
+import _applyDecoratedDescriptor from '@babel/runtime/helpers/applyDecoratedDescriptor';
 import _typeof from '@babel/runtime/helpers/typeof';
-import { observable, computed, set, extendObservable, reaction, toJS, transaction, action } from 'mobx';
+import { computed, observable, set, extendObservable, transaction, toJS, action } from 'mobx';
 import _inherits from '@babel/runtime/helpers/inherits';
 import _possibleConstructorReturn from '@babel/runtime/helpers/possibleConstructorReturn';
 import _getPrototypeOf from '@babel/runtime/helpers/getPrototypeOf';
 import _wrapNativeSuper from '@babel/runtime/helpers/wrapNativeSuper';
+import _toConsumableArray from '@babel/runtime/helpers/toConsumableArray';
 import uuidv1 from 'uuid/v1';
 import qs from 'qs';
 import pluralize from 'pluralize';
@@ -390,7 +390,7 @@ var Schema = /*#__PURE__*/function () {
 
 var schema = new Schema();
 
-var _class, _descriptor, _descriptor2, _descriptor3, _descriptor4, _temp;
+var _class, _descriptor, _temp;
 
 function ownKeys$1(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
@@ -471,15 +471,9 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
 
     _classCallCheck(this, Model);
 
-    _initializerDefineProperty(this, "_disposed", _descriptor, this);
-
-    _initializerDefineProperty(this, "_dirtyRelationships", _descriptor2, this);
-
-    _initializerDefineProperty(this, "_dirtyAttributes", _descriptor3, this);
-
     this.isInFlight = false;
 
-    _initializerDefineProperty(this, "errors", _descriptor4, this);
+    _initializerDefineProperty(this, "errors", _descriptor, this);
 
     this._snapshots = [];
 
@@ -505,94 +499,41 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
    */
 
   /**
-    * has this object been destroyed?
-    * @property _disposed
-    * @type {Boolean}
-    * @default false
-    */
+   * True if the instance has been modified from its persisted state
+   *
+   * NOTE that isDirty does _NOT_ track changes to the related objects
+   * but it _does_ track changes to the relationships themselves.
+   *
+   * For example, adding or removing a related object will mark this record as dirty,
+   * but changing a related object's properties will not mark this record as dirty.
+   *
+   * The caller is reponsible for asking related objects about their
+   * own dirty state.
+   *
+   * ```
+   * kpi = store.add('kpis', { name: 'A good thing to measure' })
+   * kpi.isDirty
+   * => true
+   * kpi.name
+   * => "A good thing to measure"
+   * await kpi.save()
+   * kpi.isDirty
+   * => false
+   * kpi.name = "Another good thing to measure"
+   * kpi.isDirty
+   * => true
+   * await kpi.save()
+   * kpi.isDirty
+   * => false
+   * ```
+   * @property isDirty
+   * @type {Boolean}
+   */
 
 
   _createClass(Model, [{
-    key: "isDirty",
-    get:
-    /**
-     * True if the instance has been modified from its persisted state
-     *
-     * NOTE that isDirty does _NOT_ track changes to the related objects
-     * but it _does_ track changes to the relationships themselves.
-     *
-     * For example, adding or removing a related object will mark this record as dirty,
-     * but changing a related object's properties will not mark this record as dirty.
-     *
-     * The caller is reponsible for asking related objects about their
-     * own dirty state.
-     *
-     * ```
-     * kpi = store.add('kpis', { name: 'A good thing to measure' })
-     * kpi.isDirty
-     * => true
-     * kpi.name
-     * => "A good thing to measure"
-     * await kpi.save()
-     * kpi.isDirty
-     * => false
-     * kpi.name = "Another good thing to measure"
-     * kpi.isDirty
-     * => true
-     * await kpi.save()
-     * kpi.isDirty
-     * => false
-     * ```
-     * @property isDirty
-     * @type {Boolean}
-     */
-    function get() {
-      return this._dirtyAttributes.size > 0 || this._dirtyRelationships.size > 0;
-    }
-    /**
-     * have any changes been made since this record was last persisted?
-     * @property hasUnpersistedChanges
-     * @type {Boolean}
-     */
-
-  }, {
-    key: "hasUnpersistedChanges",
-    get: function get() {
-      return this.isDirty || !this.previousSnapshot.persisted;
-    }
-    /**
-     * True if the model has not been sent to the store
-     * @property isNew
-     * @type {Boolean}
-     */
-
-  }, {
-    key: "isNew",
-    get: function get() {
-      var id = this.id;
-      if (!id) return true;
-      if (String(id).indexOf('tmp') === -1) return false;
-      return true;
-    }
-    /**
-     * True if the instance is coming from / going to the server
-     * ```
-     * kpi = store.find('kpis', 5)
-     * // fetch started
-     * kpi.isInFlight
-     * => true
-     * // fetch finished
-     * kpi.isInFlight
-     * => false
-     * ```
-     * @property isInFlight
-     * @type {Boolean}
-     * @default false
-     */
-
-  }, {
     key: "rollback",
-    value:
+
     /**
      * restores data to its last snapshot state
      * ```
@@ -606,7 +547,7 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
      * ```
      * @method rollback
      */
-    function rollback() {
+    value: function rollback() {
       this._applySnapshot(this.previousSnapshot);
     }
     /**
@@ -754,7 +695,7 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
                   _this.isInFlight = false;
 
                   if (![200, 202, 204].includes(response.status)) {
-                    _context.next = 18;
+                    _context.next = 17;
                     break;
                   }
 
@@ -790,17 +731,15 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
                     _this.store.createModelsFromData(json.included);
                   }
 
-                  _this.dispose();
-
                   return _context.abrupt("return", _this);
 
-                case 18:
+                case 17:
                   _this.errors = {
                     status: response.status
                   };
                   return _context.abrupt("return", _this);
 
-                case 20:
+                case 19:
                 case "end":
                   return _context.stop();
               }
@@ -832,64 +771,6 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
     value: function _makeObservable(initialAttributes) {
       var defaultAttributes = this.defaultAttributes;
       extendObservable(this, _objectSpread$1(_objectSpread$1({}, defaultAttributes), initialAttributes));
-
-      this._listenForChanges();
-    }
-    /**
-     * sets up a reaction for each top-level attribute so we can compare
-     * values after each mutation and keep track of dirty attr states
-     * if an attr is different than the last snapshot, add it to the
-     * _dirtyAttributes set
-     * if it's the same as the last snapshot, make sure it's _not_ in the
-     * _dirtyAttributes set
-     * @method _listenForChanges
-     */
-
-  }, {
-    key: "_listenForChanges",
-    value: function _listenForChanges() {
-      var _this3 = this;
-
-      this._disposers = Object.keys(this.attributes).map(function (attr) {
-        return reaction(function () {
-          return _this3.attributes[attr];
-        }, function (value) {
-          var previousValue = _this3.previousSnapshot.attributes[attr];
-
-          if (_isEqual(previousValue, value)) {
-            _this3._dirtyAttributes.delete(attr);
-          } else if (isObject(value)) {
-            // handles Objects and Arrays
-            // clear out any dirty attrs that start with this attr prefix
-            // then we can reset them if they are still (or newly) dirty
-            Array.from(_this3._dirtyAttributes).forEach(function (path) {
-              if (path.indexOf("".concat(attr, ".")) === 0) {
-                _this3._dirtyAttributes.delete(path);
-              }
-            });
-            diff(previousValue, value).forEach(function (property) {
-              _this3._dirtyAttributes.add("".concat(attr, ".").concat(property));
-            });
-          } else {
-            _this3._dirtyAttributes.add(attr);
-          }
-        });
-      });
-    }
-    /**
-     * call this when destroying an object to make sure that we clean up
-     * any event listeners and don't leak memory
-     * @method dispose
-     */
-
-  }, {
-    key: "dispose",
-    value: function dispose() {
-      this._disposed = true;
-
-      this._disposers.forEach(function (dispose) {
-        return dispose();
-      });
     }
     /**
      * The current state of defined attributes and relationships of the instance
@@ -908,21 +789,13 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
      */
 
   }, {
-    key: "snapshot",
-    get: function get() {
-      return {
-        attributes: this.attributes,
-        relationships: toJS(this.relationships)
-      };
-    }
+    key: "setPreviousSnapshot",
+
     /**
      * Sets previous snapshot to current snapshot
      *
      * @method setPreviousSnapshot
      */
-
-  }, {
-    key: "setPreviousSnapshot",
     value: function setPreviousSnapshot() {
       this._takeSnapshot();
     }
@@ -933,25 +806,8 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
      */
 
   }, {
-    key: "previousSnapshot",
-    get: function get() {
-      var length = this._snapshots.length;
-      if (length === 0) throw new Error('Invariant violated: model has no snapshots');
-      return this._snapshots[length - 1];
-    }
-    /**
-     * the latest persisted snapshot or the first snapshot if the model was never persisted
-     *
-     * @method previousSnapshot
-     */
+    key: "_takeSnapshot",
 
-  }, {
-    key: "persistedSnapshot",
-    get: function get() {
-      return findLast(this._snapshots, function (ss) {
-        return ss.persisted;
-      }) || this._snapshots[0];
-    }
     /**
      * take a snapshot of the current model state.
      * if persisted, clear the stack and push this snapshot to the top
@@ -959,17 +815,9 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
      * @method _takeSnapshot
      * @param {Object} options
      */
-
-  }, {
-    key: "_takeSnapshot",
     value: function _takeSnapshot() {
       var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
       var persisted = options.persisted || false;
-
-      this._dirtyRelationships.clear();
-
-      this._dirtyAttributes.clear();
-
       var _this$snapshot = this.snapshot,
           attributes = _this$snapshot.attributes,
           relationships = _this$snapshot.relationships;
@@ -995,44 +843,17 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
   }, {
     key: "_applySnapshot",
     value: function _applySnapshot(snapshot) {
-      var _this4 = this;
+      var _this3 = this;
 
       if (!snapshot) throw new Error('Invariant violated: tried to apply undefined snapshot');
       transaction(function () {
-        _this4.attributeNames.forEach(function (key) {
-          _this4[key] = snapshot.attributes[key];
+        _this3.attributeNames.forEach(function (key) {
+          _this3[key] = snapshot.attributes[key];
         });
 
-        _this4.relationships = snapshot.relationships;
-        _this4.errors = {};
+        _this3.relationships = snapshot.relationships;
+        _this3.errors = {};
       });
-    }
-    /**
-     * a list of any property paths which have been changed since the previous
-     * snapshot
-     * ```
-     * const todo = new Todo({ title: 'Buy Milk' })
-     * todo.dirtyAttributes
-     * => []
-     * todo.title = 'Buy Cheese'
-     * todo.dirtyAttributes
-     * => ['title']
-     * todo.note = note1
-     * todo.dirtyAttributes
-     * => ['title', 'relationships.note']
-     * ```
-     * @method dirtyAttributes
-     * @return {Array} dirty attribute paths
-     */
-
-  }, {
-    key: "dirtyAttributes",
-    get: function get() {
-      var relationships = Array.from(this._dirtyRelationships).map(function (property) {
-        return "relationships.".concat(property);
-      });
-      var attributes = Array.from(this._dirtyAttributes);
-      return [].concat(_toConsumableArray(relationships), _toConsumableArray(attributes));
     }
     /**
      * shortcut to get the static
@@ -1041,6 +862,363 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
      * @return {String} current attributes
     */
 
+  }, {
+    key: "errorForKey",
+
+    /**
+     * Getter to check if the record has errors.
+     *
+     * @method hasErrors
+     * @return {Boolean}
+     */
+    value: function errorForKey(key) {
+      return this.errors[key];
+    }
+    /**
+     * Getter to just get the names of a records attributes.
+     *
+     * @method attributeNames
+     * @return {Array}
+     */
+
+  }, {
+    key: "jsonapi",
+
+    /**
+     * getter method to get data in api compliance format
+     * TODO: Figure out how to handle unpersisted ids
+     *
+     * @method jsonapi
+     * @return {Object} data in JSON::API format
+     */
+    value: function jsonapi() {
+      var _this4 = this;
+
+      var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+      var attributeDefinitions = this.attributeDefinitions,
+          attributeNames = this.attributeNames,
+          meta = this.meta,
+          id = this.id,
+          type = this.constructor.type;
+      var filteredAttributeNames = attributeNames;
+      var filteredRelationshipNames = [];
+
+      if (options.attributes) {
+        filteredAttributeNames = attributeNames.filter(function (name) {
+          return options.attributes.includes(name);
+        });
+      }
+
+      var attributes = filteredAttributeNames.reduce(function (attrs, key) {
+        var value = _this4[key];
+
+        if (value) {
+          var DataType = attributeDefinitions[key].dataType;
+          var attr;
+
+          if (DataType.name === 'Array' || DataType.name === 'Object') {
+            attr = toJS(value);
+          } else if (DataType.name === 'Date') {
+            attr = makeDate(value).toISOString();
+          } else {
+            attr = DataType(value);
+          }
+
+          attrs[key] = attr;
+        } else {
+          attrs[key] = value;
+        }
+
+        return attrs;
+      }, {});
+      var data = {
+        type: type,
+        attributes: attributes,
+        id: String(id)
+      };
+
+      if (options.relationships) {
+        filteredRelationshipNames = Object.keys(this.relationships).filter(function (name) {
+          return options.relationships.includes(name);
+        });
+        var relationships = filteredRelationshipNames.reduce(function (rels, key) {
+          rels[key] = toJS(_this4.relationships[key]);
+          stringifyIds(rels[key]);
+          return rels;
+        }, {});
+        data.relationships = relationships;
+      }
+
+      if (meta) {
+        data['meta'] = meta;
+      }
+
+      if (String(id).match(/tmp/)) {
+        delete data.id;
+      }
+
+      return data;
+    }
+  }, {
+    key: "updateAttributes",
+    value: function updateAttributes(attributes) {
+      var _this5 = this;
+
+      transaction(function () {
+        Object.keys(attributes).forEach(function (key) {
+          _this5[key] = attributes[key];
+        });
+      });
+    } // TODO: this shares a lot of functionality with Store.createOrUpdateModel
+    // Perhaps that shared code
+
+  }, {
+    key: "updateAttributesFromResponse",
+    value: function updateAttributesFromResponse(data, included) {
+      var _this6 = this;
+
+      var tmpId = this.id;
+      var id = data.id,
+          attributes = data.attributes,
+          relationships = data.relationships;
+      transaction(function () {
+        set(_this6, 'id', id);
+        Object.keys(attributes).forEach(function (key) {
+          set(_this6, key, attributes[key]);
+        });
+
+        if (relationships) {
+          Object.keys(relationships).forEach(function (key) {
+            if (!relationships[key].hasOwnProperty('meta')) {
+              // todo: throw error if relationship is not defined in model
+              set(_this6.relationships, key, relationships[key]);
+            }
+          });
+        }
+
+        if (included) {
+          _this6.store.createModelsFromData(included);
+        }
+      }); // Update target isInFlight
+
+      this.isInFlight = false;
+
+      this._takeSnapshot({
+        persisted: true
+      });
+
+      transaction(function () {
+        // NOTE: This resolves an issue where a record is persisted but the
+        // index key is still a temp uuid. We can't simply remove the temp
+        // key because there may be associated records that have the temp
+        // uuid id as its only reference to the newly persisted record.
+        // TODO: Figure out a way to update associated records to use the
+        // newly persisted id.
+        _this6.store.data[_this6.type].records.set(String(tmpId), _this6);
+
+        _this6.store.data[_this6.type].records.set(String(_this6.id), _this6);
+      });
+    }
+  }, {
+    key: "clone",
+    value: function clone() {
+      var attributes = cloneDeep(this.snapshot.attributes);
+      var relationships = cloneDeep(this.snapshot.relationships);
+      return this.store.createModel(this.type, this.id, {
+        attributes: attributes,
+        relationships: relationships
+      });
+    }
+    /**
+     * Comparison by value
+     * returns `true` if this object has the same attrs and relationships
+     * as the "other" object, ignores differences in internal state like
+     * attribute "dirtyness" or errors
+     *
+     * @method isEqual
+     * @param {Object} other
+     * @return {Object}
+     */
+
+  }, {
+    key: "isEqual",
+    value: function isEqual(other) {
+      if (!other) return false;
+      return _isEqual(this.attributes, other.attributes) && _isEqual(this.relationships, other.relationships);
+    }
+    /**
+     * Comparison by identity
+     * returns `true` if this object has the same type and id as the
+     * "other" object, ignores differences in attrs and relationships
+     *
+     * @method isSame
+     * @param {Object} other
+     * @return {Object}
+     */
+
+  }, {
+    key: "isSame",
+    value: function isSame(other) {
+      if (!other) return false;
+      return this.type === other.type && this.id === other.id;
+    }
+  }, {
+    key: "isDirty",
+    get: function get() {
+      return this.dirtyAttributes.length > 0 || this.dirtyRelationships.length > 0;
+    }
+    /**
+     * A list of any attribute paths which have been changed since the previous snapshot
+     *
+     * const todo = new Todo({ title: 'Buy Milk' })
+     * todo.dirtyAttributes
+     * => []
+     * todo.title = 'Buy Cheese'
+     * todo.dirtyAttributes
+     * => ['title']
+     * todo.options = { variety: 'Cheddar' }
+     * todo.dirtyAttributes
+     * => ['title', 'options.variety']
+     *
+     * @method dirtyAttributes
+     * @return {Array} dirty attribute paths
+     */
+
+  }, {
+    key: "dirtyAttributes",
+    get: function get() {
+      var _this7 = this;
+
+      return Array.from(Object.keys(this.attributes).reduce(function (dirtyAccumulator, attr) {
+        var currentValue = _this7.attributes[attr];
+        var previousValue = _this7.previousSnapshot.attributes[attr];
+
+        if (isObject(currentValue)) {
+          diff(currentValue, previousValue).forEach(function (property) {
+            dirtyAccumulator.add("".concat(attr, ".").concat(property));
+          });
+        } else if (!_isEqual(previousValue, currentValue)) {
+          dirtyAccumulator.add(attr);
+        }
+
+        return dirtyAccumulator;
+      }, new Set()));
+    }
+    /**
+     * A list of any relationship paths which have been changed since the previous snapshot
+     * We check changes to both ids and types in case there are polymorphic relationships
+     *
+     * const todo = new Todo({ title: 'Buy Milk' })
+     * todo.dirtyRelationships
+     * => []
+     * todo.note = note1
+     * todo.dirtyRelationships
+     * => ['relationships.note']
+     *
+     * @method dirtyRelationships
+     * @return {Array} dirty relationship paths
+     */
+
+  }, {
+    key: "dirtyRelationships",
+    get: function get() {
+      // TODO: make what returns from this.relationships to be more consistent
+      var previousRelationships = this.previousSnapshot.relationships || {};
+      var currentRelationships = this.relationships || {};
+      var schemaRelationships = this.relationshipNames;
+
+      if (Object.keys(currentRelationships).length === 0) {
+        return Object.keys(previousRelationships);
+      }
+
+      return Array.from(schemaRelationships.reduce(function (dirtyAccumulator, name) {
+        var _currentRelationships, _previousRelationship;
+
+        var currentValues = ((_currentRelationships = currentRelationships[name]) === null || _currentRelationships === void 0 ? void 0 : _currentRelationships.data) || [];
+        var previousValues = ((_previousRelationship = previousRelationships[name]) === null || _previousRelationship === void 0 ? void 0 : _previousRelationship.data) || [];
+        var currentIds = Array.isArray(currentValues) ? currentValues.map(function (value) {
+          return [value.id, value.type];
+        }).sort() : [currentValues.id, currentValues.type];
+        var previousIds = Array.isArray(previousValues) ? previousValues.map(function (value) {
+          return [value.id, value.type];
+        }).sort() : [previousValues.id, previousValues.type];
+
+        if (!_isEqual(currentIds, previousIds)) {
+          dirtyAccumulator.add(name);
+        }
+
+        return dirtyAccumulator;
+      }, new Set()));
+    }
+    /**
+     * Have any changes been made since this record was last persisted?
+     * @property hasUnpersistedChanges
+     * @type {Boolean}
+     */
+
+  }, {
+    key: "hasUnpersistedChanges",
+    get: function get() {
+      return this.isDirty || !this.previousSnapshot.persisted;
+    }
+    /**
+     * True if the model has not been sent to the store
+     * @property isNew
+     * @type {Boolean}
+     */
+
+  }, {
+    key: "isNew",
+    get: function get() {
+      var id = this.id;
+      if (!id) return true;
+      if (String(id).indexOf('tmp') === -1) return false;
+      return true;
+    }
+    /**
+     * True if the instance is coming from / going to the server
+     * ```
+     * kpi = store.find('kpis', 5)
+     * // fetch started
+     * kpi.isInFlight
+     * => true
+     * // fetch finished
+     * kpi.isInFlight
+     * => false
+     * ```
+     * @property isInFlight
+     * @type {Boolean}
+     * @default false
+     */
+
+  }, {
+    key: "snapshot",
+    get: function get() {
+      return {
+        attributes: this.attributes,
+        relationships: toJS(this.relationships)
+      };
+    }
+  }, {
+    key: "previousSnapshot",
+    get: function get() {
+      var length = this._snapshots.length;
+      if (length === 0) throw new Error('Invariant violated: model has no snapshots');
+      return this._snapshots[length - 1];
+    }
+    /**
+     * the latest persisted snapshot or the first snapshot if the model was never persisted
+     *
+     * @method previousSnapshot
+     */
+
+  }, {
+    key: "persistedSnapshot",
+    get: function get() {
+      return findLast(this._snapshots, function (ss) {
+        return ss.persisted;
+      }) || this._snapshots[0];
+    }
   }, {
     key: "type",
     get: function get() {
@@ -1056,10 +1234,10 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
   }, {
     key: "attributes",
     get: function get() {
-      var _this5 = this;
+      var _this8 = this;
 
       return this.attributeNames.reduce(function (attributes, key) {
-        var value = toJS(_this5[key]);
+        var value = toJS(_this8[key]);
 
         if (value == null) {
           delete attributes[key];
@@ -1108,25 +1286,6 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
     get: function get() {
       return Object.keys(this.errors).length > 0;
     }
-    /**
-     * Getter to check if the record has errors.
-     *
-     * @method hasErrors
-     * @return {Boolean}
-     */
-
-  }, {
-    key: "errorForKey",
-    value: function errorForKey(key) {
-      return this.errors[key];
-    }
-    /**
-     * Getter to just get the names of a records attributes.
-     *
-     * @method attributeNames
-     * @return {Array}
-     */
-
   }, {
     key: "attributeNames",
     get: function get() {
@@ -1163,212 +1322,10 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
         relationships: {}
       });
     }
-    /**
-     * getter method to get data in api compliance format
-     * TODO: Figure out how to handle unpersisted ids
-     *
-     * @method jsonapi
-     * @return {Object} data in JSON::API format
-     */
-
-  }, {
-    key: "jsonapi",
-    value: function jsonapi() {
-      var _this6 = this;
-
-      var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-      var attributeDefinitions = this.attributeDefinitions,
-          attributeNames = this.attributeNames,
-          meta = this.meta,
-          id = this.id,
-          type = this.constructor.type;
-      var filteredAttributeNames = attributeNames;
-      var filteredRelationshipNames = [];
-
-      if (options.attributes) {
-        filteredAttributeNames = attributeNames.filter(function (name) {
-          return options.attributes.includes(name);
-        });
-      }
-
-      var attributes = filteredAttributeNames.reduce(function (attrs, key) {
-        var value = _this6[key];
-
-        if (value) {
-          var DataType = attributeDefinitions[key].dataType;
-          var attr;
-
-          if (DataType.name === 'Array' || DataType.name === 'Object') {
-            attr = toJS(value);
-          } else if (DataType.name === 'Date') {
-            attr = makeDate(value).toISOString();
-          } else {
-            attr = DataType(value);
-          }
-
-          attrs[key] = attr;
-        } else {
-          attrs[key] = value;
-        }
-
-        return attrs;
-      }, {});
-      var data = {
-        type: type,
-        attributes: attributes,
-        id: String(id)
-      };
-
-      if (options.relationships) {
-        filteredRelationshipNames = Object.keys(this.relationships).filter(function (name) {
-          return options.relationships.includes(name);
-        });
-        var relationships = filteredRelationshipNames.reduce(function (rels, key) {
-          rels[key] = toJS(_this6.relationships[key]);
-          stringifyIds(rels[key]);
-          return rels;
-        }, {});
-        data.relationships = relationships;
-      }
-
-      if (meta) {
-        data['meta'] = meta;
-      }
-
-      if (String(id).match(/tmp/)) {
-        delete data.id;
-      }
-
-      return data;
-    }
-  }, {
-    key: "updateAttributes",
-    value: function updateAttributes(attributes) {
-      var _this7 = this;
-
-      transaction(function () {
-        Object.keys(attributes).forEach(function (key) {
-          _this7[key] = attributes[key];
-        });
-      });
-    } // TODO: this shares a lot of functionality with Store.createOrUpdateModel
-    // Perhaps that shared code
-
-  }, {
-    key: "updateAttributesFromResponse",
-    value: function updateAttributesFromResponse(data, included) {
-      var _this8 = this;
-
-      var tmpId = this.id;
-      var id = data.id,
-          attributes = data.attributes,
-          relationships = data.relationships;
-      transaction(function () {
-        set(_this8, 'id', id);
-        Object.keys(attributes).forEach(function (key) {
-          set(_this8, key, attributes[key]);
-        });
-
-        if (relationships) {
-          Object.keys(relationships).forEach(function (key) {
-            if (!relationships[key].hasOwnProperty('meta')) {
-              // todo: throw error if relationship is not defined in model
-              set(_this8.relationships, key, relationships[key]);
-            }
-          });
-        }
-
-        if (included) {
-          _this8.store.createModelsFromData(included);
-        }
-      }); // Update target isInFlight
-
-      this.isInFlight = false;
-
-      this._takeSnapshot({
-        persisted: true
-      });
-
-      transaction(function () {
-        // NOTE: This resolves an issue where a record is persisted but the
-        // index key is still a temp uuid. We can't simply remove the temp
-        // key because there may be associated records that have the temp
-        // uuid id as its only reference to the newly persisted record.
-        // TODO: Figure out a way to update associated records to use the
-        // newly persisted id.
-        _this8.store.data[_this8.type].records.set(String(tmpId), _this8);
-
-        _this8.store.data[_this8.type].records.set(String(_this8.id), _this8);
-      });
-    }
-  }, {
-    key: "clone",
-    value: function clone() {
-      var attributes = cloneDeep(this.snapshot.attributes);
-      var relationships = cloneDeep(this.snapshot.relationships);
-      return this.store.createModel(this.type, this.id, {
-        attributes: attributes,
-        relationships: relationships
-      });
-    }
-    /**
-     * Comparison by value
-     * returns `true` if this object has the same attrs and relationships
-     * as the "other" object, ignores differences in internal state like
-     * attribute "dirtyness" or errors
-     *
-     * @method isEqual
-     * @param {Object} other
-     * @return {Object}
-     */
-
-  }, {
-    key: "isEqual",
-    value: function isEqual(other) {
-      if (!other) return false;
-      return _isEqual(this.attributes, other.attributes) && _isEqual(this.relationships, other.relationships);
-    }
-    /**
-     * Comparison by identity
-     * returns `true` if this object has the same type and id as the
-     * "other" object, ignores differences in attrs and relationships
-     *
-     * @method isSame
-     * @param {Object} other
-     * @return {Object}
-     */
-
-  }, {
-    key: "isSame",
-    value: function isSame(other) {
-      if (!other) return false;
-      return this.type === other.type && this.id === other.id;
-    }
   }]);
 
   return Model;
-}(), _temp), (_descriptor = _applyDecoratedDescriptor(_class.prototype, "_disposed", [observable], {
-  configurable: true,
-  enumerable: true,
-  writable: true,
-  initializer: function initializer() {
-    return false;
-  }
-}), _descriptor2 = _applyDecoratedDescriptor(_class.prototype, "_dirtyRelationships", [observable], {
-  configurable: true,
-  enumerable: true,
-  writable: true,
-  initializer: function initializer() {
-    return new Set();
-  }
-}), _descriptor3 = _applyDecoratedDescriptor(_class.prototype, "_dirtyAttributes", [observable], {
-  configurable: true,
-  enumerable: true,
-  writable: true,
-  initializer: function initializer() {
-    return new Set();
-  }
-}), _applyDecoratedDescriptor(_class.prototype, "isNew", [computed], Object.getOwnPropertyDescriptor(_class.prototype, "isNew"), _class.prototype), _descriptor4 = _applyDecoratedDescriptor(_class.prototype, "errors", [observable], {
+}(), _temp), (_applyDecoratedDescriptor(_class.prototype, "isNew", [computed], Object.getOwnPropertyDescriptor(_class.prototype, "isNew"), _class.prototype), _descriptor = _applyDecoratedDescriptor(_class.prototype, "errors", [observable], {
   configurable: true,
   enumerable: true,
   writable: true,
@@ -1377,7 +1334,7 @@ var Model = (_class = (_temp = /*#__PURE__*/function () {
   }
 })), _class);
 
-var _class$1, _descriptor$1, _descriptor2$1, _descriptor3$1, _temp$1;
+var _class$1, _descriptor$1, _descriptor2, _descriptor3, _temp$1;
 
 function ownKeys$2(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
@@ -1431,7 +1388,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
       return model;
     };
 
-    _initializerDefineProperty(this, "addModel", _descriptor2$1, this);
+    _initializerDefineProperty(this, "addModel", _descriptor2, this);
 
     this.addModels = function (type, data) {
       return transaction(function () {
@@ -1494,7 +1451,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
       };
     }();
 
-    _initializerDefineProperty(this, "remove", _descriptor3$1, this);
+    _initializerDefineProperty(this, "remove", _descriptor3, this);
 
     this.getOne = function (type, id) {
       var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
@@ -1674,7 +1631,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
 
   _createClass(Store, [{
     key: "fetchOne",
-    value:
+
     /**
      * Fetches record by `id` from the server and returns a Promise.
      *
@@ -1685,7 +1642,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
      * @param {Object} options { queryParams }
      * @return {Object} record
      */
-    function () {
+    value: function () {
       var _fetchOne = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee2(type, id) {
         var options,
             queryParams,
@@ -1783,7 +1740,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
 
   }, {
     key: "fetchUrl",
-    value:
+
     /**
      * Builds fetch url based
      *
@@ -1791,7 +1748,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
      * @param {String} type the type to find
      * @param {Object} options
      */
-    function fetchUrl(type, queryParams, id, options) {
+    value: function fetchUrl(type, queryParams, id, options) {
       var baseUrl = this.baseUrl,
           modelTypeIndex = this.modelTypeIndex;
       var endpoint = modelTypeIndex[type].endpoint;
@@ -1808,7 +1765,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
 
   }, {
     key: "fetchAll",
-    value:
+
     /**
      * Finds all records with the given `type`. Always fetches from the server.
      *
@@ -1818,7 +1775,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
      * @param {Object} options
      * @return {Promise} Promise.resolve(records) or Promise.reject(status)
      */
-    function () {
+    value: function () {
       var _fetchAll = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee3(type) {
         var _this2 = this;
 
@@ -1943,7 +1900,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
 
   }, {
     key: "reset",
-    value:
+
     /**
      * Clears the store of a given type, or clears all if no type given
      *
@@ -1954,7 +1911,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
      *
      * @method reset
      */
-    function reset(type) {
+    value: function reset(type) {
       if (type) {
         this.data[type] = {
           records: observable.map({}),
@@ -2067,7 +2024,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
       return combineRacedRequests(key, function () {
         return fetch(url, _objectSpread$2(_objectSpread$2({}, defaultFetchOptions), options));
       });
-    }
+    })
     /**
      * Gets type of collection from data observable
      *
@@ -2075,7 +2032,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
      * @param {String} type
      * @return {Object} observable type object structure
      */
-    )
+
   }, {
     key: "getType",
     value: function getType(type) {
@@ -2463,7 +2420,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
   initializer: function initializer() {
     return {};
   }
-}), _descriptor2$1 = _applyDecoratedDescriptor(_class$1.prototype, "addModel", [action], {
+}), _descriptor2 = _applyDecoratedDescriptor(_class$1.prototype, "addModel", [action], {
   configurable: true,
   enumerable: true,
   writable: true,
@@ -2483,7 +2440,7 @@ var Store = (_class$1 = (_temp$1 = /*#__PURE__*/function () {
       return model;
     };
   }
-}), _descriptor3$1 = _applyDecoratedDescriptor(_class$1.prototype, "remove", [action], {
+}), _descriptor3 = _applyDecoratedDescriptor(_class$1.prototype, "remove", [action], {
   configurable: true,
   enumerable: true,
   writable: true,
@@ -2786,8 +2743,7 @@ function setRelatedRecord(record, relatedRecord, property) {
     throw new Error('Related record must be a valid Model object');
   }
 
-  var relationships = record.relationships,
-      _dirtyRelationships = record._dirtyRelationships;
+  var relationships = record.relationships;
   var relationType = modelType || property;
   var referenceRecord = relatedRecord || getRelatedRecord(record, relationType);
 
@@ -2801,8 +2757,6 @@ function setRelatedRecord(record, relatedRecord, property) {
 
   if (!relatedRecord) {
     delete relationships[relationType];
-
-    _dirtyRelationships.add(relationType);
   } else if (!data || !(data.type === type && data.id === id)) {
     relationships[relationType] = {
       data: {
@@ -2810,8 +2764,6 @@ function setRelatedRecord(record, relatedRecord, property) {
         type: type
       }
     };
-
-    _dirtyRelationships.add(relationType);
   } else {
     return relatedRecord;
   } // hack we don't have a reference to the inverse name so we just use the record type.
@@ -2887,9 +2839,7 @@ var RelatedRecordsArray = /*#__PURE__*/function (_Array) {
           type: type
         });
 
-        _this.push(relatedRecord);
-
-        record._dirtyRelationships.add(property); // setting the inverse - hack this will only work with singularized relationships.
+        _this.push(relatedRecord); // setting the inverse - hack this will only work with singularized relationships.
 
 
         setRelatedRecord(relatedRecord, record, recordType.slice(0, recordType.length - 1));
@@ -2929,9 +2879,7 @@ var RelatedRecordsArray = /*#__PURE__*/function (_Array) {
 
         if (!Object.keys(record.relationships).length) {
           delete record.relationships;
-        }
-
-        record._dirtyRelationships.add(property); // hack this will only work with singularized relationships.
+        } // hack this will only work with singularized relationships.
 
 
         setRelatedRecord(relatedRecord, null, recordType.slice(0, recordType.length - 1));
@@ -2953,8 +2901,6 @@ var RelatedRecordsArray = /*#__PURE__*/function (_Array) {
         array.forEach(function (object) {
           return _this.add(object);
         });
-
-        record._dirtyRelationships.add(property);
       });
     };
 

--- a/docs/classes/Model.html
+++ b/docs/classes/Model.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.3.0</em>
+            <em>API Docs for: 3.4.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -84,7 +84,7 @@
 
 
         <div class="foundat">
-            Defined in: <a href="../files/src_Model.js.html#l81"><code>src&#x2F;Model.js:81</code></a>
+            Defined in: <a href="../files/src_Model.js.html#l80"><code>src&#x2F;Model.js:80</code></a>
         </div>
 
 
@@ -114,10 +114,6 @@
                     <ul class="index-list methods">
                             <li class="index-item method">
                                 <a href="#method__applySnapshot">_applySnapshot</a>
-
-                            </li>
-                            <li class="index-item method">
-                                <a href="#method__listenForChanges">_listenForChanges</a>
 
                             </li>
                             <li class="index-item method">
@@ -157,7 +153,7 @@
 
                             </li>
                             <li class="index-item method">
-                                <a href="#method_dispose">dispose</a>
+                                <a href="#method_dirtyRelationships">dirtyRelationships</a>
 
                             </li>
                             <li class="index-item method">
@@ -236,18 +232,6 @@
 
                     <ul class="index-list properties">
                             <li class="index-item property">
-                                <a href="#property__dirtyAttributes">_dirtyAttributes</a>
-
-                            </li>
-                            <li class="index-item property">
-                                <a href="#property__dirtyRelationships">_dirtyRelationships</a>
-
-                            </li>
-                            <li class="index-item property">
-                                <a href="#property__disposed">_disposed</a>
-
-                            </li>
-                            <li class="index-item property">
                                 <a href="#property_endpoint">endpoint</a>
 
                                     <span class="flag static">static</span>
@@ -311,7 +295,7 @@
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l534"><code>src&#x2F;Model.js:534</code></a>
+        <a href="../files/src_Model.js.html#l533"><code>src&#x2F;Model.js:533</code></a>
         </p>
 
 
@@ -344,42 +328,6 @@ and relationships of the snapshot to be applied. also reset errors</p>
 
 
 </div>
-<div id="method__listenForChanges" class="method item">
-    <h3 class="name"><code>_listenForChanges</code></h3>
-
-        <span class="paren">()</span>
-
-
-
-
-
-
-
-
-    <div class="meta">
-                <p>
-                Defined in
-        <a href="../files/src_Model.js.html#l417"><code>src&#x2F;Model.js:417</code></a>
-        </p>
-
-
-
-    </div>
-
-    <div class="description">
-        <p>sets up a reaction for each top-level attribute so we can compare
-values after each mutation and keep track of dirty attr states
-if an attr is different than the last snapshot, add it to the
-_dirtyAttributes set
-if it's the same as the last snapshot, make sure it's <em>not</em> in the
-_dirtyAttributes set</p>
-
-    </div>
-
-
-
-
-</div>
 <div id="method__makeObservable" class="method item">
     <h3 class="name"><code>_makeObservable</code></h3>
 
@@ -395,7 +343,7 @@ _dirtyAttributes set</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l400"><code>src&#x2F;Model.js:400</code></a>
+        <a href="../files/src_Model.js.html#l446"><code>src&#x2F;Model.js:446</code></a>
         </p>
 
 
@@ -433,7 +381,7 @@ observable</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l511"><code>src&#x2F;Model.js:511</code></a>
+        <a href="../files/src_Model.js.html#l512"><code>src&#x2F;Model.js:512</code></a>
         </p>
 
 
@@ -485,7 +433,7 @@ if not persisted, push this snapshot to the top of the stack</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l603"><code>src&#x2F;Model.js:603</code></a>
+        <a href="../files/src_Model.js.html#l578"><code>src&#x2F;Model.js:578</code></a>
         </p>
 
 
@@ -526,7 +474,7 @@ if not persisted, push this snapshot to the top of the stack</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l645"><code>src&#x2F;Model.js:645</code></a>
+        <a href="../files/src_Model.js.html#l620"><code>src&#x2F;Model.js:620</code></a>
         </p>
 
 
@@ -567,7 +515,7 @@ if not persisted, push this snapshot to the top of the stack</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l585"><code>src&#x2F;Model.js:585</code></a>
+        <a href="../files/src_Model.js.html#l560"><code>src&#x2F;Model.js:560</code></a>
         </p>
 
 
@@ -607,7 +555,7 @@ if not persisted, push this snapshot to the top of the stack</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l85"><code>src&#x2F;Model.js:85</code></a>
+        <a href="../files/src_Model.js.html#l84"><code>src&#x2F;Model.js:84</code></a>
         </p>
 
 
@@ -641,7 +589,7 @@ if not persisted, push this snapshot to the top of the stack</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l665"><code>src&#x2F;Model.js:665</code></a>
+        <a href="../files/src_Model.js.html#l640"><code>src&#x2F;Model.js:640</code></a>
         </p>
 
 
@@ -682,7 +630,7 @@ if not persisted, push this snapshot to the top of the stack</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l331"><code>src&#x2F;Model.js:331</code></a>
+        <a href="../files/src_Model.js.html#l379"><code>src&#x2F;Model.js:379</code></a>
         </p>
 
 
@@ -725,7 +673,7 @@ if not persisted, push this snapshot to the top of the stack</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l551"><code>src&#x2F;Model.js:551</code></a>
+        <a href="../files/src_Model.js.html#l144"><code>src&#x2F;Model.js:144</code></a>
         </p>
 
 
@@ -733,18 +681,16 @@ if not persisted, push this snapshot to the top of the stack</p>
     </div>
 
     <div class="description">
-        <p>a list of any property paths which have been changed since the previous
-snapshot</p>
-<pre class="code prettyprint"><code>const todo = new Todo({ title: 'Buy Milk' })
+        <p>A list of any attribute paths which have been changed since the previous snapshot</p>
+<p>const todo = new Todo({ title: 'Buy Milk' })
 todo.dirtyAttributes
 =&gt; []
 todo.title = 'Buy Cheese'
 todo.dirtyAttributes
 =&gt; ['title']
-todo.note = note1
+todo.options = { variety: 'Cheddar' }
 todo.dirtyAttributes
-=&gt; ['title', 'relationships.note']
-</code></pre>
+=&gt; ['title', 'options.variety']</p>
 
     </div>
 
@@ -761,11 +707,14 @@ todo.dirtyAttributes
 
 
 </div>
-<div id="method_dispose" class="method item">
-    <h3 class="name"><code>dispose</code></h3>
+<div id="method_dirtyRelationships" class="method item">
+    <h3 class="name"><code>dirtyRelationships</code></h3>
 
         <span class="paren">()</span>
 
+        <span class="returns-inline">
+            <span class="type">Array</span>
+        </span>
 
 
 
@@ -776,7 +725,7 @@ todo.dirtyAttributes
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l450"><code>src&#x2F;Model.js:450</code></a>
+        <a href="../files/src_Model.js.html#l177"><code>src&#x2F;Model.js:177</code></a>
         </p>
 
 
@@ -784,12 +733,27 @@ todo.dirtyAttributes
     </div>
 
     <div class="description">
-        <p>call this when destroying an object to make sure that we clean up
-any event listeners and don't leak memory</p>
+        <p>A list of any relationship paths which have been changed since the previous snapshot
+We check changes to both ids and types in case there are polymorphic relationships</p>
+<p>const todo = new Todo({ title: 'Buy Milk' })
+todo.dirtyRelationships
+=&gt; []
+todo.note = note1
+todo.dirtyRelationships
+=&gt; ['relationships.note']</p>
 
     </div>
 
 
+        <div class="returns">
+            <h4>Returns:</h4>
+
+            <div class="returns-description">
+                        <span class="type">Array</span>:
+                    <p>dirty relationship paths</p>
+
+            </div>
+        </div>
 
 
 </div>
@@ -811,7 +775,7 @@ any event listeners and don't leak memory</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l625"><code>src&#x2F;Model.js:625</code></a>
+        <a href="../files/src_Model.js.html#l600"><code>src&#x2F;Model.js:600</code></a>
         </p>
 
 
@@ -852,7 +816,7 @@ any event listeners and don't leak memory</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l635"><code>src&#x2F;Model.js:635</code></a>
+        <a href="../files/src_Model.js.html#l610"><code>src&#x2F;Model.js:610</code></a>
         </p>
 
 
@@ -899,7 +863,7 @@ any event listeners and don't leak memory</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l810"><code>src&#x2F;Model.js:810</code></a>
+        <a href="../files/src_Model.js.html#l785"><code>src&#x2F;Model.js:785</code></a>
         </p>
 
 
@@ -965,7 +929,7 @@ attribute &quot;dirtyness&quot; or errors</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l825"><code>src&#x2F;Model.js:825</code></a>
+        <a href="../files/src_Model.js.html#l800"><code>src&#x2F;Model.js:800</code></a>
         </p>
 
 
@@ -1024,7 +988,7 @@ returns <code>true</code> if this object has the same type and id as the
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l682"><code>src&#x2F;Model.js:682</code></a>
+        <a href="../files/src_Model.js.html#l657"><code>src&#x2F;Model.js:657</code></a>
         </p>
 
 
@@ -1065,7 +1029,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l491"><code>src&#x2F;Model.js:491</code></a>
+        <a href="../files/src_Model.js.html#l492"><code>src&#x2F;Model.js:492</code></a>
         </p>
 
 
@@ -1096,7 +1060,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l502"><code>src&#x2F;Model.js:502</code></a>
+        <a href="../files/src_Model.js.html#l503"><code>src&#x2F;Model.js:503</code></a>
         </p>
 
 
@@ -1130,7 +1094,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l614"><code>src&#x2F;Model.js:614</code></a>
+        <a href="../files/src_Model.js.html#l589"><code>src&#x2F;Model.js:589</code></a>
         </p>
 
 
@@ -1171,7 +1135,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l655"><code>src&#x2F;Model.js:655</code></a>
+        <a href="../files/src_Model.js.html#l630"><code>src&#x2F;Model.js:630</code></a>
         </p>
 
 
@@ -1209,7 +1173,7 @@ TODO: Figure out how to handle unpersisted ids</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l227"><code>src&#x2F;Model.js:227</code></a>
+        <a href="../files/src_Model.js.html#l275"><code>src&#x2F;Model.js:275</code></a>
         </p>
 
 
@@ -1248,7 +1212,7 @@ kpi.name
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l244"><code>src&#x2F;Model.js:244</code></a>
+        <a href="../files/src_Model.js.html#l292"><code>src&#x2F;Model.js:292</code></a>
         </p>
 
 
@@ -1289,7 +1253,7 @@ state if the model was never persisted</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l254"><code>src&#x2F;Model.js:254</code></a>
+        <a href="../files/src_Model.js.html#l302"><code>src&#x2F;Model.js:302</code></a>
         </p>
 
 
@@ -1343,7 +1307,7 @@ state if the model was never persisted</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l482"><code>src&#x2F;Model.js:482</code></a>
+        <a href="../files/src_Model.js.html#l483"><code>src&#x2F;Model.js:483</code></a>
         </p>
 
 
@@ -1377,7 +1341,7 @@ state if the model was never persisted</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l460"><code>src&#x2F;Model.js:460</code></a>
+        <a href="../files/src_Model.js.html#l461"><code>src&#x2F;Model.js:461</code></a>
         </p>
 
 
@@ -1429,7 +1393,7 @@ snapshot.title
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l575"><code>src&#x2F;Model.js:575</code></a>
+        <a href="../files/src_Model.js.html#l550"><code>src&#x2F;Model.js:550</code></a>
         </p>
 
 
@@ -1478,7 +1442,7 @@ snapshot.title
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l307"><code>src&#x2F;Model.js:307</code></a>
+        <a href="../files/src_Model.js.html#l355"><code>src&#x2F;Model.js:355</code></a>
         </p>
 
 
@@ -1552,7 +1516,7 @@ Default is to check all validations, but they can be selectively run via options
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l20"><code>src&#x2F;Model.js:20</code></a>
+        <a href="../files/src_Model.js.html#l19"><code>src&#x2F;Model.js:19</code></a>
         </p>
 
 
@@ -1621,82 +1585,6 @@ Default is to check all validations, but they can be selectively run via options
             <div id="properties" class="api-class-tabpanel">
                 <h2 class="off-left">Properties</h2>
 
-<div id="property__dirtyAttributes" class="property item">
-    <h3 class="name"><code>_dirtyAttributes</code></h3>
-    <span class="type">Set</span>
-
-
-
-
-
-    <div class="meta">
-                <p>
-                Defined in
-        <a href="../files/src_Model.js.html#l125"><code>src&#x2F;Model.js:125</code></a>
-        </p>
-
-
-    </div>
-
-    <div class="description">
-        <p>set of attributes which have changed since last snapshot</p>
-
-    </div>
-
-
-
-</div>
-<div id="property__dirtyRelationships" class="property item">
-    <h3 class="name"><code>_dirtyRelationships</code></h3>
-    <span class="type">Set</span>
-
-
-
-
-
-    <div class="meta">
-                <p>
-                Defined in
-        <a href="../files/src_Model.js.html#l118"><code>src&#x2F;Model.js:118</code></a>
-        </p>
-
-
-    </div>
-
-    <div class="description">
-        <p>set of relationships which have changed since last snapshot</p>
-
-    </div>
-
-
-
-</div>
-<div id="property__disposed" class="property item">
-    <h3 class="name"><code>_disposed</code></h3>
-    <span class="type">Boolean</span>
-
-
-
-
-
-    <div class="meta">
-                <p>
-                Defined in
-        <a href="../files/src_Model.js.html#l110"><code>src&#x2F;Model.js:110</code></a>
-        </p>
-
-
-    </div>
-
-    <div class="description">
-        <p>has this object been destroyed?</p>
-
-    </div>
-
-        <p><strong>Default:</strong> false</p>
-
-
-</div>
 <div id="property_endpoint" class="property item">
     <h3 class="name"><code>endpoint</code></h3>
     <span class="type">Unknown</span>
@@ -1709,7 +1597,7 @@ Default is to check all validations, but they can be selectively run via options
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l103"><code>src&#x2F;Model.js:103</code></a>
+        <a href="../files/src_Model.js.html#l102"><code>src&#x2F;Model.js:102</code></a>
         </p>
 
 
@@ -1735,7 +1623,7 @@ Defaults to the underscored version of the class name</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l205"><code>src&#x2F;Model.js:205</code></a>
+        <a href="../files/src_Model.js.html#l253"><code>src&#x2F;Model.js:253</code></a>
         </p>
 
 
@@ -1765,14 +1653,14 @@ kpi.errors
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l167"><code>src&#x2F;Model.js:167</code></a>
+        <a href="../files/src_Model.js.html#l215"><code>src&#x2F;Model.js:215</code></a>
         </p>
 
 
     </div>
 
     <div class="description">
-        <p>have any changes been made since this record was last persisted?</p>
+        <p>Have any changes been made since this record was last persisted?</p>
 
     </div>
 
@@ -1790,7 +1678,7 @@ kpi.errors
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l132"><code>src&#x2F;Model.js:132</code></a>
+        <a href="../files/src_Model.js.html#l109"><code>src&#x2F;Model.js:109</code></a>
         </p>
 
 
@@ -1836,7 +1724,7 @@ kpi.isDirty
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l188"><code>src&#x2F;Model.js:188</code></a>
+        <a href="../files/src_Model.js.html#l236"><code>src&#x2F;Model.js:236</code></a>
         </p>
 
 
@@ -1870,7 +1758,7 @@ kpi.isInFlight
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l176"><code>src&#x2F;Model.js:176</code></a>
+        <a href="../files/src_Model.js.html#l224"><code>src&#x2F;Model.js:224</code></a>
         </p>
 
 
@@ -1895,7 +1783,7 @@ kpi.isInFlight
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l218"><code>src&#x2F;Model.js:218</code></a>
+        <a href="../files/src_Model.js.html#l266"><code>src&#x2F;Model.js:266</code></a>
         </p>
 
 
@@ -1922,7 +1810,7 @@ kpi.isInFlight
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_Model.js.html#l95"><code>src&#x2F;Model.js:95</code></a>
+        <a href="../files/src_Model.js.html#l94"><code>src&#x2F;Model.js:94</code></a>
         </p>
 
 

--- a/docs/classes/RelatedRecordsArray.html
+++ b/docs/classes/RelatedRecordsArray.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.3.0</em>
+            <em>API Docs for: 3.4.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -84,7 +84,7 @@
 
 
         <div class="foundat">
-            Defined in: <a href="../files/src_decorators_relationships.js.html#l207"><code>src&#x2F;decorators&#x2F;relationships.js:207</code></a>
+            Defined in: <a href="../files/src_decorators_relationships.js.html#l205"><code>src&#x2F;decorators&#x2F;relationships.js:205</code></a>
         </div>
 
 
@@ -125,7 +125,7 @@
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_decorators_relationships.js.html#l207"><code>src&#x2F;decorators&#x2F;relationships.js:207</code></a>
+        <a href="../files/src_decorators_relationships.js.html#l205"><code>src&#x2F;decorators&#x2F;relationships.js:205</code></a>
         </p>
 
 
@@ -274,7 +274,7 @@
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_decorators_relationships.js.html#l238"><code>src&#x2F;decorators&#x2F;relationships.js:238</code></a>
+        <a href="../files/src_decorators_relationships.js.html#l236"><code>src&#x2F;decorators&#x2F;relationships.js:236</code></a>
         </p>
 
 
@@ -614,7 +614,7 @@ everything the same except it only returns a single record.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_decorators_relationships.js.html#l293"><code>src&#x2F;decorators&#x2F;relationships.js:293</code></a>
+        <a href="../files/src_decorators_relationships.js.html#l290"><code>src&#x2F;decorators&#x2F;relationships.js:290</code></a>
         </p>
 
 

--- a/docs/classes/Schema.html
+++ b/docs/classes/Schema.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.3.0</em>
+            <em>API Docs for: 3.4.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Store.html
+++ b/docs/classes/Store.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.3.0</em>
+            <em>API Docs for: 3.4.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/data.json
+++ b/docs/data.json
@@ -3,7 +3,7 @@
         "name": "mobx-async-store",
         "description": "Asyc Data Store for mobx",
         "url": "https://github.com/artemis-ag/mobx-async-store",
-        "version": "3.3.0"
+        "version": "3.4.0"
     },
     "files": {
         "src/decorators/attributes.js": {
@@ -68,7 +68,7 @@
             "plugin_for": [],
             "extension_for": [],
             "file": "src/decorators/relationships.js",
-            "line": 207,
+            "line": 205,
             "description": "An array that allows for updating store references and relationships",
             "is_constructor": 1,
             "params": [
@@ -98,7 +98,7 @@
             "plugin_for": [],
             "extension_for": [],
             "file": "src/Model.js",
-            "line": 81
+            "line": 80
         },
         "Store": {
             "name": "Store",
@@ -257,7 +257,7 @@
         },
         {
             "file": "src/decorators/relationships.js",
-            "line": 238,
+            "line": 236,
             "description": "Adds a record to the array, and updates references in the store, as well as inverse references",
             "itemtype": "method",
             "name": "add",
@@ -276,7 +276,7 @@
         },
         {
             "file": "src/decorators/relationships.js",
-            "line": 293,
+            "line": 290,
             "description": "Removes a record from the array, and updates references in the store, as well as inverse references",
             "itemtype": "method",
             "name": "remove",
@@ -295,7 +295,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 20,
+            "line": 19,
             "description": "Maps the passed-in property names through and runs validations against those properties",
             "itemtype": "method",
             "name": "validateProperties",
@@ -324,7 +324,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 85,
+            "line": 84,
             "description": "Initializer for model",
             "itemtype": "method",
             "name": "constructor",
@@ -332,7 +332,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 95,
+            "line": 94,
             "description": "The type of the model. Defined on the class. Defaults to the underscored version of the class name\n(eg 'calendar_events').",
             "itemtype": "property",
             "name": "type",
@@ -341,7 +341,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 103,
+            "line": 102,
             "description": "The canonical path to the resource on the server. Defined on the class.\nDefaults to the underscored version of the class name",
             "itemtype": "property",
             "name": "endpoint",
@@ -350,35 +350,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 110,
-            "description": "has this object been destroyed?",
-            "itemtype": "property",
-            "name": "_disposed",
-            "type": "{Boolean}",
-            "default": "false",
-            "class": "Model"
-        },
-        {
-            "file": "src/Model.js",
-            "line": 118,
-            "description": "set of relationships which have changed since last snapshot",
-            "itemtype": "property",
-            "name": "_dirtyRelationships",
-            "type": "{Set}",
-            "class": "Model"
-        },
-        {
-            "file": "src/Model.js",
-            "line": 125,
-            "description": "set of attributes which have changed since last snapshot",
-            "itemtype": "property",
-            "name": "_dirtyAttributes",
-            "type": "{Set}",
-            "class": "Model"
-        },
-        {
-            "file": "src/Model.js",
-            "line": 132,
+            "line": 109,
             "description": "True if the instance has been modified from its persisted state\n\nNOTE that isDirty does _NOT_ track changes to the related objects\nbut it _does_ track changes to the relationships themselves.\n\nFor example, adding or removing a related object will mark this record as dirty,\nbut changing a related object's properties will not mark this record as dirty.\n\nThe caller is reponsible for asking related objects about their\nown dirty state.\n\n```\nkpi = store.add('kpis', { name: 'A good thing to measure' })\nkpi.isDirty\n=> true\nkpi.name\n=> \"A good thing to measure\"\nawait kpi.save()\nkpi.isDirty\n=> false\nkpi.name = \"Another good thing to measure\"\nkpi.isDirty\n=> true\nawait kpi.save()\nkpi.isDirty\n=> false\n```",
             "itemtype": "property",
             "name": "isDirty",
@@ -387,8 +359,32 @@
         },
         {
             "file": "src/Model.js",
-            "line": 167,
-            "description": "have any changes been made since this record was last persisted?",
+            "line": 144,
+            "description": "A list of any attribute paths which have been changed since the previous snapshot\n\nconst todo = new Todo({ title: 'Buy Milk' })\ntodo.dirtyAttributes\n=> []\ntodo.title = 'Buy Cheese'\ntodo.dirtyAttributes\n=> ['title']\ntodo.options = { variety: 'Cheddar' }\ntodo.dirtyAttributes\n=> ['title', 'options.variety']",
+            "itemtype": "method",
+            "name": "dirtyAttributes",
+            "return": {
+                "description": "dirty attribute paths",
+                "type": "Array"
+            },
+            "class": "Model"
+        },
+        {
+            "file": "src/Model.js",
+            "line": 177,
+            "description": "A list of any relationship paths which have been changed since the previous snapshot\nWe check changes to both ids and types in case there are polymorphic relationships\n\nconst todo = new Todo({ title: 'Buy Milk' })\ntodo.dirtyRelationships\n=> []\ntodo.note = note1\ntodo.dirtyRelationships\n=> ['relationships.note']",
+            "itemtype": "method",
+            "name": "dirtyRelationships",
+            "return": {
+                "description": "dirty relationship paths",
+                "type": "Array"
+            },
+            "class": "Model"
+        },
+        {
+            "file": "src/Model.js",
+            "line": 215,
+            "description": "Have any changes been made since this record was last persisted?",
             "itemtype": "property",
             "name": "hasUnpersistedChanges",
             "type": "{Boolean}",
@@ -396,7 +392,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 176,
+            "line": 224,
             "description": "True if the model has not been sent to the store",
             "itemtype": "property",
             "name": "isNew",
@@ -405,7 +401,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 188,
+            "line": 236,
             "description": "True if the instance is coming from / going to the server\n```\nkpi = store.find('kpis', 5)\n// fetch started\nkpi.isInFlight\n=> true\n// fetch finished\nkpi.isInFlight\n=> false\n```",
             "itemtype": "property",
             "name": "isInFlight",
@@ -415,7 +411,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 205,
+            "line": 253,
             "description": "A hash of errors from the server\n```\nkpi = store.find('kpis', 5)\nkpi.errors\n=> { authorization: \"You do not have access to this resource\" }\n```",
             "itemtype": "property",
             "name": "errors",
@@ -425,7 +421,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 218,
+            "line": 266,
             "description": "a list of snapshots that have been taken since the record was either last persisted or since it was instantiated",
             "itemtype": "property",
             "name": "snapshots",
@@ -435,7 +431,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 227,
+            "line": 275,
             "description": "restores data to its last snapshot state\n```\nkpi = store.find('kpis', 5)\nkpi.name\n=> \"A good thing to measure\"\nkpi.name = \"Another good thing to measure\"\nkpi.rollback()\nkpi.name\n=> \"A good thing to measure\"\n```",
             "itemtype": "method",
             "name": "rollback",
@@ -443,7 +439,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 244,
+            "line": 292,
             "description": "restores data to its last persisted state or the oldest snapshot\nstate if the model was never persisted",
             "itemtype": "method",
             "name": "rollbackToPersisted",
@@ -451,7 +447,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 254,
+            "line": 302,
             "description": "creates or updates a record.",
             "itemtype": "method",
             "name": "save",
@@ -470,7 +466,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 307,
+            "line": 355,
             "description": "Checks all validations, adding errors where necessary and returning `false` if any are not valid\nDefault is to check all validations, but they can be selectively run via options:\n - attributes - an array of names of attributes to validate\n - relationships - an array of names of relationships to validate",
             "itemtype": "method",
             "name": "validate",
@@ -489,7 +485,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 331,
+            "line": 379,
             "description": "deletes a record from the store and server",
             "itemtype": "method",
             "name": "destroy",
@@ -501,7 +497,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 400,
+            "line": 446,
             "description": "Magic method that makes changes to records\nobservable",
             "itemtype": "method",
             "name": "_makeObservable",
@@ -509,23 +505,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 417,
-            "description": "sets up a reaction for each top-level attribute so we can compare\nvalues after each mutation and keep track of dirty attr states\nif an attr is different than the last snapshot, add it to the\n_dirtyAttributes set\nif it's the same as the last snapshot, make sure it's _not_ in the\n_dirtyAttributes set",
-            "itemtype": "method",
-            "name": "_listenForChanges",
-            "class": "Model"
-        },
-        {
-            "file": "src/Model.js",
-            "line": 450,
-            "description": "call this when destroying an object to make sure that we clean up\nany event listeners and don't leak memory",
-            "itemtype": "method",
-            "name": "dispose",
-            "class": "Model"
-        },
-        {
-            "file": "src/Model.js",
-            "line": 460,
+            "line": 461,
             "description": "The current state of defined attributes and relationships of the instance\nReally just an alias for attributes\n```\ntodo = store.find('todos', 5)\ntodo.title\n=> \"Buy the eggs\"\nsnapshot = todo.snapshot\ntodo.title = \"Buy the eggs and bacon\"\nsnapshot.title\n=> \"Buy the eggs and bacon\"\n```",
             "itemtype": "method",
             "name": "snapshot",
@@ -537,7 +517,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 482,
+            "line": 483,
             "description": "Sets previous snapshot to current snapshot",
             "itemtype": "method",
             "name": "setPreviousSnapshot",
@@ -545,7 +525,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 491,
+            "line": 492,
             "description": "the latest snapshot",
             "itemtype": "method",
             "name": "previousSnapshot",
@@ -553,7 +533,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 502,
+            "line": 503,
             "description": "the latest persisted snapshot or the first snapshot if the model was never persisted",
             "itemtype": "method",
             "name": "previousSnapshot",
@@ -561,7 +541,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 511,
+            "line": 512,
             "description": "take a snapshot of the current model state.\nif persisted, clear the stack and push this snapshot to the top\nif not persisted, push this snapshot to the top of the stack",
             "itemtype": "method",
             "name": "_takeSnapshot",
@@ -576,7 +556,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 534,
+            "line": 533,
             "description": "set the current attributes and relationships to the attributes\nand relationships of the snapshot to be applied. also reset errors",
             "itemtype": "method",
             "name": "_applySnapshot",
@@ -591,19 +571,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 551,
-            "description": "a list of any property paths which have been changed since the previous\nsnapshot\n```\nconst todo = new Todo({ title: 'Buy Milk' })\ntodo.dirtyAttributes\n=> []\ntodo.title = 'Buy Cheese'\ntodo.dirtyAttributes\n=> ['title']\ntodo.note = note1\ntodo.dirtyAttributes\n=> ['title', 'relationships.note']\n```",
-            "itemtype": "method",
-            "name": "dirtyAttributes",
-            "return": {
-                "description": "dirty attribute paths",
-                "type": "Array"
-            },
-            "class": "Model"
-        },
-        {
-            "file": "src/Model.js",
-            "line": 575,
+            "line": 550,
             "description": "shortcut to get the static",
             "itemtype": "method",
             "name": "type",
@@ -615,7 +583,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 585,
+            "line": 560,
             "description": "current attributes of record",
             "itemtype": "method",
             "name": "attributes",
@@ -627,7 +595,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 603,
+            "line": 578,
             "description": "Getter find the attribute definition for the model type.",
             "itemtype": "method",
             "name": "attributeDefinitions",
@@ -639,7 +607,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 614,
+            "line": 589,
             "description": "Getter find the relationship definitions for the model type.",
             "itemtype": "method",
             "name": "relationshipDefinitions",
@@ -651,7 +619,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 625,
+            "line": 600,
             "description": "Getter to check if the record has errors.",
             "itemtype": "method",
             "name": "hasErrors",
@@ -663,7 +631,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 635,
+            "line": 610,
             "description": "Getter to check if the record has errors.",
             "itemtype": "method",
             "name": "hasErrors",
@@ -675,7 +643,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 645,
+            "line": 620,
             "description": "Getter to just get the names of a records attributes.",
             "itemtype": "method",
             "name": "attributeNames",
@@ -687,7 +655,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 655,
+            "line": 630,
             "description": "Getter to just get the names of a records relationships.",
             "itemtype": "method",
             "name": "relationshipNames",
@@ -699,7 +667,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 665,
+            "line": 640,
             "description": "getter method to get the default attributes",
             "itemtype": "method",
             "name": "defaultAttributes",
@@ -711,7 +679,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 682,
+            "line": 657,
             "description": "getter method to get data in api compliance format\nTODO: Figure out how to handle unpersisted ids",
             "itemtype": "method",
             "name": "jsonapi",
@@ -723,7 +691,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 810,
+            "line": 785,
             "description": "Comparison by value\nreturns `true` if this object has the same attrs and relationships\nas the \"other\" object, ignores differences in internal state like\nattribute \"dirtyness\" or errors",
             "itemtype": "method",
             "name": "isEqual",
@@ -742,7 +710,7 @@
         },
         {
             "file": "src/Model.js",
-            "line": 825,
+            "line": 800,
             "description": "Comparison by identity\nreturns `true` if this object has the same type and id as the\n\"other\" object, ignores differences in attrs and relationships",
             "itemtype": "method",
             "name": "isSame",

--- a/docs/files/src_Model.js.html
+++ b/docs/files/src_Model.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.3.0</em>
+            <em>API Docs for: 3.4.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -86,7 +86,6 @@
 import {
   computed,
   extendObservable,
-  reaction,
   set,
   toJS,
   transaction,
@@ -193,28 +192,6 @@ class Model {
    */
 
   /**
-    * has this object been destroyed?
-    * @property _disposed
-    * @type {Boolean}
-    * @default false
-    */
-  @observable _disposed = false
-
-  /**
-    * set of relationships which have changed since last snapshot
-    * @property _dirtyRelationships
-    * @type {Set}
-    */
-  @observable _dirtyRelationships = new Set()
-
-  /**
-    * set of attributes which have changed since last snapshot
-    * @property _dirtyAttributes
-    * @type {Set}
-    */
-  @observable _dirtyAttributes = new Set()
-
-  /**
    * True if the instance has been modified from its persisted state
    *
    * NOTE that isDirty does _NOT_ track changes to the related objects
@@ -246,11 +223,82 @@ class Model {
    * @type {Boolean}
    */
   get isDirty () {
-    return this._dirtyAttributes.size &gt; 0 || this._dirtyRelationships.size &gt; 0
+    return this.dirtyAttributes.length &gt; 0 || this.dirtyRelationships.length &gt; 0
   }
 
   /**
-   * have any changes been made since this record was last persisted?
+   * A list of any attribute paths which have been changed since the previous snapshot
+   *
+   * const todo = new Todo({ title: &#x27;Buy Milk&#x27; })
+   * todo.dirtyAttributes
+   * =&gt; []
+   * todo.title = &#x27;Buy Cheese&#x27;
+   * todo.dirtyAttributes
+   * =&gt; [&#x27;title&#x27;]
+   * todo.options = { variety: &#x27;Cheddar&#x27; }
+   * todo.dirtyAttributes
+   * =&gt; [&#x27;title&#x27;, &#x27;options.variety&#x27;]
+   *
+   * @method dirtyAttributes
+   * @return {Array} dirty attribute paths
+   */
+  get dirtyAttributes () {
+    return Array.from(Object.keys(this.attributes).reduce((dirtyAccumulator, attr) =&gt; {
+      const currentValue = this.attributes[attr]
+      const previousValue = this.previousSnapshot.attributes[attr]
+
+      if (isObject(currentValue)) {
+        diff(currentValue, previousValue).forEach((property) =&gt; {
+          dirtyAccumulator.add(&#x60;${attr}.${property}&#x60;)
+        })
+      } else if (!isEqual(previousValue, currentValue)) {
+        dirtyAccumulator.add(attr)
+      }
+
+      return dirtyAccumulator
+    }, new Set()))
+  }
+
+  /**
+   * A list of any relationship paths which have been changed since the previous snapshot
+   * We check changes to both ids and types in case there are polymorphic relationships
+   *
+   * const todo = new Todo({ title: &#x27;Buy Milk&#x27; })
+   * todo.dirtyRelationships
+   * =&gt; []
+   * todo.note = note1
+   * todo.dirtyRelationships
+   * =&gt; [&#x27;relationships.note&#x27;]
+   *
+   * @method dirtyRelationships
+   * @return {Array} dirty relationship paths
+   */
+  get dirtyRelationships () {
+    // TODO: make what returns from this.relationships to be more consistent
+    const previousRelationships = this.previousSnapshot.relationships || {}
+    const currentRelationships = this.relationships || {}
+    const schemaRelationships = this.relationshipNames
+
+    if (Object.keys(currentRelationships).length === 0) {
+      return Object.keys(previousRelationships)
+    }
+
+    return Array.from(schemaRelationships.reduce((dirtyAccumulator, name) =&gt; {
+      const currentValues = currentRelationships[name]?.data || []
+      const previousValues = previousRelationships[name]?.data || []
+      const currentIds = Array.isArray(currentValues) ? currentValues.map(value =&gt; [value.id, value.type]).sort() : [currentValues.id, currentValues.type]
+      const previousIds = Array.isArray(previousValues) ? previousValues.map(value =&gt; [value.id, value.type]).sort() : [previousValues.id, previousValues.type]
+
+      if (!isEqual(currentIds, previousIds)) {
+        dirtyAccumulator.add(name)
+      }
+
+      return dirtyAccumulator
+    }, new Set()))
+  }
+
+  /**
+   * Have any changes been made since this record was last persisted?
    * @property hasUnpersistedChanges
    * @type {Boolean}
    */
@@ -463,8 +511,6 @@ class Model {
             _this.store.createModelsFromData(json.included)
           }
 
-          _this.dispose()
-
           return _this
         } else {
           _this.errors = { status: response.status }
@@ -495,51 +541,6 @@ class Model {
       ...defaultAttributes,
       ...initialAttributes
     })
-
-    this._listenForChanges()
-  }
-
-  /**
-   * sets up a reaction for each top-level attribute so we can compare
-   * values after each mutation and keep track of dirty attr states
-   * if an attr is different than the last snapshot, add it to the
-   * _dirtyAttributes set
-   * if it&#x27;s the same as the last snapshot, make sure it&#x27;s _not_ in the
-   * _dirtyAttributes set
-   * @method _listenForChanges
-   */
-  _listenForChanges () {
-    this._disposers = Object.keys(this.attributes).map((attr) =&gt; {
-      return reaction(() =&gt; this.attributes[attr], (value) =&gt; {
-        const previousValue = this.previousSnapshot.attributes[attr]
-        if (isEqual(previousValue, value)) {
-          this._dirtyAttributes.delete(attr)
-        } else if (isObject(value)) { // handles Objects and Arrays
-          // clear out any dirty attrs that start with this attr prefix
-          // then we can reset them if they are still (or newly) dirty
-          Array.from(this._dirtyAttributes).forEach((path) =&gt; {
-            if (path.indexOf(&#x60;${attr}.&#x60;) === 0) {
-              this._dirtyAttributes.delete(path)
-            }
-          })
-          diff(previousValue, value).forEach((property) =&gt; {
-            this._dirtyAttributes.add(&#x60;${attr}.${property}&#x60;)
-          })
-        } else {
-          this._dirtyAttributes.add(attr)
-        }
-      })
-    })
-  }
-
-  /**
-   * call this when destroying an object to make sure that we clean up
-   * any event listeners and don&#x27;t leak memory
-   * @method dispose
-   */
-  dispose () {
-    this._disposed = true
-    this._disposers.forEach((dispose) =&gt; dispose())
   }
 
   /**
@@ -602,8 +603,6 @@ class Model {
    */
   _takeSnapshot (options = {}) {
     const persisted = options.persisted || false
-    this._dirtyRelationships.clear()
-    this._dirtyAttributes.clear()
     const { attributes, relationships } = this.snapshot
     const snapshot = {
       persisted,
@@ -632,30 +631,6 @@ class Model {
       this.errors = {}
     })
   }
-
-  /**
-   * a list of any property paths which have been changed since the previous
-   * snapshot
-   * &#x60;&#x60;&#x60;
-   * const todo = new Todo({ title: &#x27;Buy Milk&#x27; })
-   * todo.dirtyAttributes
-   * =&gt; []
-   * todo.title = &#x27;Buy Cheese&#x27;
-   * todo.dirtyAttributes
-   * =&gt; [&#x27;title&#x27;]
-   * todo.note = note1
-   * todo.dirtyAttributes
-   * =&gt; [&#x27;title&#x27;, &#x27;relationships.note&#x27;]
-   * &#x60;&#x60;&#x60;
-   * @method dirtyAttributes
-   * @return {Array} dirty attribute paths
-   */
-
-   get dirtyAttributes () {
-    const relationships = Array.from(this._dirtyRelationships).map((property) =&gt; &#x60;relationships.${property}&#x60;)
-    const attributes = Array.from(this._dirtyAttributes)
-    return [...relationships, ...attributes]
-   }
 
   /**
    * shortcut to get the static

--- a/docs/files/src_Store.js.html
+++ b/docs/files/src_Store.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.3.0</em>
+            <em>API Docs for: 3.4.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_attributes.js.html
+++ b/docs/files/src_decorators_attributes.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.3.0</em>
+            <em>API Docs for: 3.4.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_relationships.js.html
+++ b/docs/files/src_decorators_relationships.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.3.0</em>
+            <em>API Docs for: 3.4.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -250,7 +250,7 @@ export function setRelatedRecord (
     throw new Error(&#x27;Related record must be a valid Model object&#x27;)
   }
 
-  const { relationships, _dirtyRelationships } = record
+  const { relationships } = record
   const relationType = modelType || property
   const referenceRecord =
     relatedRecord || getRelatedRecord(record, relationType)
@@ -265,10 +265,8 @@ export function setRelatedRecord (
 
   if (!relatedRecord) {
     delete relationships[relationType]
-    _dirtyRelationships.add(relationType)
   } else if (!data || !(data.type === type &amp;&amp; data.id === id)) {
     relationships[relationType] = { data: { id, type } }
-    _dirtyRelationships.add(relationType)
   } else {
     return relatedRecord
   }
@@ -363,7 +361,6 @@ export class RelatedRecordsArray extends Array {
     if (!alreadyThere) {
       relationships[property].data.push({ id, type })
       this.push(relatedRecord)
-      record._dirtyRelationships.add(property)
       // setting the inverse - hack this will only work with singularized relationships.
       setRelatedRecord(
         relatedRecord,
@@ -411,8 +408,6 @@ export class RelatedRecordsArray extends Array {
         delete record.relationships
       }
 
-      record._dirtyRelationships.add(property)
-
       // hack this will only work with singularized relationships.
       setRelatedRecord(
         relatedRecord,
@@ -431,7 +426,6 @@ export class RelatedRecordsArray extends Array {
     transaction(() =&gt; {
       relationships[property] = { data: [] }
       array.forEach(object =&gt; this.add(object))
-      record._dirtyRelationships.add(property)
     })
   }
 }

--- a/docs/files/src_schema.js.html
+++ b/docs/files/src_schema.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.3.0</em>
+            <em>API Docs for: 3.4.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_utils.js.html
+++ b/docs/files/src_utils.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.3.0</em>
+            <em>API Docs for: 3.4.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
                 <h1><img src="./assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.3.0</em>
+            <em>API Docs for: 3.4.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/src/decorators/relationships.js
+++ b/src/decorators/relationships.js
@@ -165,7 +165,7 @@ export function setRelatedRecord (
     throw new Error('Related record must be a valid Model object')
   }
 
-  const { relationships, _dirtyRelationships } = record
+  const { relationships } = record
   const relationType = modelType || property
   const referenceRecord =
     relatedRecord || getRelatedRecord(record, relationType)
@@ -180,10 +180,8 @@ export function setRelatedRecord (
 
   if (!relatedRecord) {
     delete relationships[relationType]
-    _dirtyRelationships.add(relationType)
   } else if (!data || !(data.type === type && data.id === id)) {
     relationships[relationType] = { data: { id, type } }
-    _dirtyRelationships.add(relationType)
   } else {
     return relatedRecord
   }
@@ -278,7 +276,6 @@ export class RelatedRecordsArray extends Array {
     if (!alreadyThere) {
       relationships[property].data.push({ id, type })
       this.push(relatedRecord)
-      record._dirtyRelationships.add(property)
       // setting the inverse - hack this will only work with singularized relationships.
       setRelatedRecord(
         relatedRecord,
@@ -326,8 +323,6 @@ export class RelatedRecordsArray extends Array {
         delete record.relationships
       }
 
-      record._dirtyRelationships.add(property)
-
       // hack this will only work with singularized relationships.
       setRelatedRecord(
         relatedRecord,
@@ -346,7 +341,6 @@ export class RelatedRecordsArray extends Array {
     transaction(() => {
       relationships[property] = { data: [] }
       array.forEach(object => this.add(object))
-      record._dirtyRelationships.add(property)
     })
   }
 }


### PR DESCRIPTION
Remove the attribute listeners to help with memory bloat - instead we will compare current attributes and relationships to the previous snapshot when checking `isDirty`