### PR TITLE
fix removing related records when some not in store

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -2907,7 +2907,7 @@ var RelatedRecordsArray = /*#__PURE__*/function (_Array) {
         }
 
         var recordIndexToRemove = _this.findIndex(function (model) {
-          return model.id.toString() === id.toString() && model.type === type;
+          return (model === null || model === void 0 ? void 0 : model.id.toString()) === id.toString() && model.type === type;
         });
 
         if (recordIndexToRemove >= 0) _this.splice(recordIndexToRemove, 1);

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -2875,7 +2875,7 @@ var RelatedRecordsArray = /*#__PURE__*/function (_Array) {
         }
 
         var recordIndexToRemove = _this.findIndex(function (model) {
-          return model.id.toString() === id.toString() && model.type === type;
+          return (model === null || model === void 0 ? void 0 : model.id.toString()) === id.toString() && model.type === type;
         });
 
         if (recordIndexToRemove >= 0) _this.splice(recordIndexToRemove, 1);

--- a/docs/classes/Model.html
+++ b/docs/classes/Model.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.10.2</em>
+            <em>API Docs for: 3.10.3</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/RelatedRecordsArray.html
+++ b/docs/classes/RelatedRecordsArray.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.10.2</em>
+            <em>API Docs for: 3.10.3</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Schema.html
+++ b/docs/classes/Schema.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.10.2</em>
+            <em>API Docs for: 3.10.3</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Store.html
+++ b/docs/classes/Store.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.10.2</em>
+            <em>API Docs for: 3.10.3</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/data.json
+++ b/docs/data.json
@@ -3,7 +3,7 @@
         "name": "mobx-async-store",
         "description": "Asyc Data Store for mobx",
         "url": "https://github.com/artemis-ag/mobx-async-store",
-        "version": "3.10.2"
+        "version": "3.10.3"
     },
     "files": {
         "src/decorators/attributes.js": {

--- a/docs/files/src_Model.js.html
+++ b/docs/files/src_Model.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.10.2</em>
+            <em>API Docs for: 3.10.3</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_Store.js.html
+++ b/docs/files/src_Store.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.10.2</em>
+            <em>API Docs for: 3.10.3</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_attributes.js.html
+++ b/docs/files/src_decorators_attributes.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.10.2</em>
+            <em>API Docs for: 3.10.3</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_relationships.js.html
+++ b/docs/files/src_decorators_relationships.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.10.2</em>
+            <em>API Docs for: 3.10.3</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -396,7 +396,7 @@ export class RelatedRecordsArray extends Array {
       if (referenceIndexToRemove &gt;= 0) { relationships[property].data.splice(referenceIndexToRemove, 1) }
 
       const recordIndexToRemove = this.findIndex(
-        model =&gt; model.id.toString() === id.toString() &amp;&amp; model.type === type
+        model =&gt; model?.id.toString() === id.toString() &amp;&amp; model.type === type
       )
       if (recordIndexToRemove &gt;= 0) this.splice(recordIndexToRemove, 1)
 

--- a/docs/files/src_schema.js.html
+++ b/docs/files/src_schema.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.10.2</em>
+            <em>API Docs for: 3.10.3</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_utils.js.html
+++ b/docs/files/src_utils.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.10.2</em>
+            <em>API Docs for: 3.10.3</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
                 <h1><img src="./assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.10.2</em>
+            <em>API Docs for: 3.10.3</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "3.10.2",
+  "version": "3.10.3",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -430,15 +430,21 @@ describe('Model', () => {
     const note2 = store.add('notes', {
       description: 'Another note'
     })
-    const todo = store.add('organizations', { id: 10, title: 'Buy Milk' })
+    const todo = store.add('organizations', {
+      title: 'Buy Milk',
+      notes: [
+        {
+          id: '1001',
+          type: 'notes'
+        },
+        note1,
+        note2
+      ]
+    })
 
-    const notes = todo.notes
-    notes.add(note1)
-    notes.add(note2)
-
-    notes.remove(note1)
-    expect(notes).not.toContain(note1)
-    expect(notes).toContain(note2)
+    todo.notes.remove(note1)
+    expect(todo.notes).not.toContain(note1)
+    expect(todo.notes).toContain(note2)
   })
 
   it('relatedToMany models remove reference to record', () => {

--- a/src/decorators/relationships.js
+++ b/src/decorators/relationships.js
@@ -311,7 +311,7 @@ export class RelatedRecordsArray extends Array {
       if (referenceIndexToRemove >= 0) { relationships[property].data.splice(referenceIndexToRemove, 1) }
 
       const recordIndexToRemove = this.findIndex(
-        model => model.id.toString() === id.toString() && model.type === type
+        model => model?.id.toString() === id.toString() && model.type === type
       )
       if (recordIndexToRemove >= 0) this.splice(recordIndexToRemove, 1)
 


### PR DESCRIPTION
currently, if there are any references to records in the `relationships` hash that are not loaded in the store, an attempt to `remove` *any* record that occurs after it in the `relatedRecordsArray` will cause an error.